### PR TITLE
feat(ts-sdk): expose per-call token usage on EvaluationMetadata

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -70,6 +70,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: VocabularyInternal; // Detailed analysis
 }
@@ -110,6 +112,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: {
     sentenceAnalysis: SentenceAnalysis;
@@ -154,6 +158,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: {
     identified_topics: string[];
@@ -218,6 +224,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: {
     conventionality_features: string[];
@@ -346,6 +354,8 @@ await evaluator.evaluate(text: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: {
     grade: string;
@@ -391,6 +401,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
+    inputTokens: number;   // Total prompt tokens across all stages
+    outputTokens: number;  // Total completion tokens across all stages
   };
   _internal: {
     complexity_score: 'slightly_complex' | 'moderately_complex' | 'very_complex' | 'exceedingly_complex' | 'more_context_needed';

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -70,8 +70,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: VocabularyInternal; // Detailed analysis
 }
@@ -112,8 +112,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: {
     sentenceAnalysis: SentenceAnalysis;
@@ -158,8 +158,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: {
     identified_topics: string[];
@@ -224,8 +224,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: {
     conventionality_features: string[];
@@ -354,8 +354,8 @@ await evaluator.evaluate(text: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: {
     grade: string;
@@ -401,8 +401,8 @@ await evaluator.evaluate(text: string, grade: string)
   metadata: {
     model: string;
     processingTimeMs: number;
-    inputTokens: number;   // Total prompt tokens across all stages
-    outputTokens: number;  // Total completion tokens across all stages
+    inputTokens: number;
+    outputTokens: number;
   };
   _internal: {
     complexity_score: 'slightly_complex' | 'moderately_complex' | 'very_complex' | 'exceedingly_complex' | 'more_context_needed';

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -110,6 +110,8 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
+          inputTokens: totalTokenUsage.input_tokens,
+          outputTokens: totalTokenUsage.output_tokens,
         },
         _internal: response.data,
       };

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -104,6 +104,8 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
+          inputTokens: tokenUsage.input_tokens,
+          outputTokens: tokenUsage.output_tokens,
         },
         _internal: response.data,
       };

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -110,6 +110,8 @@ export class PurposeEvaluator extends BaseEvaluator {
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
+          inputTokens: tokenUsage.input_tokens,
+          outputTokens: tokenUsage.output_tokens,
         },
         _internal: response.data,
       };

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -162,6 +162,8 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
+          inputTokens: totalTokenUsage.input_tokens,
+          outputTokens: totalTokenUsage.output_tokens,
         },
         _internal: {
           sentenceAnalysis: analysisResponse.data,

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -110,6 +110,8 @@ export class SmkEvaluator extends BaseEvaluator {
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
+          inputTokens: totalTokenUsage.input_tokens,
+          outputTokens: totalTokenUsage.output_tokens,
         },
         _internal: response.data,
       };

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -163,6 +163,8 @@ export class VocabularyEvaluator extends BaseEvaluator {
         metadata: {
           model: modelLabel,
           processingTimeMs: latencyMs,
+          inputTokens: totalTokenUsage.input_tokens,
+          outputTokens: totalTokenUsage.output_tokens,
         },
         _internal: complexityResponse.data,
       };

--- a/sdks/typescript/src/schemas/outputs.ts
+++ b/sdks/typescript/src/schemas/outputs.ts
@@ -19,6 +19,8 @@ export type TextComplexityLevel = z.infer<typeof TextComplexityLevel>;
 export interface EvaluationMetadata {
   model: string;
   processingTimeMs: number;
+  inputTokens: number;
+  outputTokens: number;
 }
 
 /**

--- a/sdks/typescript/tests/unit/evaluators/conventionality.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/conventionality.test.ts
@@ -84,6 +84,8 @@ describe('ConventionalityEvaluator - Evaluation Flow', () => {
     expect(result.reasoning).toContain('irony');
     expect(result.metadata.model).toBe('google:gemini-3-flash-preview');
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.metadata.inputTokens).toBe(250);
+    expect(result.metadata.outputTokens).toBe(120);
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0];

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -99,6 +99,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('google:gemini-2.5-pro');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+      expect(result.metadata.inputTokens).toBe(200);
+      expect(result.metadata.outputTokens).toBe(150);
 
       // Verify provider was called
       expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
@@ -172,6 +174,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('google:gemini-2.5-pro');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+      expect(result.metadata.inputTokens).toBe(200);
+      expect(result.metadata.outputTokens).toBe(150);
 
       // Verify _internal values
       expect(result._internal!.grade).toBe('9-10');

--- a/sdks/typescript/tests/unit/evaluators/purpose.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose.test.ts
@@ -192,6 +192,8 @@ describe('PurposeEvaluator - LLM call contract', () => {
     expect(result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
     expect(result.metadata.model).toBe(`${STEP.model.provider}:${STEP.model.name}`);
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.metadata.inputTokens).toBe(200);
+    expect(result.metadata.outputTokens).toBe(120);
     expect(result._internal).toEqual(MOCK_RESPONSE.data);
     expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
     expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -139,6 +139,9 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('openai:gpt-4o');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+      // Token usage is aggregated across both stages: stage 1 (150/100) + stage 2 (250/80)
+      expect(result.metadata.inputTokens).toBe(400);
+      expect(result.metadata.outputTokens).toBe(180);
 
       // Verify provider was called twice (once per stage)
       expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
@@ -227,6 +230,8 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('openai:gpt-4o');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+      expect(result.metadata.inputTokens).toBe(400);
+      expect(result.metadata.outputTokens).toBe(180);
     });
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/smk.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/smk.test.ts
@@ -83,6 +83,8 @@ describe('SmkEvaluator - Evaluation Flow', () => {
     expect(result.reasoning).toContain('hydraulic systems');
     expect(result.metadata.model).toBe('google:gemini-3-flash-preview');
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.metadata.inputTokens).toBe(200);
+    expect(result.metadata.outputTokens).toBe(100);
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0];

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -113,6 +113,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'gemini-2.5-pro+gpt-4o',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -123,6 +125,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'gpt-4o',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -133,6 +137,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -143,6 +149,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -294,6 +302,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'gpt-4o',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -305,6 +315,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -316,6 +328,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -361,6 +375,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'gpt-4o',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -371,6 +387,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });
@@ -381,6 +399,8 @@ describe('TextComplexityEvaluator', () => {
         metadata: {
           model: 'google:gemini-3-flash-preview',
           processingTimeMs: 100,
+          inputTokens: 100,
+          outputTokens: 50,
         },
         _internal: {},
       });

--- a/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary.test.ts
@@ -119,6 +119,9 @@ describe('VocabularyEvaluator - Evaluation Flow', () => {
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThan(0);
+      // Token usage is aggregated across both stages: background (100/50) + complexity (200/100)
+      expect(result.metadata.inputTokens).toBe(300);
+      expect(result.metadata.outputTokens).toBe(150);
 
       // Verify both providers were called
       expect(mockBackgroundProvider.generateText).toHaveBeenCalledTimes(1);
@@ -216,6 +219,8 @@ describe('VocabularyEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0); // Mocked calls can be instant (0ms)
+      expect(result.metadata.inputTokens).toBe(300);
+      expect(result.metadata.outputTokens).toBe(150);
     });
 
     it('should reflect modelOverride in metadata.model for both stages', async () => {


### PR DESCRIPTION
## Summary
- Adds `inputTokens` and `outputTokens` to `EvaluationMetadata`
- Multi-stage evaluators report the sum across stages
- Fields are required: the provider contract guarantees usage data on every successful call

## Why
Lets callers compute per-evaluation cost and compare models under `modelOverride` without parsing provider logs.

## Test plan
- [x] CI passes
- [x] Live-API run: `result.metadata.inputTokens` / `outputTokens` are non-zero
- [x] Multi-stage evaluator totals match sum of per-stage usage