### PR TITLE
fix: add explicit permissions to TypeScript SDK test workflow

### DIFF
--- a/.github/workflows/test-sdk-typescript.yml
+++ b/.github/workflows/test-sdk-typescript.yml
@@ -16,7 +16,10 @@ on:
 
 permissions:
   contents: read
-  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -26,9 +29,6 @@ jobs:
       run:
         working-directory: sdks/typescript
     steps:
-      - name: ⛔ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
@@ -52,9 +52,6 @@ jobs:
       run:
         working-directory: sdks/typescript
     steps:
-      - name: ⛔ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
@@ -81,9 +78,6 @@ jobs:
       matrix:
         node-version: ['20.19.0', '22', '24']
     steps:
-      - name: ⛔ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
@@ -111,9 +105,6 @@ jobs:
       matrix:
         node-version: ['20.19.0', '22', '24']
     steps:
-      - name: ⛔ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
@@ -147,9 +138,6 @@ jobs:
       run:
         working-directory: sdks/typescript
     steps:
-      - name: ⛔ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 

--- a/.github/workflows/test-sdk-typescript.yml
+++ b/.github/workflows/test-sdk-typescript.yml
@@ -14,6 +14,10 @@ on:
       - 'evals/prompts/**'
       - '.github/workflows/test-sdk-typescript.yml'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   lint:
     name: 👖 Lint


### PR DESCRIPTION
## Summary
  - Resolves code scanning alerts [#1](https://github.com/learning-commons-org/evaluators/security/code-scanning/1) – [#5](https://github.com/learning-commons-org/evaluators/security/code-scanning/5) - workflow was relying on default repository permissions instead of declaring explicit            
  least-privilege permissions
  - Rather than granting `actions: write` (which `styfle/cancel-workflow-action` requires), we replaced it with native `concurrency` — keeping the final permission scope to `contents: read` only