### PR TITLE
ci(ts-sdk): switch publish workflow to npm trusted publishing

### DIFF
--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -21,8 +21,9 @@ jobs:
       - name: 😻 Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: 📥 Install dependencies
         uses: bahmutov/npm-install@v1
@@ -30,4 +31,4 @@ jobs:
           working-directory: sdks/typescript
 
       - name: 📦 Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -50,6 +50,10 @@
   ],
   "author": "Learning Commons",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/learning-commons-org/evaluators.git",
@@ -58,7 +62,7 @@
   "bugs": {
     "url": "https://github.com/learning-commons-org/evaluators/issues"
   },
-  "homepage": "https://github.com/learning-commons-org/evaluators#readme",
+  "homepage": "https://github.com/learning-commons-org/evaluators/tree/main/sdks/typescript#readme",
   "peerDependencies": {
     "@ai-sdk/anthropic": ">=3.0.0",
     "@ai-sdk/google": ">=3.0.0",


### PR DESCRIPTION
## Summary

Replaces long-lived NPM_TOKEN auth with GitHub Actions OIDC. No more secret to manage; provenance attestations are generated automatically.

- drop NODE_AUTH_TOKEN/secret-based publish auth (OIDC replaces tokens)
- drop --provenance flag (automatic under trusted publishing)
- drop --access public flag (now set via publishConfig in package.json)
- bump node-version 22 -> 24 for npm >= 11.5.1
- add package-manager-cache: false (recommended for release builds)
- package.json: add publishConfig and fix homepage to point at SDK subdir

## Test
  - [x] Trusted publisher saved on npmjs.com for @learning-commons/evaluators
  - [x] Triggered publish workflow run authenticates via OIDC
  - [x] Test trigger (re-publish of 0.5.0): publish fails with 403 (version exists), confirming OIDC handshake succeeded
  - [x] First real release after merge: provenance badge appears on npm page