### PR TITLE
chore: add dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/sdks/typescript"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore: "
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore: "
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated dependency updates
- Covers the TypeScript SDK (`/sdks/typescript`) and GitHub Actions workflows
- Minor and patch updates are grouped to reduce PR noise; majors get individual PRs for manual review

## Configuration

| Ecosystem | Directory | Schedule |
|---|---|---|
| npm | `/sdks/typescript` | Weekly, Monday 10am PT |
| github-actions | `/` | Weekly, Monday 10am PT |

## Test plan
- [ ] Confirm Dependabot is active under **Insights → Dependency graph → Dependabot** after merge