### PR TITLE
feat(ts-sdk): add bypassRowLimit option for batch evaluator

### DIFF
--- a/sdks/typescript/src/batch/README.md
+++ b/sdks/typescript/src/batch/README.md
@@ -61,7 +61,7 @@ Any additional columns beyond `text` and `grade` are preserved as-is in the outp
 
 The batch evaluator runs a fixed group of evaluators together. The current available group is:
 
-- **text-complexity**: Runs grade-level appropriateness, subject matter knowledge, vocabulary complexity, sentence structure, conventionality, and purpose evaluators together (requires both Google and OpenAI API keys). Maximum 50 input rows. If you exceed the limit, the CLI will exit with an error and suggest splitting into smaller batches.
+- **text-complexity**: Runs grade-level appropriateness, subject matter knowledge, vocabulary complexity, sentence structure, conventionality, and purpose evaluators together (requires both Google and OpenAI API keys). Maximum 50 input rows. If you exceed the limit, the CLI will exit with an error and suggest splitting into smaller batches. The limit can be bypassed with `--bypass-row-limit` — see [CLI Flags](#cli-flags) below.
 
 ### Output Files
 
@@ -103,6 +103,19 @@ evaluators-batch --concurrency 5 --max-retries 3 --no-telemetry
 | `--concurrency <n>` | `3` | Number of evaluations to run in parallel |
 | `--max-retries <n>` | `2` | Number of times to retry a failed evaluation |
 | `--no-telemetry` | telemetry on | Disable telemetry reporting |
+| `--bypass-row-limit` | off | Skip the per-group input row limit (50). Use with caution: longer runs increase the risk of provider throttling. |
+
+#### When to bypass the row limit
+
+The 50-row default keeps runs short and reduces the risk of provider throttling on the underlying Google and OpenAI calls. If you understand those risks and want to process a larger CSV in one run, pass `--bypass-row-limit` on the CLI or `bypassRowLimit: true` when constructing a `BatchEvaluator` programmatically:
+
+```ts
+const evaluator = new BatchEvaluator({
+  googleApiKey,
+  openaiApiKey,
+  bypassRowLimit: true,
+});
+```
 
 ### API Keys
 

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -13,9 +13,16 @@ import {
 } from './index.js';
 import { ProgressTracker } from './progress.js';
 
-function parseArgs(): { concurrency?: number; maxRetries?: number; noTelemetry?: boolean } {
+interface CliArgs {
+  concurrency?: number;
+  maxRetries?: number;
+  noTelemetry?: boolean;
+  bypassRowLimit?: boolean;
+}
+
+function parseArgs(): CliArgs {
   const args = process.argv.slice(2);
-  const result: { concurrency?: number; maxRetries?: number; noTelemetry?: boolean } = {};
+  const result: CliArgs = {};
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--concurrency' && args[i + 1]) {
@@ -26,6 +33,8 @@ function parseArgs(): { concurrency?: number; maxRetries?: number; noTelemetry?:
       if (!isNaN(v) && v >= 0) result.maxRetries = v;
     } else if (args[i] === '--no-telemetry') {
       result.noTelemetry = true;
+    } else if (args[i] === '--bypass-row-limit') {
+      result.bypassRowLimit = true;
     }
   }
 
@@ -67,16 +76,21 @@ async function main() {
     // (Only one group currently; when more are added this becomes a selection prompt)
     const group = getAvailableGroups()[0];
     console.log(`✓ Evaluator group: ${group.name}`);
-    console.log(`  ${group.description}`);
-    console.log(`  Row limit: ${group.maxInputRows}\n`);
+    console.log(`  ${group.description}\n`);
 
-    // Enforce row limit before asking for API keys
+    // Enforce row limit before asking for API keys (unless bypass is opted in)
     if (inputs.length > group.maxInputRows) {
-      console.error(`❌ Too many rows: ${inputs.length} (max ${group.maxInputRows} for this group)\n`);
-      console.log('Suggestions:');
-      console.log(`  • Trim the CSV to ${group.maxInputRows} rows`);
-      console.log('  • Split into multiple smaller batches\n');
-      process.exit(1);
+      if (cliArgs.bypassRowLimit) {
+        console.warn(`⚠️  Row limit bypassed: ${inputs.length} rows (default max ${group.maxInputRows}).`);
+        console.warn(`   Expect longer runtime and possible provider throttling.\n`);
+      } else {
+        console.error(`❌ Too many rows: ${inputs.length} (max ${group.maxInputRows} for this group)\n`);
+        console.log('Suggestions:');
+        console.log(`  • Trim the CSV to ${group.maxInputRows} rows`);
+        console.log('  • Split into multiple smaller batches');
+        console.log('  • Re-run with --bypass-row-limit to skip this check (use with caution)\n');
+        process.exit(1);
+      }
     }
 
     // Step 3: Get API keys required by this group
@@ -170,7 +184,7 @@ async function main() {
     const totalTasks = inputs.length * group.evaluatorIds.length;
 
     console.log(`\n📝 Summary:`);
-    console.log(`  Input rows: ${inputs.length}`);
+    console.log(`  Input rows: ${inputs.length}${cliArgs.bypassRowLimit ? ' (row limit bypassed)' : ''}`);
     console.log(`  Evaluators: ${group.evaluatorIds.length}`);
     console.log(`  Total tasks: ${totalTasks}`);
     console.log(`  Concurrency: ${cliArgs.concurrency ?? 3}`);
@@ -200,6 +214,7 @@ async function main() {
       concurrency: cliArgs.concurrency ?? 3,
       maxRetries: cliArgs.maxRetries ?? 2,
       telemetry: !cliArgs.noTelemetry,
+      bypassRowLimit: cliArgs.bypassRowLimit ?? false,
     });
 
     // Handle Ctrl+C gracefully

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -87,6 +87,7 @@ export class BatchEvaluator {
       concurrency: 3,
       maxRetries: 2,
       telemetry: false,
+      bypassRowLimit: false,
       ...config,
     };
 
@@ -280,10 +281,12 @@ export class BatchEvaluator {
       );
     }
 
-    // Enforce per-group row limit
-    if (inputs.length > group.maxInputRows) {
+    // Enforce per-group row limit (unless bypass is opted in)
+    // TODO(telemetry): record when bypassRowLimit is used
+    if (!this.config.bypassRowLimit && inputs.length > group.maxInputRows) {
       throw new Error(
-        `Input exceeds limit for "${group.id}": ${inputs.length} rows (max ${group.maxInputRows}). Split into smaller batches.`
+        `Input exceeds limit for "${group.id}": ${inputs.length} rows (max ${group.maxInputRows}). ` +
+          `Split into smaller batches, or pass { bypassRowLimit: true } in BatchConfig to bypass (use --bypass-row-limit on the CLI).`
       );
     }
 

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -83,4 +83,5 @@ export interface BatchConfig {
   concurrency?: number;
   maxRetries?: number;
   telemetry?: boolean | TelemetryOptions;
+  bypassRowLimit?: boolean;
 }

--- a/sdks/typescript/tests/unit/batch/limits.test.ts
+++ b/sdks/typescript/tests/unit/batch/limits.test.ts
@@ -73,6 +73,68 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
       .rejects.toThrow(`Input exceeds limit for "${group.id}"`);
   });
 
+  it('does not throw the limit error when input count equals maxInputRows', async () => {
+    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+    const atLimit = makeInputs(group.maxInputRows);
+    const boundary = new BatchEvaluator({
+      googleApiKey: 'fake-google-key',
+      openaiApiKey: 'fake-openai-key',
+    });
+    const makeStub = () => ({
+      evaluate: async () => ({ score: 1, reasoning: 'stub', metadata: {} }),
+    });
+    const instances = (boundary as unknown as { evaluatorInstances: Map<string, ReturnType<typeof makeStub>> }).evaluatorInstances;
+    for (const id of group.evaluatorIds) instances.set(id, makeStub());
+
+    await expect(boundary.evaluate(atLimit, group.id)).resolves.toBeDefined();
+  });
+
+  it('error message mentions the bypassRowLimit escape hatch', async () => {
+    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+    const tooMany = makeInputs(group.maxInputRows + 1);
+
+    await expect(evaluator.evaluate(tooMany, group.id))
+      .rejects.toThrow(/bypassRowLimit/);
+  });
+
+  it('explicitly setting bypassRowLimit: false still throws on overflow', async () => {
+    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+    const tooMany = makeInputs(group.maxInputRows + 1);
+    const strict = new BatchEvaluator({
+      googleApiKey: 'fake-google-key',
+      openaiApiKey: 'fake-openai-key',
+      bypassRowLimit: false,
+    });
+
+    await expect(strict.evaluate(tooMany, group.id))
+      .rejects.toThrow(`Input exceeds limit for "${group.id}"`);
+  });
+
+  it('bypassRowLimit: true skips the row limit check', async () => {
+    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+    const tooMany = makeInputs(group.maxInputRows + 1);
+    const bypassed = new BatchEvaluator({
+      googleApiKey: 'fake-google-key',
+      openaiApiKey: 'fake-openai-key',
+      bypassRowLimit: true,
+    });
+
+    // Pre-populate evaluatorInstances with no-op stubs. initializeEvaluators
+    // skips IDs already present in the map, so these stubs survive and
+    // executeTask runs against them — no real network calls, no race.
+    const makeStub = () => ({
+      evaluate: async () => ({ score: 1, reasoning: 'stub', metadata: {} }),
+    });
+    const instances = (bypassed as unknown as { evaluatorInstances: Map<string, ReturnType<typeof makeStub>> }).evaluatorInstances;
+    for (const id of group.evaluatorIds) instances.set(id, makeStub());
+
+    const output = await bypassed.evaluate(tooMany, group.id);
+    const expectedTasks = tooMany.length * group.evaluatorIds.length;
+    expect(output.summary.totalTasks).toBe(expectedTasks);
+    expect(output.summary.successful).toBe(expectedTasks);
+    expect(output.summary.failed).toBe(0);
+  });
+
   it('cancel() before evaluation starts returns an empty array', () => {
     const fresh = new BatchEvaluator({ googleApiKey: 'k', openaiApiKey: 'k' });
     expect(fresh.cancel()).toEqual([]);


### PR DESCRIPTION
## Summary
- Adds `bypassRowLimit` to `BatchConfig` and `--bypass-row-limit` CLI flag, letting users opt out of the per-group 50-row hard limit when they accept the longer-runtime / provider-throttling risk.
- Default behavior is unchanged — limit is still enforced unless the flag is explicitly set. Error message and CLI suggestion now point users at the escape hatch.
- Resolves #75

## Test plan
- [x] `npm run build` clean
- [x] `npm test` passes
- [x] `npm run lint` — 0 errors
- [x] Manual CLI smoke test with 51-row CSV: error path lists `--bypass-row-limit`; `--bypass-row-limit` shows warning and proceeds to key prompts
- [x] Programmatic verification covered by `bypassRowLimit: true skips the row limit check` unit test