### PR TITLE
feat(ts-sdk): add modelOverride option to all evaluators

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -29,7 +29,7 @@ const evaluator = new VocabularyEvaluator({
 });
 
 const result = await evaluator.evaluate("Your text here", "5");
-console.log(result.score); // "moderately complex"
+console.log(result.score); // "Moderately complex"
 ```
 
 ---
@@ -65,7 +65,7 @@ await evaluator.evaluate(text: string, grade: string)
 **Returns:**
 ```typescript
 {
-  score: 'slightly complex' | 'moderately complex' | 'very complex' | 'exceedingly complex';
+  score: 'Slightly complex' | 'Moderately complex' | 'Very complex' | 'Exceedingly complex';
   reasoning: string;
   metadata: {
     model: string;
@@ -105,7 +105,7 @@ await evaluator.evaluate(text: string, grade: string)
 **Returns:**
 ```typescript
 {
-  score: 'Slightly Complex' | 'Moderately Complex' | 'Very Complex' | 'Exceedingly Complex';
+  score: 'Slightly complex' | 'Moderately complex' | 'Very complex' | 'Exceedingly complex';
   reasoning: string;
   metadata: {
     model: string;
@@ -369,11 +369,12 @@ Evaluates the Purpose dimension of qualitative text complexity — how explicitl
 **Constructor:**
 ```typescript
 const evaluator = new PurposeEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  googleApiKey?: string;                  // Google API key (required by this evaluator)
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -575,7 +575,7 @@ All evaluators use the same `BaseEvaluatorConfig` interface:
 interface BaseEvaluatorConfig {
   googleApiKey?: string;                  // Google API key (required by some evaluators)
   openaiApiKey?: string;                  // OpenAI API key (required by some evaluators)
-  anthropicApiKey?: string;               // Anthropic API key (required if an evaluator defaults to Claude)
+  anthropicApiKey?: string;               // Anthropic API key (required if an evaluator defaults to Claude or when `modelOverride` uses `Provider.Anthropic`)
   modelOverride?: ModelOverride;          // Override the provider and model (see Model Override section)
   maxRetries?: number;                    // Max retry attempts (default: 2)
   telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -540,6 +540,13 @@ When `modelOverride` is set:
 - A warning is logged to indicate results may differ from the defaults
 - Telemetry records `model_override: true` so override usage is tracked separately
 
+**Validation:** The SDK validates `modelOverride` at construction time and throws `ConfigurationError` if:
+- `provider` is not one of the supported `Provider` values (`openai`, `google`, `anthropic`)
+- `model` is empty or blank — no default is assumed; you must always specify the model ID explicitly
+- The API key for the chosen provider is missing
+
+If the model ID is valid at construction but doesn't exist on the provider's API, `ConfigurationError` is thrown when `evaluate()` is called.
+
 ```typescript
 import { VocabularyEvaluator, Provider } from '@learning-commons/evaluators';
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -71,7 +71,7 @@ await evaluator.evaluate(text: string, grade: string)
     model: string;
     processingTimeMs: number;
   };
-  _internal: VocabularyComplexity; // Detailed analysis
+  _internal: VocabularyInternal; // Detailed analysis
 }
 ```
 
@@ -369,7 +369,7 @@ Evaluates the Purpose dimension of qualitative text complexity — how explicitl
 **Constructor:**
 ```typescript
 const evaluator = new PurposeEvaluator({
-  googleApiKey?: string;                  // Google API key (required by this evaluator)
+  googleApiKey: string;                   // Google API key (required by this evaluator)
   modelOverride?: ModelOverride;          // Override the default provider and model
   maxRetries?: number;                    // Max retry attempts (default: 2)
   telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -38,7 +38,7 @@ console.log(result.score); // "moderately complex"
 
 ### 1. Vocabulary Evaluator
 
-Evaluates vocabulary complexity using the Qual Text Complexity rubric (SAP).
+Evaluates vocabulary complexity using the Qualitative Text Complexity rubric (SAP).
 
 **Supported Grades:** 3-12
 
@@ -47,12 +47,13 @@ Evaluates vocabulary complexity using the Qual Text Complexity rubric (SAP).
 **Constructor:**
 ```typescript
 const evaluator = new VocabularyEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  openaiApiKey?: string;  // OpenAI API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - SILENT | ERROR | WARN | INFO | DEBUG (default: WARN)
+  googleApiKey: string;                   // Google API key
+  openaiApiKey: string;                   // OpenAI API key
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -87,11 +88,12 @@ Evaluates sentence structure complexity based on grammatical features.
 **Constructor:**
 ```typescript
 const evaluator = new SentenceStructureEvaluator({
-  openaiApiKey?: string;  // OpenAI API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  openaiApiKey: string;                   // OpenAI API key
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -130,11 +132,12 @@ Evaluates the background knowledge demands of educational texts relative to grad
 **Constructor:**
 ```typescript
 const evaluator = new SmkEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  googleApiKey: string;                   // Google API key
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -193,11 +196,12 @@ Evaluates how explicit, literal, and straightforward a text's meaning is versus 
 **Constructor:**
 ```typescript
 const evaluator = new ConventionalityEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  googleApiKey: string;                   // Google API key
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -250,17 +254,18 @@ Composite evaluator that analyzes vocabulary, sentence structure, subject matter
 
 **Supported Grades:** 3-12
 
-**Uses:** Google Gemini 2.5 Pro + Google Gemini 3 Flash Preview + OpenAI GPT-4o (composite)
+**Uses:** Google Gemini 2.5 Pro + Google Gemini 3 Flash Preview + OpenAI GPT-4o + OpenAI GPT-4.1 (composite)
 
 **Constructor:**
 ```typescript
 const evaluator = new TextComplexityEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  openaiApiKey?: string;  // OpenAI API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  googleApiKey: string;                   // Google API key
+  openaiApiKey: string;                   // OpenAI API key
+  modelOverride?: ModelOverride;          // Override the default provider and model for all sub-evaluators
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -319,11 +324,12 @@ Determines appropriate grade level for text.
 **Constructor:**
 ```typescript
 const evaluator = new GradeLevelAppropriatenessEvaluator({
-  googleApiKey?: string;  // Google API key (required by this evaluator)
-  maxRetries?: number;    // Optional - Max retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Optional (default: true)
-  logger?: Logger;        // Optional - Custom logger
-  logLevel?: LogLevel;    // Optional - Logging verbosity (default: WARN)
+  googleApiKey: string;                   // Google API key
+  modelOverride?: ModelOverride;          // Override the default provider and model
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
 });
 ```
 
@@ -477,6 +483,9 @@ try {
   } else if (error instanceof NetworkError) {
     // Network connectivity issues
     console.error('Network error:', error.message);
+  } else if (error instanceof TimeoutError) {
+    // Request timed out
+    console.error('Timeout:', error.message);
   } else if (error instanceof APIError) {
     // Other API errors
     console.error('API error:', error.message, 'Status:', error.statusCode);
@@ -521,6 +530,37 @@ const evaluator = new VocabularyEvaluator({
 
 ---
 
+## Model Override
+
+By default each evaluator uses a recommended provider and model tuned for that task. You can override this with any supported provider — OpenAI, Google, or Anthropic — using the `modelOverride` option.
+
+When `modelOverride` is set:
+- All LLM calls within the evaluator use the specified provider and model
+- Only the API key for the override provider is required (e.g. `anthropicApiKey` when using `Provider.Anthropic`); default provider keys are not validated
+- A warning is logged to indicate results may differ from the defaults
+- Telemetry records `model_override: true` so override usage is tracked separately
+
+```typescript
+import { VocabularyEvaluator, Provider } from '@learning-commons/evaluators';
+
+const evaluator = new VocabularyEvaluator({
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  modelOverride: {
+    provider: Provider.Anthropic,
+    model: 'claude-sonnet-4-6',
+  },
+});
+
+const result = await evaluator.evaluate("Your text here", "5");
+console.log(result.metadata.model); // "anthropic:claude-sonnet-4-6"
+```
+
+See the [Installation](#installation) section for provider adapter setup if you haven't already.
+
+> **Note:** Evaluators are validated and quality-tested against their default models. Results with other models may vary. Check `result.metadata.model` to confirm which model was used.
+
+---
+
 ## Telemetry & Privacy
 
 See [docs/telemetry.md](./docs/telemetry.md) for telemetry configuration and privacy information.
@@ -533,13 +573,15 @@ All evaluators use the same `BaseEvaluatorConfig` interface:
 
 ```typescript
 interface BaseEvaluatorConfig {
-  googleApiKey?: string;  // Google API key (required by some evaluators)
-  openaiApiKey?: string;  // OpenAI API key (required by some evaluators)
-  maxRetries?: number;    // Max API retry attempts (default: 2)
-  telemetry?: boolean | TelemetryOptions; // Telemetry config (default: true)
-  logger?: Logger;        // Custom logger (optional)
-  logLevel?: LogLevel;    // Console log level (default: WARN)
-  partnerKey?: string;    // Learning Commons partner key for authenticated telemetry (optional)
+  googleApiKey?: string;                  // Google API key (required by some evaluators)
+  openaiApiKey?: string;                  // OpenAI API key (required by some evaluators)
+  anthropicApiKey?: string;               // Anthropic API key (required if an evaluator defaults to Claude)
+  modelOverride?: ModelOverride;          // Override the provider and model (see Model Override section)
+  maxRetries?: number;                    // Max retry attempts (default: 2)
+  telemetry?: boolean | TelemetryOptions; // Telemetry settings (default: enabled)
+  logger?: Logger;                        // Custom logger
+  logLevel?: LogLevel;                    // Log verbosity (default: WARN)
+  partnerKey?: string;                    // Learning Commons partner key for authenticated telemetry
 }
 ```
 
@@ -551,6 +593,8 @@ interface BaseEvaluatorConfig {
 - **Text Complexity**: Requires both `googleApiKey` and `openaiApiKey`
 - **Grade Level Appropriateness**: Requires `googleApiKey` only
 - **Purpose**: Requires `googleApiKey` only
+
+When `modelOverride` is set, the default key requirements are bypassed — only the key for the override provider is required (e.g. `anthropicApiKey` when using `Provider.Anthropic`).
 
 ---
 

--- a/sdks/typescript/docs/telemetry.md
+++ b/sdks/typescript/docs/telemetry.md
@@ -34,6 +34,7 @@ If you prefer not to send any telemetry, you can disable it entirely — see [Di
     "input_tokens": 650,
     "output_tokens": 350
   },
+  "model_override": true,
   "metadata": {
     "stage_details": [
       {
@@ -73,6 +74,7 @@ If you prefer not to send any telemetry, you can disable it entirely — see [Di
 | `text_length_chars` | Length of input text in characters |
 | `provider` | LLM provider(s) used (e.g., "openai:gpt-4o", "google:gemini-2.5-pro+openai:gpt-4o") |
 | `token_usage` | Total tokens consumed (input, output) |
+| `model_override` | `true` if a `modelOverride` was supplied; omitted otherwise |
 | `input_text` | The text being evaluated (only included if `recordInputs: true`) |
 | `metadata.stage_details` | Per-stage breakdown for multi-stage evaluators (optional) |
 

--- a/sdks/typescript/docs/telemetry.md
+++ b/sdks/typescript/docs/telemetry.md
@@ -29,7 +29,7 @@ If you prefer not to send any telemetry, you can disable it entirely — see [Di
   "status": "success",
   "latency_ms": 3500,
   "text_length_chars": 456,
-  "provider": "openai:gpt-4o-2024-11-20 + google:gemini-2.5-pro",
+  "provider": "openai:gpt-4o-2024-11-20+google:gemini-2.5-pro",
   "token_usage": {
     "input_tokens": 650,
     "output_tokens": 350

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -187,14 +187,18 @@ export class TimeoutError extends APIError {
  * Parse structured output from LLM provider error
  */
 function parseProviderError(error: unknown): { message: string; statusCode?: number; code?: string } {
-  // Handle Error objects
   if (error instanceof Error) {
     const message = error.message;
+    const err = error as Error & { statusCode?: number; status?: number };
 
-    // Try to extract status code from error message
-    // Common patterns: "429", "401", "Error 429:", "Status: 429"
-    const statusMatch = message.match(/\b(4\d{2}|5\d{2})\b/);
-    const statusCode = statusMatch ? parseInt(statusMatch[1]) : undefined;
+    // Prefer a statusCode/status property (Vercel AI SDK's APICallError sets these)
+    // then fall back to parsing from the message string
+    const statusCode =
+      err.statusCode ??
+      err.status ??
+      (message.match(/\b(4\d{2}|5\d{2})\b/)?.[1] !== undefined
+        ? parseInt(message.match(/\b(4\d{2}|5\d{2})\b/)![1])
+        : undefined);
 
     return {
       message,
@@ -203,19 +207,32 @@ function parseProviderError(error: unknown): { message: string; statusCode?: num
     };
   }
 
-  // Handle unknown error types
   return {
     message: String(error),
   };
 }
 
 /**
- * Wrap a provider error into the appropriate error type
+ * Wrap a provider error into the appropriate error type.
+ *
+ * Returns `ConfigurationError` for model-not-found responses (HTTP 404, or HTTP 400
+ * with a model-related message), since those indicate a bad model ID in config.
+ * Returns the appropriate `APIError` subclass for all other provider errors.
  *
  * @internal
  */
-export function wrapProviderError(error: unknown, defaultMessage: string = 'API request failed'): APIError {
+export function wrapProviderError(error: unknown, defaultMessage: string = 'API request failed'): EvaluatorError {
   const { message, statusCode, code } = parseProviderError(error);
+
+  // Detect model-not-found errors (404, or 400 with model-related message)
+  if (
+    statusCode === 404 ||
+    (statusCode === 400 && /\bmodel\b.*(not found|does not exist|invalid)/i.test(message))
+  ) {
+    return new ConfigurationError(
+      `Model not found or invalid: ${message}. Check the model ID in your modelOverride config.`
+    );
+  }
 
   // Detect authentication errors (401, 403)
   if (statusCode === 401 || statusCode === 403) {

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -193,12 +193,11 @@ function parseProviderError(error: unknown): { message: string; statusCode?: num
 
     // Prefer a statusCode/status property (Vercel AI SDK's APICallError sets these)
     // then fall back to parsing from the message string
+    const statusMatch = message.match(/\b(4\d{2}|5\d{2})\b/);
     const statusCode =
       err.statusCode ??
       err.status ??
-      (message.match(/\b(4\d{2}|5\d{2})\b/)?.[1] !== undefined
-        ? parseInt(message.match(/\b(4\d{2}|5\d{2})\b/)![1])
-        : undefined);
+      (statusMatch ? parseInt(statusMatch[1]) : undefined);
 
     return {
       message,

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -216,7 +216,7 @@ function parseProviderError(error: unknown): { message: string; statusCode?: num
  * Wrap a provider error into the appropriate error type.
  *
  * Returns `ConfigurationError` for model-not-found responses (HTTP 404, or HTTP 400
- * with a model-related message), since those indicate a bad model ID in config.
+ * with a model-related message), since those indicate a bad model ID in configuration.
  * Returns the appropriate `APIError` subclass for all other provider errors.
  *
  * @internal
@@ -230,7 +230,7 @@ export function wrapProviderError(error: unknown, defaultMessage: string = 'API 
     (statusCode === 400 && /\bmodel\b.*(not found|does not exist|invalid)/i.test(message))
   ) {
     return new ConfigurationError(
-      `Model not found or invalid: ${message}. Check the model ID in your modelOverride config.`
+      `Model not found or invalid: ${message}. Check the model ID passed to the provider.`
     );
   }
 

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -7,6 +7,8 @@ import {
 } from '../telemetry/index.js';
 import { ConfigurationError, ValidationError } from '../errors.js';
 import { createLogger, LogLevel, type Logger } from '../logger.js';
+import { createProvider } from '../providers/index.js';
+import type { LLMProvider } from '../providers/index.js';
 
 /**
  * Validation constants for input text
@@ -17,6 +19,15 @@ export const VALIDATION_LIMITS = {
   /** Maximum text length in characters (100K chars ≈ 25K tokens) */
   MAX_TEXT_LENGTH: 100_000,
 } as const;
+
+/**
+ * Supported LLM providers
+ */
+export enum Provider {
+  OpenAI = 'openai',
+  Google = 'google',
+  Anthropic = 'anthropic',
+}
 
 /**
  * Granular telemetry configuration options
@@ -30,6 +41,21 @@ export interface TelemetryOptions {
 }
 
 /**
+ * Override the provider and model used by an evaluator.
+ *
+ * When set, all LLM calls use this provider and model instead of the defaults.
+ * The evaluator's normal key requirements are bypassed — provide the key for
+ * the chosen provider via the matching top-level config field
+ * (e.g. `anthropicApiKey` for `Provider.Anthropic`).
+ *
+ * Results may vary; evaluators are validated against their recommended models.
+ */
+export interface ModelOverride {
+  provider: Provider;
+  model: string;
+}
+
+/**
  * Base configuration for all evaluators
  */
 export interface BaseEvaluatorConfig {
@@ -39,8 +65,18 @@ export interface BaseEvaluatorConfig {
   /** OpenAI API key (for evaluators using GPT) */
   openaiApiKey?: string;
 
+  /** Anthropic API key (for evaluators using Claude) */
+  anthropicApiKey?: string;
+
   /** Learning Commons partner key for authenticated telemetry (optional) */
   partnerKey?: string;
+
+  /**
+   * Override the provider and model used by this evaluator.
+   * When set, all LLM calls use this provider and model instead of the defaults.
+   * See {@link ModelOverride} for details.
+   */
+  modelOverride?: ModelOverride;
 
   /**
    * Maximum number of retries for failed API calls (default: 2)
@@ -93,10 +129,8 @@ export interface EvaluatorMetadata {
   readonly description: string;
   /** Supported grade levels (e.g., ['3', '4', '5', ...]) */
   readonly supportedGrades: readonly string[];
-  /** Whether this evaluator requires a Google API key */
-  readonly requiresGoogleKey: boolean;
-  /** Whether this evaluator requires an OpenAI API key */
-  readonly requiresOpenAIKey: boolean;
+  /** Providers required by this evaluator's default configuration */
+  readonly defaultProviders: readonly Provider[];
 }
 
 /**
@@ -116,6 +150,10 @@ export abstract class BaseEvaluator {
   protected logger: Logger;
   protected config: Required<Pick<BaseEvaluatorConfig, 'maxRetries'>> & {
     telemetry: Required<TelemetryOptions>;
+    modelOverride?: ModelOverride;
+    googleApiKey?: string;
+    openaiApiKey?: string;
+    anthropicApiKey?: string;
   };
 
   /**
@@ -131,8 +169,7 @@ export abstract class BaseEvaluator {
    *     name: 'My Evaluator',
    *     description: 'Does something useful',
    *     supportedGrades: ['3', '4', '5'],
-   *     requiresGoogleKey: true,
-   *     requiresOpenAIKey: false,
+   *     defaultProviders: [Provider.Google],
    *   };
    * }
    * ```
@@ -153,7 +190,18 @@ export abstract class BaseEvaluator {
     this.config = {
       maxRetries: config.maxRetries ?? 2,
       telemetry: telemetryConfig,
+      modelOverride: config.modelOverride,
+      googleApiKey: config.googleApiKey,
+      openaiApiKey: config.openaiApiKey,
+      anthropicApiKey: config.anthropicApiKey,
     };
+
+    if (config.modelOverride) {
+      this.logger.warn(
+        `modelOverride is active: using ${config.modelOverride.provider}:${config.modelOverride.model} instead of the default model. ` +
+        'Evaluation quality may differ from recommended defaults.'
+      );
+    }
 
     // Initialize telemetry if enabled
     if (this.config.telemetry.enabled) {
@@ -186,16 +234,37 @@ export abstract class BaseEvaluator {
    * @throws {ConfigurationError} If required API keys are missing
    */
   private validateApiKeys(config: BaseEvaluatorConfig): void {
-    if (this.metadata.requiresGoogleKey && !config.googleApiKey) {
-      throw new ConfigurationError(
-        `Google API key is required for ${this.metadata.name} evaluator. Pass googleApiKey in config.`
-      );
+    const keyFor: Record<Provider, string | undefined> = {
+      [Provider.OpenAI]: config.openaiApiKey,
+      [Provider.Google]: config.googleApiKey,
+      [Provider.Anthropic]: config.anthropicApiKey,
+    };
+    const humanName: Record<Provider, string> = {
+      [Provider.OpenAI]: 'OpenAI API key',
+      [Provider.Google]: 'Google API key',
+      [Provider.Anthropic]: 'Anthropic API key',
+    };
+    const configKey: Record<Provider, string> = {
+      [Provider.OpenAI]: 'openaiApiKey',
+      [Provider.Google]: 'googleApiKey',
+      [Provider.Anthropic]: 'anthropicApiKey',
+    };
+
+    if (config.modelOverride) {
+      if (!keyFor[config.modelOverride.provider]) {
+        throw new ConfigurationError(
+          `${humanName[config.modelOverride.provider]} is required when using modelOverride with provider "${config.modelOverride.provider}". Pass ${configKey[config.modelOverride.provider]} in config.`
+        );
+      }
+      return;
     }
 
-    if (this.metadata.requiresOpenAIKey && !config.openaiApiKey) {
-      throw new ConfigurationError(
-        `OpenAI API key is required for ${this.metadata.name} evaluator. Pass openaiApiKey in config.`
-      );
+    for (const provider of this.metadata.defaultProviders) {
+      if (!keyFor[provider]) {
+        throw new ConfigurationError(
+          `${humanName[provider]} is required for ${this.metadata.name} evaluator. Pass ${configKey[provider]} in config.`
+        );
+      }
     }
   }
 
@@ -300,6 +369,41 @@ export abstract class BaseEvaluator {
   }
 
   /**
+   * Create an LLM provider, honouring modelOverride if set.
+   * When override is active, the key for the override provider is resolved
+   * from the matching top-level config field (e.g. anthropicApiKey for Anthropic).
+   */
+  protected createConfiguredProvider(
+    defaultType: Provider,
+    defaultModel: string,
+    defaultApiKey: string | undefined,
+    options?: { maxTokens?: number }
+  ): LLMProvider {
+    const override = this.config.modelOverride;
+    if (override) {
+      const apiKeyFor: Record<Provider, string | undefined> = {
+        [Provider.OpenAI]: this.config.openaiApiKey,
+        [Provider.Google]: this.config.googleApiKey,
+        [Provider.Anthropic]: this.config.anthropicApiKey,
+      };
+      return createProvider({
+        type: override.provider,
+        model: override.model,
+        apiKey: apiKeyFor[override.provider],
+        maxRetries: this.config.maxRetries,
+        ...options,
+      });
+    }
+    return createProvider({
+      type: defaultType,
+      model: defaultModel,
+      apiKey: defaultApiKey,
+      maxRetries: this.config.maxRetries,
+      ...options,
+    });
+  }
+
+  /**
    * Send telemetry event to analytics service
    * Common helper for all evaluators
    */
@@ -330,6 +434,7 @@ export abstract class BaseEvaluator {
       provider: params.provider,
       token_usage: params.tokenUsage,
       metadata: params.metadata,
+      model_override: this.config.modelOverride ? true : undefined,
       // Include input text only if recording is enabled
       input_text: this.config.telemetry.recordInputs ? params.inputText : undefined,
     });

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -180,6 +180,11 @@ export abstract class BaseEvaluator {
    */
   static readonly metadata: EvaluatorMetadata;
 
+  /**
+   * @throws {ConfigurationError} If the subclass has not defined static metadata
+   * @throws {ConfigurationError} If modelOverride has an invalid provider or empty model
+   * @throws {ConfigurationError} If a required API key is missing
+   */
   constructor(config: BaseEvaluatorConfig) {
     // Initialize logger
     this.logger = createLogger(config.logger, config.logLevel ?? LogLevel.WARN);
@@ -253,7 +258,7 @@ export abstract class BaseEvaluator {
 
     if (!config.modelOverride.model || config.modelOverride.model.trim() === '') {
       throw new ConfigurationError(
-        `modelOverride.model is required. Specify a model ID for provider "${config.modelOverride.provider}" (e.g. "gpt-4o" for openai).`
+        `modelOverride.model is required. Specify the model ID for provider "${config.modelOverride.provider}".`
       );
     }
   }

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -48,6 +48,10 @@ export interface TelemetryOptions {
  * the chosen provider via the matching top-level config field
  * (e.g. `anthropicApiKey` for `Provider.Anthropic`).
  *
+ * Both `provider` and `model` are required. An empty or missing `model` throws
+ * `ConfigurationError` at construction time. An unrecognised model ID throws
+ * `ConfigurationError` at evaluation time when the provider rejects it.
+ *
  * Results may vary; evaluators are validated against their recommended models.
  */
 export interface ModelOverride {
@@ -180,6 +184,9 @@ export abstract class BaseEvaluator {
     // Initialize logger
     this.logger = createLogger(config.logger, config.logLevel ?? LogLevel.WARN);
 
+    // Validate modelOverride shape before key checks
+    this.validateModelOverride(config);
+
     // Validate required API keys based on metadata
     this.validateApiKeys(config);
 
@@ -230,8 +237,32 @@ export abstract class BaseEvaluator {
   }
 
   /**
-   * Validate that required API keys are provided based on metadata
-   * @throws {ConfigurationError} If required API keys are missing
+   * Validate modelOverride shape: provider must be a known Provider value and
+   * model must be a non-empty string.
+   * @throws {ConfigurationError} If the override is malformed
+   */
+  private validateModelOverride(config: BaseEvaluatorConfig): void {
+    if (!config.modelOverride) return;
+
+    const validProviders = Object.values(Provider) as string[];
+    if (!validProviders.includes(config.modelOverride.provider as string)) {
+      throw new ConfigurationError(
+        `Invalid provider "${config.modelOverride.provider}" in modelOverride. Valid providers are: ${validProviders.join(', ')}.`
+      );
+    }
+
+    if (!config.modelOverride.model || config.modelOverride.model.trim() === '') {
+      throw new ConfigurationError(
+        `modelOverride.model is required. Specify a model ID for provider "${config.modelOverride.provider}" (e.g. "gpt-4o" for openai).`
+      );
+    }
+  }
+
+  /**
+   * Validate that the required API key is present.
+   * When modelOverride is set, checks the override provider's key.
+   * Otherwise checks the keys required by the evaluator's default providers.
+   * @throws {ConfigurationError} If a required key is missing
    */
   private validateApiKeys(config: BaseEvaluatorConfig): void {
     const keyFor: Record<Provider, string | undefined> = {

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -377,7 +377,6 @@ export abstract class BaseEvaluator {
     defaultType: Provider,
     defaultModel: string,
     defaultApiKey: string | undefined,
-    options?: { maxTokens?: number }
   ): LLMProvider {
     const override = this.config.modelOverride;
     if (override) {
@@ -391,7 +390,6 @@ export abstract class BaseEvaluator {
         model: override.model,
         apiKey: apiKeyFor[override.provider],
         maxRetries: this.config.maxRetries,
-        ...options,
       });
     }
     return createProvider({
@@ -399,7 +397,6 @@ export abstract class BaseEvaluator {
       model: defaultModel,
       apiKey: defaultApiKey,
       maxRetries: this.config.maxRetries,
-      ...options,
     });
   }
 

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -271,9 +271,9 @@ export abstract class BaseEvaluator {
    */
   private validateApiKeys(config: BaseEvaluatorConfig): void {
     const keyFor: Record<Provider, string | undefined> = {
-      [Provider.OpenAI]: config.openaiApiKey,
-      [Provider.Google]: config.googleApiKey,
-      [Provider.Anthropic]: config.anthropicApiKey,
+      [Provider.OpenAI]: config.openaiApiKey?.trim() || undefined,
+      [Provider.Google]: config.googleApiKey?.trim() || undefined,
+      [Provider.Anthropic]: config.anthropicApiKey?.trim() || undefined,
     };
     const humanName: Record<Provider, string> = {
       [Provider.OpenAI]: 'OpenAI API key',

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -56,6 +56,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
   async evaluate(

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -1,10 +1,9 @@
 import type { LLMProvider } from '../providers/index.js';
-import { createProvider } from '../providers/index.js';
 import { ConventionalityOutputSchema, type ConventionalityInternal } from '../schemas/conventionality.js';
 import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/conventionality/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { ValidationError, wrapProviderError } from '../errors.js';
 
@@ -37,8 +36,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
     name: 'Conventionality',
     description: 'Evaluates how explicit, literal, and straightforward a text\'s meaning is relative to grade level',
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
-    requiresGoogleKey: true,
-    requiresOpenAIKey: false,
+    defaultProviders: [Provider.Google] as const,
   };
 
   private provider: LLMProvider;
@@ -46,12 +44,9 @@ export class ConventionalityEvaluator extends BaseEvaluator {
   constructor(config: BaseEvaluatorConfig) {
     super(config);
 
-    this.provider = createProvider({
-      type: 'google',
-      model: 'gemini-3-flash-preview',
-      apiKey: config.googleApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.provider = this.createConfiguredProvider(
+      Provider.Google, 'gemini-3-flash-preview', config.googleApiKey
+    );
   }
 
   /**
@@ -92,7 +87,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'conventionality_evaluation',
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         latency_ms: response.latencyMs,
         token_usage: {
           input_tokens: response.usage.inputTokens,
@@ -112,7 +107,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         score: response.data.complexity_score,
         reasoning: response.data.reasoning,
         metadata: {
-          model: 'google:gemini-3-flash-preview',
+          model: this.provider.label,
           processingTimeMs: latencyMs,
         },
         _internal: response.data,
@@ -124,7 +119,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
           stage_details: stageDetails,
@@ -165,7 +160,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -1,12 +1,11 @@
 import type { LLMProvider } from '../providers/index.js';
-import { createProvider } from '../providers/index.js';
 import {
   GradeLevelAppropriatenessSchema,
   type GradeLevelAppropriatenessInternal,
 } from '../schemas/grade-level-appropriateness.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/grade-level-appropriateness/index.js';
 import type { EvaluationResult, GradeBand } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { ValidationError, wrapProviderError } from '../errors.js';
 
 /**
@@ -42,8 +41,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
     name: 'Grade Level Appropriateness',
     description: 'Determines appropriate grade level for text with scaffolding recommendations',
     supportedGrades: [] as const, // No grade parameter required - evaluates what grade the text is appropriate for
-    requiresGoogleKey: true,
-    requiresOpenAIKey: false,
+    defaultProviders: [Provider.Google] as const,
   };
 
   private provider: LLMProvider;
@@ -52,13 +50,9 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
     // Call base constructor for common setup (telemetry, API key validation, etc.)
     super(config);
 
-    // Create Google Gemini provider
-    this.provider = createProvider({
-      type: 'google',
-      model: 'gemini-2.5-pro',
-      apiKey: config.googleApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.provider = this.createConfiguredProvider(
+      Provider.Google, 'gemini-2.5-pro', config.googleApiKey
+    );
   }
 
   /**
@@ -107,7 +101,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
         score: response.data.grade,
         reasoning: response.data.reasoning,
         metadata: {
-          model: 'google:gemini-2.5-pro',
+          model: this.provider.label,
           processingTimeMs: latencyMs,
         },
         _internal: response.data,
@@ -118,7 +112,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        provider: 'google:gemini-2.5-pro',
+        provider: this.provider.label,
         tokenUsage,
         // No metadata.stage_details for single-stage evaluator
         inputText: text,
@@ -150,7 +144,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        provider: 'google:gemini-2.5-pro',
+        provider: this.provider.label,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         inputText: text,
       }).catch(() => {

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -61,6 +61,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @returns Evaluation result with grade recommendations and scaffolding suggestions
    * @throws {ValidationError} If text is empty or too short/long
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
   async evaluate(text: string): Promise<EvaluationResult<GradeBand, GradeLevelAppropriatenessInternal>> {

--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -1,6 +1,8 @@
 export {
   BaseEvaluator,
+  Provider,
   type BaseEvaluatorConfig,
+  type ModelOverride,
   type TelemetryOptions,
   type EvaluatorMetadata,
 } from './base.js';

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -1,12 +1,11 @@
-import type { LLMProvider, ProviderConfig } from '../providers/index.js';
-import { createProvider, Providers } from '../providers/index.js';
+import type { LLMProvider } from '../providers/index.js';
 import { PurposeOutputSchema, type PurposeInternal } from '../schemas/purpose.js';
 import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/purpose/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ConfigurationError, ValidationError, wrapProviderError } from '../errors.js';
+import { ValidationError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/prompts/purpose/config.json';
 import INPUT_SCHEMA from '../../../../evals/prompts/purpose/input_schema.json';
 
@@ -38,11 +37,9 @@ export class PurposeEvaluator extends BaseEvaluator {
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
     supportedGrades: SUPPORTED_GRADES,
-    requiresGoogleKey: CONFIG.steps.some(s => s.model.provider === Providers.google),
-    requiresOpenAIKey: CONFIG.steps.some(s => s.model.provider === Providers.openai),
+    defaultProviders: [Provider.Google] as const,
   };
 
-  private static readonly MODEL_ID = `${STEP.model.provider}:${STEP.model.name}`;
   private static readonly TEMPERATURE = STEP.generation.temperature;
 
   private static computeFkScore(text: string): number {
@@ -56,26 +53,21 @@ export class PurposeEvaluator extends BaseEvaluator {
   constructor(config: BaseEvaluatorConfig) {
     super(config);
 
-    const providerType = STEP.model.provider as ProviderConfig['type'];
-    let apiKey: string | undefined;
-    if (providerType === Providers.google) {
-      apiKey = config.googleApiKey;
-    } else if (providerType === Providers.openai) {
-      apiKey = config.openaiApiKey;
-    } else {
-      throw new ConfigurationError(
-        `Unsupported provider "${providerType}" in purpose config. Supported: ${Providers.google}, ${Providers.openai}.`,
-      );
-    }
-
-    this.provider = createProvider({
-      type: providerType,
-      model: STEP.model.name,
-      apiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.provider = this.createConfiguredProvider(
+      Provider.Google, STEP.model.name, config.googleApiKey
+    );
   }
 
+  /**
+   * Evaluate purpose complexity for a given text and grade level
+   *
+   * @param text - The text to evaluate
+   * @param grade - The target grade level (3-12)
+   * @returns Evaluation result with complexity score and detailed analysis
+   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
+   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   */
   async evaluate(text: string, grade: string): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
     this.logger.info('Starting Purpose evaluation', {
       evaluator: PurposeEvaluator.metadata.id,
@@ -107,7 +99,7 @@ export class PurposeEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: STEP.id,
-        provider: PurposeEvaluator.MODEL_ID,
+        provider: this.provider.label,
         latency_ms: response.latencyMs,
         token_usage: tokenUsage,
       });
@@ -116,7 +108,7 @@ export class PurposeEvaluator extends BaseEvaluator {
         score: COMPLEXITY_SCORE_DISPLAY[response.data.complexity_score],
         reasoning: response.data.reasoning,
         metadata: {
-          model: PurposeEvaluator.MODEL_ID,
+          model: this.provider.label,
           processingTimeMs: latencyMs,
         },
         _internal: response.data,
@@ -127,7 +119,7 @@ export class PurposeEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade: String(gradeNum),
-        provider: PurposeEvaluator.MODEL_ID,
+        provider: this.provider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
         inputText: text,
@@ -165,7 +157,7 @@ export class PurposeEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade: String(grade),
-        provider: PurposeEvaluator.MODEL_ID,
+        provider: this.provider.label,
         tokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -90,6 +90,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
   async evaluate(

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -1,5 +1,4 @@
 import type { LLMProvider } from '../providers/index.js';
-import { createProvider } from '../providers/index.js';
 import {
   SentenceAnalysisSchema,
   ComplexityClassificationSchema,
@@ -16,7 +15,7 @@ import {
   getUserPromptComplexity,
 } from '../prompts/sentence-structure/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { ValidationError, wrapProviderError } from '../errors.js';
 
@@ -71,31 +70,17 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
     name: 'Sentence Structure',
     description: 'Evaluates sentence structure complexity based on grammatical features',
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
-    requiresGoogleKey: false,
-    requiresOpenAIKey: true,
+    defaultProviders: [Provider.OpenAI] as const,
   };
 
-  private analysisProvider: LLMProvider;
-  private complexityProvider: LLMProvider;
+  private provider: LLMProvider;
 
   constructor(config: BaseEvaluatorConfig) {
     // Call base constructor for common setup (telemetry, API key validation, etc.)
     super(config);
 
-    // Create OpenAI GPT-4o provider for both stages
-    this.analysisProvider = createProvider({
-      type: 'openai',
-      model: 'gpt-4o',
-      apiKey: config.openaiApiKey,
-      maxRetries: this.config.maxRetries,
-    });
-
-    this.complexityProvider = createProvider({
-      type: 'openai',
-      model: 'gpt-4o',
-      apiKey: config.openaiApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    // Both stages use the same model — share a single provider instance
+    this.provider = this.createConfiguredProvider(Provider.OpenAI, 'gpt-4o', config.openaiApiKey);
   }
 
   /**
@@ -134,7 +119,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'sentence_analysis',
-        provider: 'openai:gpt-4o',
+        provider: this.provider.label,
         latency_ms: analysisResponse.latencyMs,
         token_usage: {
           input_tokens: analysisResponse.usage.inputTokens,
@@ -154,7 +139,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'complexity_classification',
-        provider: 'openai:gpt-4o',
+        provider: this.provider.label,
         latency_ms: complexityResponse.latencyMs,
         token_usage: {
           input_tokens: complexityResponse.usage.inputTokens,
@@ -174,7 +159,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         score: complexityResponse.data.answer,
         reasoning: complexityResponse.data.reasoning,
         metadata: {
-          model: 'openai:gpt-4o',
+          model: this.provider.label,
           processingTimeMs: latencyMs,
         },
         _internal: {
@@ -190,7 +175,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'openai:gpt-4o',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
           stage_details: stageDetails,
@@ -234,7 +219,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'openai:gpt-4o',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
@@ -274,7 +259,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
     const userPrompt = getUserPromptAnalysis(text, gtCountsStr);
 
-    const response = await this.analysisProvider.generateStructured({
+    const response = await this.provider.generateStructured({
       messages: [
         { role: 'system', content: getSystemPromptAnalysis() },
         { role: 'user', content: userPrompt },
@@ -305,7 +290,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
     const userPrompt = getUserPromptComplexity(featuresJSON, grade, excerpt);
 
-    const response = await this.complexityProvider.generateStructured({
+    const response = await this.provider.generateStructured({
       messages: [
         { role: 'system', content: getSystemPromptComplexity() },
         { role: 'user', content: userPrompt },

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -1,10 +1,9 @@
 import type { LLMProvider } from '../providers/index.js';
-import { createProvider } from '../providers/index.js';
 import { SmkOutputSchema, type SmkInternal } from '../schemas/smk.js';
 import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/subject-matter-knowledge/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { ValidationError, wrapProviderError } from '../errors.js';
 
@@ -37,8 +36,7 @@ export class SmkEvaluator extends BaseEvaluator {
     name: 'Subject Matter Knowledge',
     description: 'Evaluates background knowledge demands of educational texts relative to grade level',
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
-    requiresGoogleKey: true,
-    requiresOpenAIKey: false,
+    defaultProviders: [Provider.Google] as const,
   };
 
   private provider: LLMProvider;
@@ -46,12 +44,9 @@ export class SmkEvaluator extends BaseEvaluator {
   constructor(config: BaseEvaluatorConfig) {
     super(config);
 
-    this.provider = createProvider({
-      type: 'google',
-      model: 'gemini-3-flash-preview',
-      apiKey: config.googleApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.provider = this.createConfiguredProvider(
+      Provider.Google, 'gemini-3-flash-preview', config.googleApiKey
+    );
   }
 
   /**
@@ -92,7 +87,7 @@ export class SmkEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'smk_evaluation',
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         latency_ms: response.latencyMs,
         token_usage: {
           input_tokens: response.usage.inputTokens,
@@ -112,7 +107,7 @@ export class SmkEvaluator extends BaseEvaluator {
         score: response.data.complexity_score,
         reasoning: response.data.reasoning,
         metadata: {
-          model: 'google:gemini-3-flash-preview',
+          model: this.provider.label,
           processingTimeMs: latencyMs,
         },
         _internal: response.data,
@@ -124,7 +119,7 @@ export class SmkEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
           stage_details: stageDetails,
@@ -165,7 +160,7 @@ export class SmkEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: 'google:gemini-3-flash-preview',
+        provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -56,6 +56,7 @@ export class SmkEvaluator extends BaseEvaluator {
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
   async evaluate(

--- a/sdks/typescript/src/evaluators/text-complexity.ts
+++ b/sdks/typescript/src/evaluators/text-complexity.ts
@@ -85,7 +85,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Map of sub-evaluator results
-   * @throws {ValidationError} If text is empty or grade is invalid
+   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {Error} If all sub-evaluators fail
    */

--- a/sdks/typescript/src/evaluators/text-complexity.ts
+++ b/sdks/typescript/src/evaluators/text-complexity.ts
@@ -4,8 +4,7 @@ import { SentenceStructureEvaluator } from './sentence-structure.js';
 import { SmkEvaluator } from './smk.js';
 import { ConventionalityEvaluator } from './conventionality.js';
 import type { SentenceStructureInternal } from '../schemas/sentence-structure.js';
-import type { BaseEvaluatorConfig } from './base.js';
-import { BaseEvaluator } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import type { VocabularyInternal } from '../schemas/vocabulary.js';
 import type { SmkInternal } from '../schemas/smk.js';
@@ -53,8 +52,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
     name: 'Text Complexity',
     description: 'Composite evaluator analyzing vocabulary, sentence structure, subject matter knowledge, and conventionality complexity',
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
-    requiresGoogleKey: true,
-    requiresOpenAIKey: true,
+    defaultProviders: [Provider.Google, Provider.OpenAI] as const,
   };
 
   private vocabularyEvaluator: VocabularyEvaluator;
@@ -150,7 +148,9 @@ export class TextComplexityEvaluator extends BaseEvaluator {
       latencyMs,
       textLength: text.length,
       grade,
-      provider: 'composite:google+openai',
+      provider: this.config.modelOverride
+        ? `${this.config.modelOverride.provider}:${this.config.modelOverride.model}`
+        : 'composite:google+openai',
       errorCode: hasFailures ? 'PartialFailure' : undefined,
       inputText: text,
     }).catch(() => {

--- a/sdks/typescript/src/evaluators/text-complexity.ts
+++ b/sdks/typescript/src/evaluators/text-complexity.ts
@@ -86,6 +86,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
    * @param grade - The target grade level (3-12)
    * @returns Map of sub-evaluator results
    * @throws {ValidationError} If text is empty or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {Error} If all sub-evaluators fail
    */
   async evaluate(text: string, grade: string): Promise<TextComplexityResult> {

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -103,7 +103,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
     // When override is active all providers resolve to the same model — show a single label.
     const modelLabel = this.config.modelOverride
       ? backgroundProviderLabel
-      : `${backgroundProviderLabel} + ${complexityProviderLabel}`;
+      : `${backgroundProviderLabel}+${complexityProviderLabel}`;
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -1,5 +1,4 @@
 import type { LLMProvider } from '../providers/index.js';
-import { createProvider } from '../providers/index.js';
 import {
   VocabularyComplexitySchema,
   type VocabularyInternal,
@@ -12,7 +11,7 @@ import {
   getUserPrompt,
 } from '../prompts/vocabulary/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, type BaseEvaluatorConfig } from './base.js';
+import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { ValidationError, wrapProviderError } from '../errors.js';
 
@@ -48,8 +47,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
     name: 'Vocabulary',
     description: 'Evaluates vocabulary complexity of educational texts relative to grade level',
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
-    requiresGoogleKey: true,
-    requiresOpenAIKey: true,
+    defaultProviders: [Provider.Google, Provider.OpenAI] as const,
   };
 
   private grades34ComplexityProvider: LLMProvider;
@@ -61,28 +59,19 @@ export class VocabularyEvaluator extends BaseEvaluator {
     super(config);
 
     // Create Google Gemini provider for complexity evaluation (grades 3-4)
-    this.grades34ComplexityProvider = createProvider({
-      type: 'google',
-      model: 'gemini-2.5-pro',
-      apiKey: config.googleApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.grades34ComplexityProvider = this.createConfiguredProvider(
+      Provider.Google, 'gemini-2.5-pro', config.googleApiKey
+    );
 
     // Create OpenAI GPT-4.1 provider for complexity evaluation (grades 5-12)
-    this.otherGradesComplexityProvider = createProvider({
-      type: 'openai',
-      model: 'gpt-4.1-2025-04-14',
-      apiKey: config.openaiApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.otherGradesComplexityProvider = this.createConfiguredProvider(
+      Provider.OpenAI, 'gpt-4.1-2025-04-14', config.openaiApiKey
+    );
 
     // Create OpenAI GPT-4o provider for background knowledge generation
-    this.backgroundKnowledgeProvider = createProvider({
-      type: 'openai',
-      model: 'gpt-4o-2024-11-20',
-      apiKey: config.openaiApiKey,
-      maxRetries: this.config.maxRetries,
-    });
+    this.backgroundKnowledgeProvider = this.createConfiguredProvider(
+      Provider.OpenAI, 'gpt-4o-2024-11-20', config.openaiApiKey
+    );
   }
 
   /**
@@ -107,9 +96,14 @@ export class VocabularyEvaluator extends BaseEvaluator {
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
-    const complexityProviderName = (grade === '3' || grade === '4')
-      ? 'google:gemini-2.5-pro'
-      : 'openai:gpt-4.1-2025-04-14';
+    const complexityProviderLabel = (grade === '3' || grade === '4')
+      ? this.grades34ComplexityProvider.label
+      : this.otherGradesComplexityProvider.label;
+    const backgroundProviderLabel = this.backgroundKnowledgeProvider.label;
+    // When override is active all providers resolve to the same model — show a single label.
+    const modelLabel = this.config.modelOverride
+      ? backgroundProviderLabel
+      : `${backgroundProviderLabel} + ${complexityProviderLabel}`;
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
@@ -125,7 +119,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'background_knowledge',
-        provider: 'openai:gpt-4o-2024-11-20',
+        provider: backgroundProviderLabel,
         latency_ms: bgResponse.latencyMs,
         token_usage: {
           input_tokens: bgResponse.usage.inputTokens,
@@ -146,7 +140,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'complexity_evaluation',
-        provider: complexityProviderName,
+        provider: complexityProviderLabel,
         latency_ms: complexityResponse.latencyMs,
         token_usage: {
           input_tokens: complexityResponse.usage.inputTokens,
@@ -166,7 +160,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
         score: complexityResponse.data.complexity_score,
         reasoning: complexityResponse.data.reasoning,
         metadata: {
-          model: `openai:gpt-4o-2024-11-20 + ${complexityProviderName}`,
+          model: modelLabel,
           processingTimeMs: latencyMs,
         },
         _internal: complexityResponse.data,
@@ -178,7 +172,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: `openai:gpt-4o-2024-11-20 + ${complexityProviderName}`,
+        provider: modelLabel,
         tokenUsage: totalTokenUsage,
         metadata: {
           stage_details: stageDetails,
@@ -222,7 +216,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
         latencyMs,
         textLength: text.length,
         grade,
-        provider: `openai:gpt-4o-2024-11-20 + ${complexityProviderName}`,
+        provider: modelLabel,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -81,6 +81,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
   async evaluate(

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -82,7 +82,9 @@ export {
   PurposeEvaluator,
   evaluatePurpose,
   type PurposeComplexityLevel,
+  Provider,
   type BaseEvaluatorConfig,
+  type ModelOverride,
   type TelemetryOptions,
   type EvaluatorMetadata,
 } from './evaluators/index.js';

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -21,12 +21,15 @@ const DEFAULT_MODELS = {
  * Supports OpenAI, Anthropic, and Google Gemini
  */
 export class VercelAIProvider implements LLMProvider {
+  readonly label: string;
+
   constructor(private config: ProviderConfig) {
     if (config.type === 'custom') {
       throw new Error(
         'VercelAIProvider does not support custom type. Use config.customProvider directly.'
       );
     }
+    this.label = `${config.type}:${config.model ?? DEFAULT_MODELS[config.type]}`;
   }
 
   /**

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -8,20 +8,12 @@ import type {
 } from './base.js';
 
 /**
- * Default models for each provider based on Python implementation
- */
-const DEFAULT_MODELS = {
-  openai: 'gpt-4o',
-  anthropic: 'claude-sonnet-4-5-20250929',
-  google: 'gemini-2.5-pro',
-} as const;
-
-/**
  * Vercel AI SDK provider implementation
  * Supports OpenAI, Anthropic, and Google Gemini
  */
 export class VercelAIProvider implements LLMProvider {
   readonly label: string;
+  private readonly model: string;
 
   constructor(private config: ProviderConfig) {
     if (config.type === 'custom') {
@@ -29,14 +21,20 @@ export class VercelAIProvider implements LLMProvider {
         'VercelAIProvider does not support custom type. Use config.customProvider directly.'
       );
     }
-    this.label = `${config.type}:${config.model ?? DEFAULT_MODELS[config.type]}`;
+    if (!config.model || config.model.trim() === '') {
+      throw new Error(
+        `model is required for VercelAIProvider (type: "${config.type}"). No default is assumed.`
+      );
+    }
+    this.model = config.model;
+    this.label = `${config.type}:${config.model}`;
   }
 
   /**
    * Generate structured output using Vercel AI SDK's generateText with output
    */
   async generateStructured<T>(request: LLMRequest<T>): Promise<LLMResponse<T>> {
-    const model = await this.getModel(request.model);
+    const model = await this.getModel();
     const startTime = Date.now();
 
     const { output, usage } = await aiGenerateText({
@@ -50,7 +48,7 @@ export class VercelAIProvider implements LLMProvider {
 
     return {
       data: output as T,
-      model: request.model || this.getDefaultModel(),
+      model: this.model,
       usage: {
         inputTokens: usage.inputTokens || 0,
         outputTokens: usage.outputTokens || 0,
@@ -87,8 +85,7 @@ export class VercelAIProvider implements LLMProvider {
    * Get the configured language model.
    * Uses dynamic imports so consumers only need to install the provider packages they use.
    */
-  private async getModel(requestModel?: string) {
-    const modelId = requestModel || this.config.model || this.getDefaultModel();
+  private async getModel() {
     const apiKey = this.config.apiKey;
 
     switch (this.config.type) {
@@ -98,7 +95,7 @@ export class VercelAIProvider implements LLMProvider {
             'To use the OpenAI provider, install its adapter: npm install @ai-sdk/openai'
           );
         });
-        return createOpenAI(apiKey ? { apiKey } : {})(modelId);
+        return createOpenAI(apiKey ? { apiKey } : {})(this.model);
       }
       case 'anthropic': {
         const { createAnthropic } = await import('@ai-sdk/anthropic').catch(() => {
@@ -106,7 +103,7 @@ export class VercelAIProvider implements LLMProvider {
             'To use the Anthropic provider, install its adapter: npm install @ai-sdk/anthropic'
           );
         });
-        return createAnthropic(apiKey ? { apiKey } : {})(modelId);
+        return createAnthropic(apiKey ? { apiKey } : {})(this.model);
       }
       case 'google': {
         const { createGoogleGenerativeAI } = await import('@ai-sdk/google').catch(() => {
@@ -114,24 +111,11 @@ export class VercelAIProvider implements LLMProvider {
             'To use the Google provider, install its adapter: npm install @ai-sdk/google'
           );
         });
-        return createGoogleGenerativeAI(apiKey ? { apiKey } : {})(modelId);
+        return createGoogleGenerativeAI(apiKey ? { apiKey } : {})(this.model);
       }
       default:
         throw new Error(`Unsupported provider type: ${this.config.type}`);
     }
-  }
-
-  /**
-   * Get default model for the configured provider
-   */
-  private getDefaultModel(): string {
-    const providerType = this.config.type;
-
-    if (providerType === 'custom') {
-      throw new Error('Cannot get default model for custom provider type');
-    }
-
-    return DEFAULT_MODELS[providerType];
   }
 }
 

--- a/sdks/typescript/src/providers/base.ts
+++ b/sdks/typescript/src/providers/base.ts
@@ -48,6 +48,9 @@ export interface TextGenerationResponse {
  * Base interface for LLM provider implementations
  */
 export interface LLMProvider {
+  /** Canonical label for the provider and model in use (e.g. "openai:gpt-4o") */
+  readonly label: string;
+
   /**
    * Generate structured output from LLM using Zod schema
    */

--- a/sdks/typescript/src/providers/base.ts
+++ b/sdks/typescript/src/providers/base.ts
@@ -16,7 +16,6 @@ export interface LLMRequest<T> {
   schema: z.ZodSchema<T>;
   temperature?: number;
   maxTokens?: number;
-  model?: string;
 }
 
 /**

--- a/sdks/typescript/src/telemetry/types.ts
+++ b/sdks/typescript/src/telemetry/types.ts
@@ -68,6 +68,7 @@ export interface TelemetryEvent {
   provider: string; // Format: "provider:model" or "provider1+provider2" for multi-provider
   token_usage?: TokenUsage; // Aggregated across all stages and attempts
   metadata?: TelemetryMetadata; // Optional per-stage breakdown
+  model_override?: boolean; // true when the caller supplied a modelOverride
   input_text?: string; // Input text (only if recordInputs enabled)
 }
 

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { SentenceStructureEvaluator } from '../../src/evaluators/sentence-structure.js';
+import { ConfigurationError } from '../../src/errors.js';
+import { Provider } from '../../src/evaluators/base.js';
+
+/**
+ * modelOverride integration tests (live API)
+ *
+ * Uses SentenceStructureEvaluator as the vehicle — simplest single-provider evaluator.
+ * These tests are about the override feature, not sentence structure evaluation quality.
+ *
+ * To run:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
+                         !process.env.OPENAI_API_KEY;
+
+const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const SAMPLE_TEXT =
+  'The mitochondria is the powerhouse of the cell. It produces energy through a process called cellular respiration.';
+
+describeIntegration('modelOverride — model validity (live API)', () => {
+  it('succeeds with a valid model override', async () => {
+    const evaluator = new SentenceStructureEvaluator({
+      openaiApiKey: process.env.OPENAI_API_KEY!,
+      modelOverride: { provider: Provider.OpenAI, model: 'gpt-4o-mini' },
+      telemetry: false,
+    });
+
+    const result = await evaluator.evaluate(SAMPLE_TEXT, '5');
+    expect(result.score).toBeDefined();
+    expect(result.metadata.model).toMatch(/^openai:gpt-4o-mini/);
+  }, TEST_TIMEOUT_MS);
+
+  it('throws ConfigurationError for a non-existent model override', async () => {
+    const evaluator = new SentenceStructureEvaluator({
+      openaiApiKey: process.env.OPENAI_API_KEY!,
+      modelOverride: { provider: Provider.OpenAI, model: 'gpt-this-model-does-not-exist-9999' },
+      telemetry: false,
+    });
+
+    await expect(evaluator.evaluate(SAMPLE_TEXT, '5')).rejects.toThrow(ConfigurationError);
+  }, TEST_TIMEOUT_MS);
+});

--- a/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
+++ b/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { APICallError } from 'ai';
+import { wrapProviderError, ConfigurationError, AuthenticationError, RateLimitError, APIError } from '../../../src/errors.js';
+
+const makeAPICallError = (statusCode: number, message: string) =>
+  new APICallError({
+    message,
+    url: 'https://api.example.com/v1/chat',
+    requestBodyValues: {},
+    statusCode,
+    responseHeaders: {},
+    responseBody: message,
+    isRetryable: false,
+  });
+
+describe('wrapProviderError — model-not-found detection', () => {
+  it('returns ConfigurationError for a 404 APICallError', () => {
+    const err = makeAPICallError(404, "The model 'gpt-fake' does not exist");
+    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('returns ConfigurationError for a 400 APICallError with model-related message', () => {
+    const err = makeAPICallError(400, 'model gpt-fake-99 does not exist or you do not have access');
+    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('does NOT return ConfigurationError for a 400 without model-related message', () => {
+    const err = makeAPICallError(400, 'Invalid request: missing required field');
+    expect(wrapProviderError(err)).not.toBeInstanceOf(ConfigurationError);
+    expect(wrapProviderError(err)).toBeInstanceOf(APIError);
+  });
+
+  it('returns ConfigurationError for a plain Error with statusCode: 404 property', () => {
+    const err = Object.assign(new Error("The model 'gpt-fake' does not exist"), { statusCode: 404 });
+    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+  });
+});
+
+describe('wrapProviderError — existing error type detection (regression)', () => {
+  it('returns AuthenticationError for 401', () => {
+    const err = makeAPICallError(401, 'Invalid API key');
+    expect(wrapProviderError(err)).toBeInstanceOf(AuthenticationError);
+  });
+
+  it('returns AuthenticationError for 403', () => {
+    const err = makeAPICallError(403, 'Forbidden');
+    expect(wrapProviderError(err)).toBeInstanceOf(AuthenticationError);
+  });
+
+  it('returns RateLimitError for 429', () => {
+    const err = makeAPICallError(429, 'Rate limit exceeded');
+    expect(wrapProviderError(err)).toBeInstanceOf(RateLimitError);
+  });
+
+  it('returns generic APIError for 500', () => {
+    const err = makeAPICallError(500, 'Internal server error');
+    expect(wrapProviderError(err)).toBeInstanceOf(APIError);
+    expect(wrapProviderError(err)).not.toBeInstanceOf(ConfigurationError);
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/conventionality.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/conventionality.test.ts
@@ -3,13 +3,14 @@ import { ConventionalityEvaluator } from '../../../src/evaluators/conventionalit
 import type { LLMProvider } from '../../../src/providers/base.js';
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 vi.mock('../../../src/telemetry/client.js', () => ({
@@ -30,8 +31,7 @@ describe('ConventionalityEvaluator - Metadata', () => {
   it('should have correct metadata', () => {
     expect(ConventionalityEvaluator.metadata.id).toBe('conventionality');
     expect(ConventionalityEvaluator.metadata.name).toBe('Conventionality');
-    expect(ConventionalityEvaluator.metadata.requiresGoogleKey).toBe(true);
-    expect(ConventionalityEvaluator.metadata.requiresOpenAIKey).toBe(false);
+    expect(ConventionalityEvaluator.metadata.defaultProviders).toEqual(['google']);
     expect(ConventionalityEvaluator.metadata.supportedGrades).toEqual([
       '3', '4', '5', '6', '7', '8', '9', '10', '11', '12',
     ]);

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -15,14 +15,15 @@ import type { LLMProvider } from '../../../src/providers/base.js';
  */
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 // Mock the createProvider factory
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 // Mock telemetry to avoid real HTTP calls

--- a/sdks/typescript/tests/unit/evaluators/purpose.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHash } from 'node:crypto';
 import { PurposeEvaluator } from '../../../src/evaluators/purpose.js';
+import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 import CONFIG from '../../../../../evals/prompts/purpose/config.json';
 import { getSystemPrompt, getUserPrompt } from '../../../src/prompts/purpose/index.js';
 
 const STEP = CONFIG.steps[0];
 
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
@@ -16,7 +18,7 @@ vi.mock('../../../src/providers/index.js', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...(actual as object),
-    createProvider: vi.fn(() => createMockProvider()),
+    createProvider: vi.fn((config) => createMockProvider(config)),
   };
 });
 
@@ -76,13 +78,12 @@ describe('PurposeEvaluator - Metadata', () => {
     expect(PurposeEvaluator.metadata.description).toBe(CONFIG.evaluator.description);
   });
 
-  it('requiresGoogleKey is true (config provider is google)', () => {
-    expect(PurposeEvaluator.metadata.requiresGoogleKey).toBe(STEP.model.provider === 'google');
-    expect(PurposeEvaluator.metadata.requiresGoogleKey).toBe(true);
+  it('defaultProviders includes Google', () => {
+    expect(PurposeEvaluator.metadata.defaultProviders).toContain(Provider.Google);
   });
 
-  it('requiresOpenAIKey is false', () => {
-    expect(PurposeEvaluator.metadata.requiresOpenAIKey).toBe(false);
+  it('defaultProviders does not include OpenAI', () => {
+    expect(PurposeEvaluator.metadata.defaultProviders).not.toContain(Provider.OpenAI);
   });
 
   it('supports integer grades 3–12', () => {
@@ -195,6 +196,37 @@ describe('PurposeEvaluator - LLM call contract', () => {
     expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
     expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
     expect(result._internal?.details.recommended_use_cases).toBeInstanceOf(Array);
+  });
+
+  it('reflects modelOverride in metadata.model', async () => {
+    const overrideEvaluator = new PurposeEvaluator({
+      anthropicApiKey: 'test-key',
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-haiku-4-5-20251001' },
+      telemetry: false,
+    });
+    // @ts-expect-error accessing private for testing
+    const overrideProvider: LLMProvider = overrideEvaluator.provider;
+
+    vi.mocked(overrideProvider.generateStructured).mockResolvedValue({
+      data: {
+        complexity_score: 'slightly_complex' as const,
+        reasoning: 'Simple purpose.',
+        details: {
+          detailed_summary: [],
+          adjustment_and_scaffolding: [],
+          recommended_use_cases: [],
+        },
+      },
+      model: 'claude-haiku-4-5-20251001',
+      usage: { inputTokens: 100, outputTokens: 50 },
+      latencyMs: 300,
+    });
+
+    const result = await overrideEvaluator.evaluate(
+      'When going to the beach, find out which ones have lifeguards.', '3'
+    );
+
+    expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
 
   it('accepts string grade (consistent with all other evaluators)', async () => {

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -56,14 +56,15 @@ const createMockSentenceAnalysis = () => ({
 });
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 // Mock the createProvider factory
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 // Mock telemetry to avoid real HTTP calls
@@ -86,8 +87,7 @@ describe('SentenceStructureEvaluator - Constructor Validation', () => {
 
 describe('SentenceStructureEvaluator - Evaluation Flow', () => {
   let evaluator: SentenceStructureEvaluator;
-  let mockAnalysisProvider: LLMProvider;
-  let mockComplexityProvider: LLMProvider;
+  let mockProvider: LLMProvider;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,11 +98,9 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       telemetry: false,
     });
 
-    // Get references to the mocked providers
+    // Both stages share a single provider instance
     // @ts-expect-error Accessing private property for testing
-    mockAnalysisProvider = evaluator.analysisProvider;
-    // @ts-expect-error Accessing private property for testing
-    mockComplexityProvider = evaluator.complexityProvider;
+    mockProvider = evaluator.provider;
   });
 
   afterEach(() => {
@@ -114,30 +112,23 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       const testText = 'The cat sat on the mat. It was sleeping peacefully.';
       const testGrade = '3';
 
-      // Mock sentence analysis response
-      vi.mocked(mockAnalysisProvider.generateStructured).mockResolvedValue({
-        data: createMockSentenceAnalysis(),
-        model: 'gpt-4o',
-        usage: {
-          inputTokens: 150,
-          outputTokens: 100,
-        },
-        latencyMs: 600,
-      });
-
-      // Mock complexity classification response
-      vi.mocked(mockComplexityProvider.generateStructured).mockResolvedValue({
-        data: {
-          answer: 'Slightly complex',
-          reasoning: 'The text uses simple sentence structures appropriate for third grade.',
-        },
-        model: 'gpt-4o',
-        usage: {
-          inputTokens: 250,
-          outputTokens: 80,
-        },
-        latencyMs: 500,
-      });
+      // Stage 1: sentence analysis, Stage 2: complexity classification — same provider
+      vi.mocked(mockProvider.generateStructured)
+        .mockResolvedValueOnce({
+          data: createMockSentenceAnalysis(),
+          model: 'gpt-4o',
+          usage: { inputTokens: 150, outputTokens: 100 },
+          latencyMs: 600,
+        })
+        .mockResolvedValueOnce({
+          data: {
+            answer: 'Slightly complex',
+            reasoning: 'The text uses simple sentence structures appropriate for third grade.',
+          },
+          model: 'gpt-4o',
+          usage: { inputTokens: 250, outputTokens: 80 },
+          latencyMs: 500,
+        });
 
       // Execute evaluation
       const result = await evaluator.evaluate(testText, testGrade);
@@ -149,9 +140,8 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       expect(result.metadata.model).toBe('openai:gpt-4o');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
 
-      // Verify both providers were called
-      expect(mockAnalysisProvider.generateStructured).toHaveBeenCalledTimes(1);
-      expect(mockComplexityProvider.generateStructured).toHaveBeenCalledTimes(1);
+      // Verify provider was called twice (once per stage)
+      expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
 
       // Verify internal data structure
       expect(result._internal).toBeDefined();
@@ -166,8 +156,8 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       const testText = 'Test text here for API failure';
       const testGrade = '3';
 
-      // Mock analysis failure
-      vi.mocked(mockAnalysisProvider.generateStructured).mockRejectedValue(
+      // Stage 1 fails — stage 2 should never be reached
+      vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(
         new Error('API timeout')
       );
 
@@ -175,55 +165,52 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       await expect(evaluator.evaluate(testText, testGrade))
         .rejects.toThrow('API timeout');
 
-      // Verify complexity provider was never called
-      expect(mockComplexityProvider.generateStructured).not.toHaveBeenCalled();
+      // Provider called once (stage 1 only)
+      expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
     });
 
     it('should handle complexity classification API failure', async () => {
       const testText = 'Test text here for complexity failure';
       const testGrade = '5';
 
-      // Mock successful analysis
-      vi.mocked(mockAnalysisProvider.generateStructured).mockResolvedValue({
-        data: createMockSentenceAnalysis(),
-        model: 'gpt-4o',
-        usage: { inputTokens: 150, outputTokens: 100 },
-        latencyMs: 600,
-      });
-
-      // Mock complexity failure
-      vi.mocked(mockComplexityProvider.generateStructured).mockRejectedValue(
-        new Error('Schema validation failed')
-      );
+      // Stage 1 succeeds, stage 2 fails
+      vi.mocked(mockProvider.generateStructured)
+        .mockResolvedValueOnce({
+          data: createMockSentenceAnalysis(),
+          model: 'gpt-4o',
+          usage: { inputTokens: 150, outputTokens: 100 },
+          latencyMs: 600,
+        })
+        .mockRejectedValueOnce(new Error('Schema validation failed'));
 
       // Should propagate the error
       await expect(evaluator.evaluate(testText, testGrade))
         .rejects.toThrow('Schema validation failed');
 
-      // Verify analysis provider was called (stage 1 completed)
-      expect(mockAnalysisProvider.generateStructured).toHaveBeenCalledTimes(1);
+      // Provider called twice (stage 1 completed, stage 2 failed)
+      expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
     });
 
   });
 
   describe('Response Structure', () => {
     it('should return correct result structure', async () => {
-      vi.mocked(mockAnalysisProvider.generateStructured).mockResolvedValue({
-        data: createMockSentenceAnalysis(),
-        model: 'gpt-4o',
-        usage: { inputTokens: 150, outputTokens: 100 },
-        latencyMs: 600,
-      });
-
-      vi.mocked(mockComplexityProvider.generateStructured).mockResolvedValue({
-        data: {
-          answer: 'Moderately complex',
-          reasoning: 'Detailed reasoning here',
-        },
-        model: 'gpt-4o',
-        usage: { inputTokens: 250, outputTokens: 80 },
-        latencyMs: 500,
-      });
+      vi.mocked(mockProvider.generateStructured)
+        .mockResolvedValueOnce({
+          data: createMockSentenceAnalysis(),
+          model: 'gpt-4o',
+          usage: { inputTokens: 150, outputTokens: 100 },
+          latencyMs: 600,
+        })
+        .mockResolvedValueOnce({
+          data: {
+            answer: 'Moderately complex',
+            reasoning: 'Detailed reasoning here',
+          },
+          model: 'gpt-4o',
+          usage: { inputTokens: 250, outputTokens: 80 },
+          latencyMs: 500,
+        });
 
       const result = await evaluator.evaluate('Test text here', '5');
 

--- a/sdks/typescript/tests/unit/evaluators/smk.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/smk.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SmkEvaluator } from '../../../src/evaluators/smk.js';
+import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 vi.mock('../../../src/telemetry/client.js', () => ({
@@ -30,8 +32,7 @@ describe('SmkEvaluator - Metadata', () => {
   it('should have correct metadata', () => {
     expect(SmkEvaluator.metadata.id).toBe('subject-matter-knowledge');
     expect(SmkEvaluator.metadata.name).toBe('Subject Matter Knowledge');
-    expect(SmkEvaluator.metadata.requiresGoogleKey).toBe(true);
-    expect(SmkEvaluator.metadata.requiresOpenAIKey).toBe(false);
+    expect(SmkEvaluator.metadata.defaultProviders).toEqual(['google']);
     expect(SmkEvaluator.metadata.supportedGrades).toEqual([
       '3', '4', '5', '6', '7', '8', '9', '10', '11', '12',
     ]);
@@ -89,6 +90,36 @@ describe('SmkEvaluator - Evaluation Flow', () => {
     expect(call[0].messages[1].content).toContain(testGrade);
     expect(call[0].schema).toBeDefined();
     expect(call[0].temperature).toBe(0);
+  });
+
+  it('should reflect modelOverride in metadata.model', async () => {
+    const overrideEvaluator = new SmkEvaluator({
+      anthropicApiKey: 'test-key',
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-haiku-4-5-20251001' },
+      telemetry: false,
+    });
+    // @ts-expect-error Accessing private property for testing
+    const overrideProvider: LLMProvider = overrideEvaluator.provider;
+
+    vi.mocked(overrideProvider.generateStructured).mockResolvedValue({
+      data: {
+        identified_topics: ['biology'],
+        curriculum_check: 'Standard.',
+        assumptions_and_scaffolding: 'None.',
+        friction_analysis: 'Low.',
+        complexity_score: 'Slightly complex',
+        reasoning: 'Simple text.',
+      },
+      model: 'claude-haiku-4-5-20251001',
+      usage: { inputTokens: 150, outputTokens: 50 },
+      latencyMs: 400,
+    });
+
+    const result = await overrideEvaluator.evaluate(
+      'The mitochondria is the powerhouse of the cell.', '5'
+    );
+
+    expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
 
   it('should propagate LLM API errors', async () => {

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -111,7 +111,7 @@ describe('TextComplexityEvaluator', () => {
         score: 'Moderately complex',
         reasoning: 'Vocabulary test reasoning',
         metadata: {
-          model: 'gemini-2.5-pro + gpt-4o',
+          model: 'gemini-2.5-pro+gpt-4o',
           processingTimeMs: 100,
         },
         _internal: {},

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -11,7 +11,8 @@ vi.mock('../../../src/telemetry/client.js', () => ({
 
 // Mock providers to avoid real API calls
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => ({
+  createProvider: vi.fn((config) => ({
+    label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
     generateStructured: vi.fn().mockResolvedValue({
       data: {
         complexity_score: 'moderately complex',
@@ -34,8 +35,7 @@ describe('TextComplexityEvaluator', () => {
     it('should have correct metadata', () => {
       expect(TextComplexityEvaluator.metadata.id).toBe('text-complexity');
       expect(TextComplexityEvaluator.metadata.name).toBe('Text Complexity');
-      expect(TextComplexityEvaluator.metadata.requiresGoogleKey).toBe(true);
-      expect(TextComplexityEvaluator.metadata.requiresOpenAIKey).toBe(true);
+      expect(TextComplexityEvaluator.metadata.defaultProviders).toEqual(['google', 'openai']);
       expect(TextComplexityEvaluator.metadata.supportedGrades).toEqual([
         '3', '4', '5', '6', '7', '8', '9', '10', '11', '12',
       ]);

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -152,7 +152,8 @@ describe('ModelOverride', () => {
         new Error("The model 'gpt-fake' does not exist"),
         { statusCode: 404 }
       );
-      vi.mocked((evaluator as any).provider.generateStructured).mockRejectedValueOnce(notFoundError);
+      // @ts-expect-error accessing private field for test
+      vi.mocked(evaluator.provider.generateStructured).mockRejectedValueOnce(notFoundError);
 
       await expect(
         evaluator.evaluate('This is a sample text long enough to pass validation.', '5')

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
-import { VALIDATION_LIMITS } from '../../../src/evaluators/base.js';
+import { SmkEvaluator } from '../../../src/evaluators/smk.js';
+import { VALIDATION_LIMITS, Provider } from '../../../src/evaluators/base.js';
 import { ConfigurationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
+import { createProvider } from '../../../src/providers/index.js';
 
 /**
  * Comprehensive validation tests for input validation
@@ -14,14 +16,15 @@ import type { LLMProvider } from '../../../src/providers/base.js';
  */
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 // Mock the createProvider factory
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 // Mock telemetry to avoid real HTTP calls
@@ -46,6 +49,54 @@ describe('Configuration Validation', () => {
       googleApiKey: 'test-google-key',
       openaiApiKey: '',
     })).toThrow(ConfigurationError);
+  });
+});
+
+describe('ModelOverride', () => {
+  it('should bypass default key validation when modelOverride is provided with the matching key', () => {
+    // No googleApiKey or openaiApiKey — normally would throw for VocabularyEvaluator
+    expect(() => new VocabularyEvaluator({
+      anthropicApiKey: 'test-key',
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-sonnet-4-6' },
+    })).not.toThrow();
+  });
+
+  it('should throw ConfigurationError when the override provider key is missing', () => {
+    // modelOverride requests Anthropic but no anthropicApiKey provided
+    expect(() => new VocabularyEvaluator({
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-sonnet-4-6' },
+    })).toThrow(ConfigurationError);
+  });
+
+  it('should pass override params to createProvider', () => {
+    vi.mocked(createProvider).mockClear();
+
+    new SmkEvaluator({
+      anthropicApiKey: 'test-key',
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-haiku-4-5-20251001' },
+      telemetry: false,
+    });
+
+    expect(vi.mocked(createProvider)).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'anthropic', model: 'claude-haiku-4-5-20251001' })
+    );
+  });
+
+  it('should not call createProvider with default provider params when override is set', () => {
+    vi.mocked(createProvider).mockClear();
+
+    new SmkEvaluator({
+      openaiApiKey: 'test-key',
+      modelOverride: { provider: Provider.OpenAI, model: 'gpt-4o-mini' },
+      telemetry: false,
+    });
+
+    expect(vi.mocked(createProvider)).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'openai', model: 'gpt-4o-mini' })
+    );
+    expect(vi.mocked(createProvider)).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google' })
+    );
   });
 });
 

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -98,6 +98,67 @@ describe('ModelOverride', () => {
       expect.objectContaining({ type: 'google' })
     );
   });
+
+  describe('modelOverride shape validation', () => {
+    it('should throw ConfigurationError when model is an empty string', () => {
+      expect(() => new SmkEvaluator({
+        openaiApiKey: 'test-key',
+        modelOverride: { provider: Provider.OpenAI, model: '' },
+        telemetry: false,
+      })).toThrow(ConfigurationError);
+    });
+
+    it('should throw ConfigurationError when model is whitespace only', () => {
+      expect(() => new SmkEvaluator({
+        openaiApiKey: 'test-key',
+        modelOverride: { provider: Provider.OpenAI, model: '   ' },
+        telemetry: false,
+      })).toThrow(ConfigurationError);
+    });
+
+    it('should throw ConfigurationError when provider is not a valid Provider value', () => {
+      expect(() => new SmkEvaluator({
+        openaiApiKey: 'test-key',
+        // @ts-expect-error intentional invalid provider for runtime test
+        modelOverride: { provider: 'unsupported-provider', model: 'some-model' },
+        telemetry: false,
+      })).toThrow(ConfigurationError);
+    });
+
+    it('error message should list valid providers when provider is invalid', () => {
+      expect(() => new SmkEvaluator({
+        openaiApiKey: 'test-key',
+        // @ts-expect-error intentional invalid provider for runtime test
+        modelOverride: { provider: 'unsupported-provider', model: 'some-model' },
+        telemetry: false,
+      })).toThrow(/openai.*google.*anthropic|anthropic.*openai.*google/i);
+    });
+
+  });
+
+  describe('model-not-found runtime error', () => {
+    it('should throw ConfigurationError when provider returns a 404 for the model', async () => {
+      vi.mocked(createProvider).mockReturnValueOnce(
+        createMockProvider({ type: 'openai', model: 'gpt-fake' })
+      );
+
+      const evaluator = new SmkEvaluator({
+        openaiApiKey: 'test-key',
+        modelOverride: { provider: Provider.OpenAI, model: 'gpt-fake' },
+        telemetry: false,
+      });
+
+      const notFoundError = Object.assign(
+        new Error("The model 'gpt-fake' does not exist"),
+        { statusCode: 404 }
+      );
+      vi.mocked((evaluator as any).provider.generateStructured).mockRejectedValueOnce(notFoundError);
+
+      await expect(
+        evaluator.evaluate('This is a sample text long enough to pass validation.', '5')
+      ).rejects.toThrow(ConfigurationError);
+    });
+  });
 });
 
 describe('Input Validation - Text Validation', () => {

--- a/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
+import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
 /**
@@ -15,14 +16,15 @@ import type { LLMProvider } from '../../../src/providers/base.js';
  */
 
 // Mock providers
-const createMockProvider = (): LLMProvider => ({
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
   generateStructured: vi.fn(),
   generateText: vi.fn(),
 });
 
 // Mock the createProvider factory
 vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => createMockProvider()),
+  createProvider: vi.fn((config) => createMockProvider(config)),
 }));
 
 // Mock telemetry to avoid real HTTP calls
@@ -214,6 +216,35 @@ describe('VocabularyEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20 + openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0); // Mocked calls can be instant (0ms)
+    });
+
+    it('should reflect modelOverride in metadata.model for both stages', async () => {
+      const overrideEvaluator = new VocabularyEvaluator({
+        openaiApiKey: 'test-key',
+        modelOverride: { provider: Provider.OpenAI, model: 'gpt-4o-mini' },
+        telemetry: false,
+      });
+      // @ts-expect-error Accessing private property for testing
+      const bgProvider: LLMProvider = overrideEvaluator.backgroundKnowledgeProvider;
+      // @ts-expect-error Accessing private property for testing
+      const complexityProvider: LLMProvider = overrideEvaluator.otherGradesComplexityProvider;
+
+      vi.mocked(bgProvider.generateText).mockResolvedValue({
+        text: 'Background knowledge',
+        usage: { inputTokens: 100, outputTokens: 50 },
+        latencyMs: 300,
+      });
+      vi.mocked(complexityProvider.generateStructured).mockResolvedValue({
+        data: { complexity_score: 'Slightly complex', reasoning: 'Simple.', factors: [] },
+        model: 'gpt-4o-mini',
+        usage: { inputTokens: 200, outputTokens: 80 },
+        latencyMs: 400,
+      });
+
+      const result = await overrideEvaluator.evaluate('Test text here', '5');
+
+      // All providers resolve to the same model under override — label is a single entry
+      expect(result.metadata.model).toBe('openai:gpt-4o-mini');
     });
 
     it('should include internal data', async () => {

--- a/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
@@ -117,7 +117,7 @@ describe('VocabularyEvaluator - Evaluation Flow', () => {
       expect(result.score).toBe('Moderately complex');
       expect(result.reasoning).toContain('grade-appropriate vocabulary');
       expect(result.metadata).toBeDefined();
-      expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20 + openai:gpt-4.1-2025-04-14');
+      expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThan(0);
 
       // Verify both providers were called
@@ -214,7 +214,7 @@ describe('VocabularyEvaluator - Evaluation Flow', () => {
       expect(result.metadata).toHaveProperty('processingTimeMs');
 
       // Verify metadata values
-      expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20 + openai:gpt-4.1-2025-04-14');
+      expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0); // Mocked calls can be instant (0ms)
     });
 


### PR DESCRIPTION
## Summary

- Adds `modelOverride: { provider, model }` to `BaseEvaluatorConfig`, letting callers swap the LLM provider and model for any evaluator without touching evaluation logic
- Adds Anthropic as a supported provider (`Provider.Anthropic`, `anthropicApiKey`)
- When `modelOverride` is set, only the API key for the override provider is required; default key validation is bypassed
- Refactors provider label tracking: `LLMProvider` interface now has a `readonly label` property computed at construction time, eliminating the per-evaluator `modelLabel` field and `getModelLabel` helper
- Telemetry: `model_override: boolean` flag when override is active; `provider` field reflects actual model used in all evaluators including `TextComplexityEvaluator`

## Test plan

- [x] Instantiate any evaluator with `modelOverride` set — confirm only the override provider's key is required, default keys are not
- [x] Check `result.metadata.model` reflects the override provider and model (e.g. `"anthropic:claude-sonnet-4-6"`)
- [x] Instantiate with `modelOverride` and a missing override key — confirm `ConfigurationError` is thrown
- [x] Run with telemetry enabled and override active — confirm `model_override: true` appears in the event and `provider` reflects the override model