### PR TITLE
feat(python-sdk): add Grade Level Appropriateness evaluator

### DIFF
--- a/sdks/python/scripts/generate_settings.py
+++ b/sdks/python/scripts/generate_settings.py
@@ -327,19 +327,20 @@ def _snake_to_pascal(name: str) -> str:
 
 def _resolve_settings_class(evaluator_name: str) -> type[EvaluationSettings]:
     """Import ``<Pascal>EvaluationSettings`` from ``learning_commons_evaluators.schemas.<name>``."""
-    if not evaluator_name.isidentifier():
+    py_name = evaluator_name.replace("-", "_")
+    if not py_name.isidentifier():
         raise SystemExit(
-            f"Evaluator folder name {evaluator_name!r} is not a valid Python identifier; "
-            "rename the directory under sdks/settings/."
+            f"Evaluator folder name {evaluator_name!r} is not a valid Python identifier "
+            "(after converting hyphens to underscores); rename the directory under sdks/settings/."
         )
-    class_name = f"{_snake_to_pascal(evaluator_name)}EvaluationSettings"
-    module_name = f"{_LCE_PACKAGE}.schemas.{evaluator_name}"
+    class_name = f"{_snake_to_pascal(py_name)}EvaluationSettings"
+    module_name = f"{_LCE_PACKAGE}.schemas.{py_name}"
     try:
         mod = importlib.import_module(module_name)
     except ModuleNotFoundError as e:
         raise SystemExit(
             f"No Python module {module_name!r} for evaluator {evaluator_name!r} "
-            f"(expected class {class_name}). Add schemas/{evaluator_name}.py or align the folder name."
+            f"(expected class {class_name}). Add schemas/{py_name}.py or align the folder name."
         ) from e
     try:
         cls = getattr(mod, class_name)
@@ -375,7 +376,7 @@ def _discover_evaluators() -> list[_EvaluatorTarget]:
             continue
         name = child.name
         settings_cls = _resolve_settings_class(name)
-        output = _GENERATED_DIR / f"_generated_{name}_settings.py"
+        output = _GENERATED_DIR / f"_generated_{name.replace('-', '_')}_settings.py"
         out.append(
             _EvaluatorTarget(
                 name=name,

--- a/sdks/python/src/learning_commons_evaluators/__init__.py
+++ b/sdks/python/src/learning_commons_evaluators/__init__.py
@@ -35,6 +35,8 @@ from learning_commons_evaluators.errors import (
 from learning_commons_evaluators.evaluators import (
     BaseEvaluator,
     ConventionalityEvaluator,
+    GradeLevelAppropriatenessEvaluationInput,
+    GradeLevelAppropriatenessEvaluator,
     InputT,
     OutputT,
     VocabularyEvaluationInput,
@@ -60,6 +62,12 @@ from learning_commons_evaluators.schemas.config import EvaluationSettings, LLMPr
 from learning_commons_evaluators.schemas.conventionality import (
     ConventionalityEvaluationSettings,
     ConventionalityOutput,
+)
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAnswer,
+    GradeLevelAppropriatenessEvaluationSettings,
+    GradeLevelAppropriatenessOutput,
+    GradeLevelAppropriatenessResult,
 )
 
 # Schemas (core)
@@ -104,6 +112,12 @@ __all__ = [
     "ConventionalityEvaluationSettings",
     "ConventionalityEvaluator",
     "ConventionalityOutput",
+    "GradeLevelAnswer",
+    "GradeLevelAppropriatenessEvaluationInput",
+    "GradeLevelAppropriatenessEvaluationSettings",
+    "GradeLevelAppropriatenessEvaluator",
+    "GradeLevelAppropriatenessOutput",
+    "GradeLevelAppropriatenessResult",
     "EvaluationAnswer",
     "EvaluationExplanation",
     "EvaluationInput",

--- a/sdks/python/src/learning_commons_evaluators/evaluators/__init__.py
+++ b/sdks/python/src/learning_commons_evaluators/evaluators/__init__.py
@@ -11,6 +11,10 @@ from learning_commons_evaluators.evaluators.conventionality import (
     ConventionalityEvaluationInput,
     ConventionalityEvaluator,
 )
+from learning_commons_evaluators.evaluators.grade_level_appropriateness import (
+    GradeLevelAppropriatenessEvaluationInput,
+    GradeLevelAppropriatenessEvaluator,
+)
 from learning_commons_evaluators.evaluators.vocabulary import (
     VocabularyEvaluationInput,
     VocabularyEvaluator,
@@ -21,6 +25,8 @@ __all__ = [
     "BaseEvaluator",
     "ConventionalityEvaluationInput",
     "ConventionalityEvaluator",
+    "GradeLevelAppropriatenessEvaluationInput",
+    "GradeLevelAppropriatenessEvaluator",
     "InputT",
     "OutputT",
     "VocabularyEvaluationInput",

--- a/sdks/python/src/learning_commons_evaluators/evaluators/grade_level_appropriateness.py
+++ b/sdks/python/src/learning_commons_evaluators/evaluators/grade_level_appropriateness.py
@@ -1,0 +1,108 @@
+"""Grade Level Appropriateness evaluator: determines appropriate grade band for a text."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import Field
+
+from learning_commons_evaluators.evaluators.base import BaseEvaluator
+from learning_commons_evaluators.schemas.common_inputs import TextInputField
+from learning_commons_evaluators.schemas.evaluator import (
+    EvaluationExplanation,
+    EvaluationInput,
+)
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAnswer,
+    GradeLevelAppropriatenessEvaluationSettings,
+    GradeLevelAppropriatenessOutput,
+    GradeLevelAppropriatenessResult,
+)
+from learning_commons_evaluators.schemas.metadata import (
+    EvaluationMetadata,
+    EvaluatorMetadata,
+)
+from learning_commons_evaluators.settings._generated_grade_level_appropriateness_settings import (
+    CONFIG as _GLA_CONFIG,
+)
+
+_INPUT_SETTINGS = _GLA_CONFIG.evaluator_metadata.inputs
+
+
+class GradeLevelAppropriatenessEvaluationInput(EvaluationInput):
+    """Input for a grade level appropriateness evaluation.
+
+    Constraints (min/max text length) are sourced from
+    ``[[evaluator_metadata.inputs]]`` in evaluator settings and applied
+    automatically — callers supply raw values, not field objects.
+
+    Example::
+
+        inp = GradeLevelAppropriatenessEvaluationInput(text="The quick brown fox...")
+    """
+
+    _input_settings: ClassVar[dict] = _INPUT_SETTINGS
+
+    text: TextInputField = Field(description="The text to evaluate.")
+
+    def __init__(self, *, text: str, **kwargs):
+        super().__init__(text=text, **kwargs)
+
+
+class GradeLevelAppropriatenessEvaluator(
+    BaseEvaluator[
+        GradeLevelAppropriatenessEvaluationInput,
+        GradeLevelAppropriatenessResult,
+        GradeLevelAppropriatenessEvaluationSettings,
+    ]
+):
+    """Evaluates text to determine appropriate K-12 grade band for independent reading."""
+
+    metadata: EvaluatorMetadata = _GLA_CONFIG.evaluator_metadata
+    default_evaluation_settings: GradeLevelAppropriatenessEvaluationSettings = (
+        _GLA_CONFIG.evaluation_settings
+    )
+
+    async def evaluate_impl(
+        self,
+        input: GradeLevelAppropriatenessEvaluationInput,
+        evaluation_settings: GradeLevelAppropriatenessEvaluationSettings,
+        evaluation_metadata: EvaluationMetadata,
+    ) -> GradeLevelAppropriatenessResult:
+        """Run grade level appropriateness evaluation. Returns GradeLevelAppropriatenessResult."""
+        step_prompt_settings = evaluation_settings.prompt_settings_step_gla_evaluation
+
+        prompt_inputs = input.input_values()
+
+        parser = JsonOutputParser(pydantic_object=GradeLevelAppropriatenessOutput)
+        prompts = _GLA_CONFIG.prompts
+        template = ChatPromptTemplate.from_messages(
+            [
+                ("system", prompts["system_prompt"]),
+                ("human", prompts["human_prompt"]),
+            ]
+        ).partial(format_instructions=parser.get_format_instructions())
+
+        gla_output = await self.execute_prompt_chain_step(
+            step_name="gla_evaluation",
+            prompt_settings=step_prompt_settings,
+            evaluation_metadata=evaluation_metadata,
+            template=template,
+            chain_inputs=prompt_inputs,
+            parser_output_type=GradeLevelAppropriatenessOutput,
+        )
+
+        answer = GradeLevelAnswer.from_score(gla_output.grade)
+        return GradeLevelAppropriatenessResult(
+            answer=answer,
+            explanation=EvaluationExplanation(
+                summary=gla_output.reasoning,
+                details={
+                    "alternative_grade": gla_output.alternative_grade,
+                    "scaffolding_needed": gla_output.scaffolding_needed,
+                },
+            ),
+            metadata=evaluation_metadata,
+        )

--- a/sdks/python/src/learning_commons_evaluators/schemas/__init__.py
+++ b/sdks/python/src/learning_commons_evaluators/schemas/__init__.py
@@ -14,18 +14,18 @@ from learning_commons_evaluators.schemas.conventionality import (
     ConventionalityOutput,
 )
 from learning_commons_evaluators.schemas.errors import InputValidationError
-from learning_commons_evaluators.schemas.grade_level_appropriateness import (
-    GradeLevelAnswer,
-    GradeLevelAppropriatenessEvaluationSettings,
-    GradeLevelAppropriatenessOutput,
-    GradeLevelAppropriatenessResult,
-)
 from learning_commons_evaluators.schemas.evaluator import (
     EvaluationAnswer,
     EvaluationExplanation,
     EvaluationInput,
     EvaluationResult,
     InputField,
+)
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAnswer,
+    GradeLevelAppropriatenessEvaluationSettings,
+    GradeLevelAppropriatenessOutput,
+    GradeLevelAppropriatenessResult,
 )
 from learning_commons_evaluators.schemas.input_specs import (
     AnyInputSpec,

--- a/sdks/python/src/learning_commons_evaluators/schemas/__init__.py
+++ b/sdks/python/src/learning_commons_evaluators/schemas/__init__.py
@@ -14,6 +14,12 @@ from learning_commons_evaluators.schemas.conventionality import (
     ConventionalityOutput,
 )
 from learning_commons_evaluators.schemas.errors import InputValidationError
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAnswer,
+    GradeLevelAppropriatenessEvaluationSettings,
+    GradeLevelAppropriatenessOutput,
+    GradeLevelAppropriatenessResult,
+)
 from learning_commons_evaluators.schemas.evaluator import (
     EvaluationAnswer,
     EvaluationExplanation,
@@ -47,6 +53,10 @@ __all__ = [
     "AnyInputSpec",
     "ConventionalityEvaluationSettings",
     "ConventionalityOutput",
+    "GradeLevelAnswer",
+    "GradeLevelAppropriatenessEvaluationSettings",
+    "GradeLevelAppropriatenessOutput",
+    "GradeLevelAppropriatenessResult",
     "GradeInputSpec",
     "InputSpec",
     "TextInputSpec",

--- a/sdks/python/src/learning_commons_evaluators/schemas/grade_level_appropriateness.py
+++ b/sdks/python/src/learning_commons_evaluators/schemas/grade_level_appropriateness.py
@@ -1,0 +1,72 @@
+"""Grade Level Appropriateness schemas."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from learning_commons_evaluators.schemas.config import (
+    EvaluationSettings,
+    PromptSettings,
+)
+from learning_commons_evaluators.schemas.evaluator import (
+    EvaluationAnswer,
+    EvaluationResult,
+)
+
+GradeBandLiteral = Literal["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"]
+
+
+class GradeLevelAppropriatenessEvaluationSettings(EvaluationSettings):
+    """Settings for a grade level appropriateness evaluation."""
+
+    prompt_settings_step_gla_evaluation: PromptSettings
+
+
+class GradeLevelAppropriatenessOutput(BaseModel):
+    """Raw LLM output for grade level appropriateness evaluation."""
+
+    reasoning: str = Field(
+        description="Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis."
+    )
+    grade: GradeBandLiteral = Field(
+        description="The appropriate grade level for the text"
+    )
+    alternative_grade: GradeBandLiteral = Field(
+        description="An alternative grade level for the text"
+    )
+    scaffolding_needed: str = Field(
+        description="Scaffolding needed for the text to be appropriate for the alternative grade"
+    )
+
+
+class GradeLevelAnswer(Enum):
+    """Allowed grade level answers. Each member's value is an EvaluationAnswer."""
+
+    K1 = EvaluationAnswer(score="K-1", label="Grades K-1")
+    TWO_THREE = EvaluationAnswer(score="2-3", label="Grades 2-3")
+    FOUR_FIVE = EvaluationAnswer(score="4-5", label="Grades 4-5")
+    SIX_EIGHT = EvaluationAnswer(score="6-8", label="Grades 6-8")
+    NINE_TEN = EvaluationAnswer(score="9-10", label="Grades 9-10")
+    ELEVEN_CCR = EvaluationAnswer(score="11-CCR", label="Grades 11-CCR")
+
+    @property
+    def score(self) -> str:
+        return self.value.score
+
+    @property
+    def label(self) -> str:
+        return self.value.label
+
+    @classmethod
+    def from_score(cls, score: str) -> "GradeLevelAnswer":
+        for member in cls:
+            if member.value.score == score:
+                return member
+        raise ValueError(f"Unknown grade band: {score!r}")
+
+
+class GradeLevelAppropriatenessResult(EvaluationResult):
+    """Result of a grade level appropriateness evaluation: answer (enum), explanation, metadata."""
+
+    answer: GradeLevelAnswer  # type: ignore[assignment]  # Enum members hold EvaluationAnswer values

--- a/sdks/python/src/learning_commons_evaluators/schemas/grade_level_appropriateness.py
+++ b/sdks/python/src/learning_commons_evaluators/schemas/grade_level_appropriateness.py
@@ -29,9 +29,7 @@ class GradeLevelAppropriatenessOutput(BaseModel):
     reasoning: str = Field(
         description="Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis."
     )
-    grade: GradeBandLiteral = Field(
-        description="The appropriate grade level for the text"
-    )
+    grade: GradeBandLiteral = Field(description="The appropriate grade level for the text")
     alternative_grade: GradeBandLiteral = Field(
         description="An alternative grade level for the text"
     )

--- a/sdks/python/src/learning_commons_evaluators/settings/_generated_grade_level_appropriateness_settings.py
+++ b/sdks/python/src/learning_commons_evaluators/settings/_generated_grade_level_appropriateness_settings.py
@@ -1,0 +1,176 @@
+# !! AUTO-GENERATED — do not edit directly.
+# Source: sdks/settings/grade-level-appropriateness/settings.toml
+# Regenerate : python scripts/generate_settings.py
+# Staleness check: python scripts/generate_settings.py --check
+
+from __future__ import annotations
+
+from learning_commons_evaluators.schemas.config import LLMProvider, PromptSettings
+from learning_commons_evaluators.schemas.grade_level_appropriateness import GradeLevelAppropriatenessEvaluationSettings
+from learning_commons_evaluators.schemas.input_specs import TextInputSpec
+from learning_commons_evaluators.schemas.metadata import EvaluatorMaturity, EvaluatorMetadata
+from learning_commons_evaluators.settings.load_settings import EvaluatorSettingsResult
+
+# ── Evaluator metadata ────────────────────────────────────────────────────────
+
+_EVALUATOR_METADATA = EvaluatorMetadata(
+    id='grade-level-appropriateness',
+    version='0.1',
+    name='Grade Level Appropriateness',
+    description='Grade Level Appropriateness Evaluator',
+    maturity=EvaluatorMaturity.early_access,
+    inputs={'text': TextInputSpec(name='text', min_text_length=10, max_text_length=100000)},
+)
+
+# ── Prompt templates ──────────────────────────────────────────────────────────
+
+_PROMPTS: dict[str, str] = {
+    'system_prompt': """You are an expert in English literature education for K-12.
+Your job is to help evaluate the grade level appropriateness of a given text.
+
+You will be given a text and you should determine which grade level the text is appropriate for (grade levels include: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR)
+
+IMPORTANT: You should pay attention to the vocabulary used, topics of the text and readability of text.
+
+Please first reason out loud about the vocabulary complexity of the text and then provide an answer between grade level options: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR.
+
+""",
+    'human_prompt': """Use these steps to determine appropriate grade level for a text:
+1. Calculate word count and Flesch-Kincaid Grade Level of the text, and generate a grade band.
+Here are the bands guideline for word count
+
+2-3: 200-800 words
+4-5: 200-800 words
+6-8: 400-1000 words
+9-10: 500-1500 words
+11-CCR: 1501 words and more
+
+Here is the formula for Flesch-Kincaid Grade Level:
+Flesch-Kincaid Grade Level = 0.39 * (total words / total sentences) + 11.8 * (total syllables / total words) - 15.59
+
+
+2. Determine the qualitative complexity using this text complexity rubric:
+TEXT STRUCTURE
+
+Exceedingly Complex
+	•	Deep, intricate, often ambiguous connections between many ideas/processes/events
+	•	Organization is intricate or discipline-specific
+	•	Text features are essential for understanding
+	•	Graphics are intricate, extensive, and integral to meaning; may convey unique information
+
+Very Complex
+	•	Expanded ideas/processes/events with implicit or subtle connections
+	•	Organization may have multiple pathways or discipline-specific traits
+	•	Text features directly enhance understanding
+	•	Graphics support or are integral to understanding
+
+Moderately Complex
+	•	Some implicit/subtle connections between ideas/events
+	•	Organization is evident and generally sequential or chronological
+	•	Text features enhance understanding
+	•	Graphics are mostly supplementary
+
+Slightly Complex
+	•	Explicit and clear connections between ideas/events
+	•	Organization is chronological, sequential, or predictable
+	•	Text features help navigation but are not essential
+	•	Graphics are simple, not necessary, but may assist understanding
+
+⸺
+
+LANGUAGE FEATURES
+
+Exceedingly Complex
+	•	Dense, abstract, ironic, and/or figurative language
+	•	Complex, unfamiliar, archaic, subject-specific, or ambiguous vocabulary
+	•	Mainly complex sentences with multiple subordinate clauses and transitions
+
+Very Complex
+	•	Fairly complex; some abstract, ironic, and/or figurative language
+	•	Some unfamiliar, archaic, or overly academic vocabulary
+	•	Many complex sentences with subordinate phrases/clauses
+
+Moderately Complex
+	•	Mostly explicit language with some complex meaning
+	•	Mostly familiar and conversational vocabulary
+	•	Primarily simple and compound sentences, with some complex ones
+
+Slightly Complex
+	•	Explicit, literal, straightforward language
+	•	Contemporary, familiar, conversational vocabulary
+	•	Mainly simple sentences
+
+⸺
+
+PURPOSE
+
+Exceedingly Complex
+	•	Subtle, intricate, and difficult to determine
+	•	Includes many theoretical or abstract elements
+
+Very Complex
+	•	Implicit or subtle, fairly easy to infer
+	•	More theoretical or abstract than concrete
+
+Moderately Complex
+	•	Implied but easy to identify based on context or source
+
+Slightly Complex
+	•	Explicitly stated, clear, concrete, and narrowly focused
+
+⸺
+
+KNOWLEDGE DEMANDS
+
+Exceedingly Complex
+	•	Requires extensive discipline-specific or theoretical knowledge
+	•	Many references/allusions to other texts or ideas
+
+Very Complex
+	•	Requires moderate discipline-specific knowledge
+	•	Some references/allusions to other texts or ideas
+
+Moderately Complex
+	•	Requires common knowledge and some discipline-specific knowledge
+	•	Few references/allusions
+
+Slightly Complex
+	•	Requires everyday, practical knowledge
+	•	No references/allusions
+
+3. Background knowledge:
+At which grade level would student have enough background knowledge to understand the text?
+
+4. Use your judgement of the above three steps. First use the quantitative signal to get first signal of the appropriate grade level range, then use qualitative analysis to refine your decisions and consider if student at such grade will have enough background knowledge to arrive at a final grade level band. Also consider if the text can be for a lower grade with additional scaffolding.
+
+<begin of text to evaluate>
+<text>{text}</text>
+<end of text to evaluate>
+
+When providing your response, first think out loud of your reasoning and then provide your answer from one of the grade band options above. Your reasoning and answer needs to be in JSON format. Strictly follow the following format for your response.
+
+Your final answer should be in the "grade" property for the target grade band for the text aimed for independent reading.  If there is alternative appropriate grade students can read and comprehend with scaffold (eg. picture, graph, additional context, etc) or for read-aloud purposes for lower grade, provide it in the "alternative_grade" property and provide the types of scaffolding in the "scaffolding_needed" property.
+
+In your reasoning, provide numbered bullet points for each of the analyses in each of the 3 steps. At the end, give me the 4th bullet point called "synthesis" to summarize your analysis from the above 3 steps that help you arrive at the final decision.
+
+{format_instructions}
+""",
+}
+
+# ── Evaluation settings ───────────────────────────────────────────────────────
+
+_EVALUATION_SETTINGS = GradeLevelAppropriatenessEvaluationSettings(
+    prompt_settings_step_gla_evaluation=PromptSettings(
+        provider_type=LLMProvider.GOOGLE,
+        model='gemini-2.5-pro',
+        temperature=0.25,
+    ),
+)
+
+# ── Public config object (imported by evaluator modules) ──────────────────────
+
+CONFIG: EvaluatorSettingsResult[GradeLevelAppropriatenessEvaluationSettings] = EvaluatorSettingsResult(
+    evaluator_metadata=_EVALUATOR_METADATA,
+    evaluation_settings=_EVALUATION_SETTINGS,
+    prompts=_PROMPTS,
+)

--- a/sdks/python/src/learning_commons_evaluators/settings/grade-level-appropriateness/contracts.toml
+++ b/sdks/python/src/learning_commons_evaluators/settings/grade-level-appropriateness/contracts.toml
@@ -1,0 +1,193 @@
+# Contract tests for the Grade Level Appropriateness evaluator.
+#
+# This file captures the exact LLM interaction for known inputs so that
+# tests can verify the SDK sends the same request as the notebook and
+# produces the same result from the same response.
+#
+# HOW TO REGENERATE
+# -----------------
+# Run the notebook for the GLA evaluator from the repo root with GOOGLE_API_KEY
+# set. It loads prompts from the evaluator settings TOML (same as the SDK) and
+# prints a TOML block — paste into this file and run `make sync-settings` from
+# sdks/python/ to update the bundled copy.
+#
+# WHAT BELONGS HERE
+# -----------------
+# Only data that originates from external sources:
+#   - input:           what the caller provides to the evaluator
+#   - prompt_steps:    what the SDK sends to the LLM (fully formatted messages,
+#                      model, temperature) and the raw response the LLM returned
+#   - expected_result: the structured output the LLM returned (notebook format)
+#
+# Deterministic values computed by library code (e.g. format_instructions from
+# LangChain's JsonOutputParser) are NOT stored as standalone fields — they appear
+# inside the fully formatted prompts, where they are implicitly verified by the
+# prompt-request assertion in the contract test.
+
+[cases.trees]
+description = "Simple informational passage about trees (grade 4-5)"
+
+[cases.trees.input]
+text = '''Trees are important plants that grow in many parts of the world. They have roots that go deep into the ground to find water and nutrients. Their leaves use sunlight to make food through a process called photosynthesis. Trees provide homes for birds and animals. They also give us wood for building homes and making furniture. Some trees produce fruit that people and animals eat. Forests made of many trees help keep the air clean and fresh.'''
+
+[cases.trees.prompt_steps.main]
+model = "gemini-2.5-pro"
+temperature = 0.25
+system_prompt = '''You are an expert in English literature education for K-12.
+Your job is to help evaluate the grade level appropriateness of a given text.
+
+You will be given a text and you should determine which grade level the text is appropriate for (grade levels include: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR)
+
+IMPORTANT: You should pay attention to the vocabulary used, topics of the text and readability of text.
+
+Please first reason out loud about the vocabulary complexity of the text and then provide an answer between grade level options: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR.
+'''
+user_prompt = '''Use these steps to determine appropriate grade level for a text:
+1. Calculate word count and Flesch-Kincaid Grade Level of the text, and generate a grade band.
+Here are the bands guideline for word count
+
+2-3: 200-800 words
+4-5: 200-800 words
+6-8: 400-1000 words
+9-10: 500-1500 words
+11-CCR: 1501 words and more
+
+Here is the formula for Flesch-Kincaid Grade Level:
+Flesch-Kincaid Grade Level = 0.39 * (total words / total sentences) + 11.8 * (total syllables / total words) - 15.59
+
+
+2. Determine the qualitative complexity using this text complexity rubric:
+TEXT STRUCTURE
+
+Exceedingly Complex
+	•	Deep, intricate, often ambiguous connections between many ideas/processes/events
+	•	Organization is intricate or discipline-specific
+	•	Text features are essential for understanding
+	•	Graphics are intricate, extensive, and integral to meaning; may convey unique information
+
+Very Complex
+	•	Expanded ideas/processes/events with implicit or subtle connections
+	•	Organization may have multiple pathways or discipline-specific traits
+	•	Text features directly enhance understanding
+	•	Graphics support or are integral to understanding
+
+Moderately Complex
+	•	Some implicit/subtle connections between ideas/events
+	•	Organization is evident and generally sequential or chronological
+	•	Text features enhance understanding
+	•	Graphics are mostly supplementary
+
+Slightly Complex
+	•	Explicit and clear connections between ideas/events
+	•	Organization is chronological, sequential, or predictable
+	•	Text features help navigation but are not essential
+	•	Graphics are simple, not necessary, but may assist understanding
+
+⸺
+
+LANGUAGE FEATURES
+
+Exceedingly Complex
+	•	Dense, abstract, ironic, and/or figurative language
+	•	Complex, unfamiliar, archaic, subject-specific, or ambiguous vocabulary
+	•	Mainly complex sentences with multiple subordinate clauses and transitions
+
+Very Complex
+	•	Fairly complex; some abstract, ironic, and/or figurative language
+	•	Some unfamiliar, archaic, or overly academic vocabulary
+	•	Many complex sentences with subordinate phrases/clauses
+
+Moderately Complex
+	•	Mostly explicit language with some complex meaning
+	•	Mostly familiar and conversational vocabulary
+	•	Primarily simple and compound sentences, with some complex ones
+
+Slightly Complex
+	•	Explicit, literal, straightforward language
+	•	Contemporary, familiar, conversational vocabulary
+	•	Mainly simple sentences
+
+⸺
+
+PURPOSE
+
+Exceedingly Complex
+	•	Subtle, intricate, and difficult to determine
+	•	Includes many theoretical or abstract elements
+
+Very Complex
+	•	Implicit or subtle, fairly easy to infer
+	•	More theoretical or abstract than concrete
+
+Moderately Complex
+	•	Implied but easy to identify based on context or source
+
+Slightly Complex
+	•	Explicitly stated, clear, concrete, and narrowly focused
+
+⸺
+
+KNOWLEDGE DEMANDS
+
+Exceedingly Complex
+	•	Requires extensive discipline-specific or theoretical knowledge
+	•	Many references/allusions to other texts or ideas
+
+Very Complex
+	•	Requires moderate discipline-specific knowledge
+	•	Some references/allusions to other texts or ideas
+
+Moderately Complex
+	•	Requires common knowledge and some discipline-specific knowledge
+	•	Few references/allusions
+
+Slightly Complex
+	•	Requires everyday, practical knowledge
+	•	No references/allusions
+
+3. Background knowledge:
+At which grade level would student have enough background knowledge to understand the text?
+
+4. Use your judgement of the above three steps. First use the quantitative signal to get first signal of the appropriate grade level range, then use qualitative analysis to refine your decisions and consider if student at such grade will have enough background knowledge to arrive at a final grade level band. Also consider if the text can be for a lower grade with additional scaffolding.
+
+<begin of text to evaluate>
+<text>Trees are important plants that grow in many parts of the world. They have roots that go deep into the ground to find water and nutrients. Their leaves use sunlight to make food through a process called photosynthesis. Trees provide homes for birds and animals. They also give us wood for building homes and making furniture. Some trees produce fruit that people and animals eat. Forests made of many trees help keep the air clean and fresh.</text>
+<end of text to evaluate>
+
+When providing your response, first think out loud of your reasoning and then provide your answer from one of the grade band options above. Your reasoning and answer needs to be in JSON format. Strictly follow the following format for your response.
+
+Your final answer should be in the "grade" property for the target grade band for the text aimed for independent reading.  If there is alternative appropriate grade students can read and comprehend with scaffold (eg. picture, graph, additional context, etc) or for read-aloud purposes for lower grade, provide it in the "alternative_grade" property and provide the types of scaffolding in the "scaffolding_needed" property.
+
+In your reasoning, provide numbered bullet points for each of the analyses in each of the 3 steps. At the end, give me the 4th bullet point called "synthesis" to summarize your analysis from the above 3 steps that help you arrive at the final decision.
+
+STRICT OUTPUT FORMAT:
+- Return only the JSON value that conforms to the schema. Do not include any additional text, explanations, headings, or separators.
+- Do not wrap the JSON in Markdown or code fences (no ``` or ```json).
+- Do not prepend or append any text (e.g., do not write "Here is the JSON:").
+- The response must be a single top-level JSON value exactly as required by the schema (object/array/etc.), with no trailing commas or comments.
+
+The output should be formatted as a JSON instance that conforms to the JSON schema below.
+
+As an example, for the schema {"properties": {"foo": {"title": "Foo", "description": "a list of strings", "type": "array", "items": {"type": "string"}}}, "required": ["foo"]} the object {"foo": ["bar", "baz"]} is a well-formatted instance of the schema. The object {"properties": {"foo": ["bar", "baz"]}} is not well-formatted.
+
+Here is the output schema (shown in a code block for readability only — do not include any backticks or Markdown in your output):
+```
+{"description": "Raw LLM output for grade level appropriateness evaluation.", "properties": {"reasoning": {"description": "Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis.", "title": "Reasoning", "type": "string"}, "grade": {"description": "The appropriate grade level for the text", "enum": ["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"], "title": "Grade", "type": "string"}, "alternative_grade": {"description": "An alternative grade level for the text", "enum": ["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"], "title": "Alternative Grade", "type": "string"}, "scaffolding_needed": {"description": "Scaffolding needed for the text to be appropriate for the alternative grade", "title": "Scaffolding Needed", "type": "string"}}, "required": ["reasoning", "grade", "alternative_grade", "scaffolding_needed"]}
+```
+'''
+llm_response = '''
+{
+  "reasoning": "1. Quantitative analysis: The text has approximately 75 words across 7 sentences. Applying the FK formula: (75/7) ≈ 10.7 words per sentence; estimating syllables at ~105, (105/75) ≈ 1.4 syllables per word. FK = 0.39 * 10.7 + 11.8 * 1.4 - 15.59 = 4.17 + 16.52 - 15.59 ≈ 5.1. This suggests approximately grade 5. Word count (75 words) is below the 200-800 range for grades 4-5, pointing to a simpler text.\n2. Qualitative complexity: TEXT STRUCTURE - Slightly Complex: explicit, sequential sentences about tree characteristics with no implicit connections. LANGUAGE FEATURES - Slightly to Moderately Complex: mostly familiar, conversational vocabulary with one technical term ('photosynthesis'). Simple sentences predominate. PURPOSE - Slightly Complex: explicitly stated informational purpose. KNOWLEDGE DEMANDS - Slightly Complex: everyday knowledge about plants and nature, no references or allusions.\n3. Background knowledge: Students in grade 2 or above would have sufficient background knowledge about trees, plants, and basic nature concepts to understand this text. The term 'photosynthesis' may require grade 4+ science exposure.\n4. Synthesis: Quantitative analysis yields FK ≈ 5, but the short word count and simple sentence structure indicate a text well within the lower range of grades 4-5. Qualitatively, the text is explicit and largely simple. The single technical term 'photosynthesis' distinguishes it from K-1 or 2-3 texts. Grade 4-5 is appropriate for independent reading; grade 2-3 is achievable with scaffolding around the science vocabulary.",
+  "grade": "4-5",
+  "alternative_grade": "2-3",
+  "scaffolding_needed": "Pre-teach the term 'photosynthesis' with a simple diagram or analogy (e.g., leaves as tiny solar-powered kitchens) before students read independently."
+}'''
+
+[cases.trees.expected_result]
+grade = "4-5"
+alternative_grade = "2-3"
+scaffolding_needed = "Pre-teach the term 'photosynthesis' with a simple diagram or analogy (e.g., leaves as tiny solar-powered kitchens) before students read independently."
+reasoning = '''1. Quantitative analysis: The text has approximately 75 words across 7 sentences. Applying the FK formula: (75/7) ≈ 10.7 words per sentence; estimating syllables at ~105, (105/75) ≈ 1.4 syllables per word. FK = 0.39 * 10.7 + 11.8 * 1.4 - 15.59 = 4.17 + 16.52 - 15.59 ≈ 5.1. This suggests approximately grade 5. Word count (75 words) is below the 200-800 range for grades 4-5, pointing to a simpler text.
+2. Qualitative complexity: TEXT STRUCTURE - Slightly Complex: explicit, sequential sentences about tree characteristics with no implicit connections. LANGUAGE FEATURES - Slightly to Moderately Complex: mostly familiar, conversational vocabulary with one technical term ('photosynthesis'). Simple sentences predominate. PURPOSE - Slightly Complex: explicitly stated informational purpose. KNOWLEDGE DEMANDS - Slightly Complex: everyday knowledge about plants and nature, no references or allusions.
+3. Background knowledge: Students in grade 2 or above would have sufficient background knowledge about trees, plants, and basic nature concepts to understand this text. The term 'photosynthesis' may require grade 4+ science exposure.
+4. Synthesis: Quantitative analysis yields FK ≈ 5, but the short word count and simple sentence structure indicate a text well within the lower range of grades 4-5. Qualitatively, the text is explicit and largely simple. The single technical term 'photosynthesis' distinguishes it from K-1 or 2-3 texts. Grade 4-5 is appropriate for independent reading; grade 2-3 is achievable with scaffolding around the science vocabulary.'''

--- a/sdks/python/tests/contract_tests/grade_level_appropriateness.py
+++ b/sdks/python/tests/contract_tests/grade_level_appropriateness.py
@@ -1,0 +1,84 @@
+"""Grade Level Appropriateness-specific helpers for contract tests.
+
+Provides:
+  - Named case loaders (one function per test case in the TOML).
+  - ``gla_notebook_to_sdk_result``: converts the notebook-format expected result
+    (raw ``JsonOutputParser`` dict) to the expected ``GradeLevelAppropriatenessResult``
+    that the SDK should produce.
+"""
+
+from __future__ import annotations
+
+from learning_commons_evaluators.schemas.evaluator import EvaluationExplanation
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAnswer,
+    GradeLevelAppropriatenessResult,
+)
+from learning_commons_evaluators.schemas.metadata import (
+    EvaluationMetadata,
+    EvaluatorMaturity,
+    EvaluatorMetadata,
+    Status,
+)
+
+from .loader import ContractCase, load_contract_case
+
+# ---------------------------------------------------------------------------
+# Case loaders
+# ---------------------------------------------------------------------------
+
+
+def load_gla_trees_case() -> ContractCase:
+    """Load the 'trees' contract test case for the GLA evaluator."""
+    return load_contract_case("grade-level-appropriateness", "trees")
+
+
+# ---------------------------------------------------------------------------
+# Result mapper
+# ---------------------------------------------------------------------------
+
+
+def gla_notebook_to_sdk_result(case: ContractCase) -> GradeLevelAppropriatenessResult:
+    """Convert ``case.expected_result`` (notebook format) to a ``GradeLevelAppropriatenessResult``.
+
+    The notebook outputs a plain dict from ``JsonOutputParser``; the SDK wraps
+    that into ``GradeLevelAppropriatenessResult``.  This function performs the same
+    structural mapping the SDK does so tests can assert equality.
+
+    Only ``answer`` and ``explanation`` are compared — ``metadata`` is excluded
+    because it contains non-deterministic fields (timing, evaluation ID, etc.).
+
+    Args:
+        case: A loaded :class:`~loader.ContractCase` with a populated
+            ``expected_result``.
+
+    Returns:
+        A ``GradeLevelAppropriatenessResult`` built from the contract's expected output.
+        The ``metadata`` field is a minimal placeholder so the object is valid.
+    """
+    r = case.expected_result
+    answer = GradeLevelAnswer.from_score(r["grade"])
+    explanation = EvaluationExplanation(
+        summary=r["reasoning"],
+        details={
+            "alternative_grade": r["alternative_grade"],
+            "scaffolding_needed": r["scaffolding_needed"],
+        },
+    )
+    placeholder_metadata = EvaluationMetadata(
+        evaluator_metadata=EvaluatorMetadata(
+            id="grade-level-appropriateness",
+            version="0.1",
+            name="Grade Level Appropriateness",
+            description="Contract-test placeholder metadata (not compared).",
+            maturity=EvaluatorMaturity.early_access,
+        ),
+        evaluation_settings=None,
+        input_metadata={},
+        status=Status.succeeded,
+    )
+    return GradeLevelAppropriatenessResult(
+        answer=answer,
+        explanation=explanation,
+        metadata=placeholder_metadata,
+    )

--- a/sdks/python/tests/contract_tests/test_grade_level_appropriateness.py
+++ b/sdks/python/tests/contract_tests/test_grade_level_appropriateness.py
@@ -1,0 +1,78 @@
+"""Contract test: GradeLevelAppropriatenessEvaluator matches the notebook.
+
+This test verifies two things for each contract case:
+  1. The SDK sends the same LLM request as the notebook (same fully-formatted
+     system prompt, user prompt, model, and temperature).
+  2. Given the same LLM response, the SDK produces the same result as the
+     notebook.
+
+HOW TO ADD A NEW CASE
+---------------------
+1. Add a ``[cases.<name>]`` entry to
+   ``sdks/settings/grade-level-appropriateness/contracts.toml``.
+2. Add a loader function to ``contract_tests/grade_level_appropriateness.py``.
+3. Add a test function here following the pattern below.
+
+HOW TO REFRESH CONTRACT DATA
+-----------------------------
+Run the notebook for the GLA evaluator from the **repository root** with a
+valid ``GOOGLE_API_KEY``. The notebook loads prompts from the evaluator settings
+TOML (same as the SDK) and prints a TOML block. Paste it into
+``sdks/settings/grade-level-appropriateness/contracts.toml`` (the canonical
+copy), then run ``make sync-settings`` from ``sdks/python/`` to update the
+bundled copy.
+"""
+
+from learning_commons_evaluators import (
+    GradeLevelAppropriatenessEvaluationInput,
+    GradeLevelAppropriatenessEvaluator,
+    create_config_no_telemetry,
+)
+from learning_commons_evaluators.schemas.metadata import Status
+
+from .grade_level_appropriateness import (
+    gla_notebook_to_sdk_result,
+    load_gla_trees_case,
+)
+from .harness import ContractTestHarness
+
+
+class TestGradeLevelAppropriatenessContract:
+    def test_trees_passage(self) -> None:
+        """Simple trees informational passage.
+
+        Verifies:
+        - The fully-formatted system and user prompts match the notebook.
+        - The model and temperature match the notebook.
+        - Given the notebook's LLM response, the SDK returns the same
+          answer and explanation as the notebook.
+        """
+        case = load_gla_trees_case()
+
+        config = create_config_no_telemetry()
+        evaluator = GradeLevelAppropriatenessEvaluator(config)
+        inp = GradeLevelAppropriatenessEvaluationInput(
+            text=case.input["text"],
+        )
+
+        with ContractTestHarness(case) as harness:
+            result = evaluator.evaluate_sync(inp)
+
+        # --- Prompt fidelity ---
+        harness.assert_prompt_step("main")
+
+        # --- Result fidelity ---
+        expected = gla_notebook_to_sdk_result(case)
+        assert result.metadata.status == Status.succeeded
+        assert result.answer.score == expected.answer.score, (
+            f"answer.score: SDK={result.answer.score!r}, notebook={expected.answer.score!r}"
+        )
+        assert result.answer.label == expected.answer.label, (
+            f"answer.label: SDK={result.answer.label!r}, notebook={expected.answer.label!r}"
+        )
+        assert result.explanation.summary == expected.explanation.summary, (
+            "explanation.summary (reasoning) differs between SDK and notebook"
+        )
+        assert result.explanation.details == expected.explanation.details, (
+            "explanation.details differs between SDK and notebook"
+        )

--- a/sdks/python/tests/evaluators/test_grade_level_appropriateness.py
+++ b/sdks/python/tests/evaluators/test_grade_level_appropriateness.py
@@ -1,0 +1,132 @@
+"""Tests for GradeLevelAppropriatenessEvaluator and related helpers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from learning_commons_evaluators import (
+    GradeLevelAppropriatenessEvaluationInput,
+    GradeLevelAppropriatenessEvaluator,
+    create_config_no_telemetry,
+)
+from learning_commons_evaluators.schemas.errors import ConfigurationError
+from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+    GradeLevelAppropriatenessOutput,
+)
+from learning_commons_evaluators.schemas.metadata import Status
+
+# Long sample text (well above ``min_text_length`` from GLA settings TOML).
+_SAMPLE_TEXT = (
+    "Marco Polo was a Venetian merchant and explorer who traveled through Asia "
+    "in the late 13th century. He spent nearly two decades at the court of "
+    "Kublai Khan, the Mongol ruler of China, and described his experiences in "
+    "a book that introduced Europeans to the Far East."
+)
+
+
+def _make_mock_output():
+    return GradeLevelAppropriatenessOutput(
+        reasoning=(
+            "1. Word count: ~50 words; FK Grade Level: ~8. Grade band signal: 6-8.\n"
+            "2. Qualitative: moderately complex structure, some unfamiliar vocabulary.\n"
+            "3. Background knowledge: students in grade 6+ would have sufficient context.\n"
+            "4. Synthesis: text is appropriate for grades 6-8 for independent reading."
+        ),
+        grade="6-8",
+        alternative_grade="4-5",
+        scaffolding_needed="Pre-reading vocabulary support and brief historical context.",
+    )
+
+
+class TestGradeLevelAppropriatenessEvaluator:
+    def test_evaluate_returns_evaluation_result(self):
+        config = create_config_no_telemetry()
+        evaluator = GradeLevelAppropriatenessEvaluator(config)
+        inp = GradeLevelAppropriatenessEvaluationInput(text=_SAMPLE_TEXT)
+        with patch.object(evaluator, "execute_prompt_chain_step", return_value=_make_mock_output()):
+            result = evaluator.evaluate_sync(inp)
+        assert result.answer.score == "6-8"
+        assert result.answer.label == "Grades 6-8"
+        assert result.explanation.summary is not None
+        assert result.explanation.details["alternative_grade"] == "4-5"
+        assert result.explanation.details["scaffolding_needed"] is not None
+        assert result.metadata.status == Status.succeeded
+        assert result.metadata.evaluator_metadata.id == "grade-level-appropriateness"
+
+    def test_evaluate_with_explicit_settings(self):
+        from learning_commons_evaluators.schemas.config import (
+            LLMProvider,
+            PromptSettings,
+        )
+        from learning_commons_evaluators.schemas.grade_level_appropriateness import (
+            GradeLevelAppropriatenessEvaluationSettings,
+        )
+
+        config = create_config_no_telemetry()
+        evaluator = GradeLevelAppropriatenessEvaluator(config)
+        settings = GradeLevelAppropriatenessEvaluationSettings(
+            prompt_settings_step_gla_evaluation=PromptSettings(
+                provider_type=LLMProvider.GOOGLE,
+                model="gemini-2.0-flash",
+                temperature=0.0,
+            )
+        )
+        inp = GradeLevelAppropriatenessEvaluationInput(text=_SAMPLE_TEXT)
+        with patch.object(evaluator, "execute_prompt_chain_step", return_value=_make_mock_output()):
+            result = evaluator.evaluate_sync(inp, evaluation_settings=settings)
+        assert result.metadata.status == Status.succeeded
+
+    def test_metadata_and_default_settings(self):
+        evaluator = GradeLevelAppropriatenessEvaluator(create_config_no_telemetry())
+        assert evaluator.metadata.id == "grade-level-appropriateness"
+        assert evaluator.metadata.version == "0.1"
+        assert evaluator.default_evaluation_settings is not None
+
+
+class TestGradeLevelAppropriatenessEvaluationInputConfiguration:
+    """Tests that GradeLevelAppropriatenessEvaluationInput fails loudly on bad configuration.
+
+    These tests patch ``GradeLevelAppropriatenessEvaluationInput._input_settings`` directly
+    because the ClassVar is bound at class-definition time.  Patching the
+    module-level ``_INPUT_SETTINGS`` name would rebind the module variable but
+    leave the class variable pointing at the original dict.
+    """
+
+    def test_missing_text_spec_raises_configuration_error(self, monkeypatch):
+        """If 'text' is absent from _input_settings, ConfigurationError is raised immediately."""
+        monkeypatch.setattr(GradeLevelAppropriatenessEvaluationInput, "_input_settings", {})
+        with pytest.raises(ConfigurationError, match="'text'"):
+            GradeLevelAppropriatenessEvaluationInput(text=_SAMPLE_TEXT)
+
+    def test_wrong_text_spec_type_raises_configuration_error(self, monkeypatch):
+        """If the 'text' spec has the wrong type, ConfigurationError names the type mismatch."""
+        from learning_commons_evaluators.schemas.input_specs import GradeInputSpec
+
+        monkeypatch.setattr(
+            GradeLevelAppropriatenessEvaluationInput,
+            "_input_settings",
+            {"text": GradeInputSpec(name="text")},
+        )
+        with pytest.raises(ConfigurationError, match="TextInputSpec"):
+            GradeLevelAppropriatenessEvaluationInput(text=_SAMPLE_TEXT)
+
+
+class TestGradeLevelAppropriatenessOutput:
+    def test_output_grade_literal(self):
+        out = GradeLevelAppropriatenessOutput(
+            reasoning="Test reasoning.",
+            grade="4-5",
+            alternative_grade="2-3",
+            scaffolding_needed="Vocabulary preview.",
+        )
+        assert out.grade == "4-5"
+        assert out.alternative_grade == "2-3"
+        assert out.reasoning == "Test reasoning."
+
+    def test_all_grade_bands_valid(self):
+        from learning_commons_evaluators.schemas.grade_level_appropriateness import GradeLevelAnswer
+
+        bands = ["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"]
+        for band in bands:
+            answer = GradeLevelAnswer.from_score(band)
+            assert answer.score == band

--- a/sdks/settings/grade-level-appropriateness/contracts.toml
+++ b/sdks/settings/grade-level-appropriateness/contracts.toml
@@ -1,0 +1,193 @@
+# Contract tests for the Grade Level Appropriateness evaluator.
+#
+# This file captures the exact LLM interaction for known inputs so that
+# tests can verify the SDK sends the same request as the notebook and
+# produces the same result from the same response.
+#
+# HOW TO REGENERATE
+# -----------------
+# Run the notebook for the GLA evaluator from the repo root with GOOGLE_API_KEY
+# set. It loads prompts from the evaluator settings TOML (same as the SDK) and
+# prints a TOML block — paste into this file and run `make sync-settings` from
+# sdks/python/ to update the bundled copy.
+#
+# WHAT BELONGS HERE
+# -----------------
+# Only data that originates from external sources:
+#   - input:           what the caller provides to the evaluator
+#   - prompt_steps:    what the SDK sends to the LLM (fully formatted messages,
+#                      model, temperature) and the raw response the LLM returned
+#   - expected_result: the structured output the LLM returned (notebook format)
+#
+# Deterministic values computed by library code (e.g. format_instructions from
+# LangChain's JsonOutputParser) are NOT stored as standalone fields — they appear
+# inside the fully formatted prompts, where they are implicitly verified by the
+# prompt-request assertion in the contract test.
+
+[cases.trees]
+description = "Simple informational passage about trees (grade 4-5)"
+
+[cases.trees.input]
+text = '''Trees are important plants that grow in many parts of the world. They have roots that go deep into the ground to find water and nutrients. Their leaves use sunlight to make food through a process called photosynthesis. Trees provide homes for birds and animals. They also give us wood for building homes and making furniture. Some trees produce fruit that people and animals eat. Forests made of many trees help keep the air clean and fresh.'''
+
+[cases.trees.prompt_steps.main]
+model = "gemini-2.5-pro"
+temperature = 0.25
+system_prompt = '''You are an expert in English literature education for K-12.
+Your job is to help evaluate the grade level appropriateness of a given text.
+
+You will be given a text and you should determine which grade level the text is appropriate for (grade levels include: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR)
+
+IMPORTANT: You should pay attention to the vocabulary used, topics of the text and readability of text.
+
+Please first reason out loud about the vocabulary complexity of the text and then provide an answer between grade level options: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR.
+'''
+user_prompt = '''Use these steps to determine appropriate grade level for a text:
+1. Calculate word count and Flesch-Kincaid Grade Level of the text, and generate a grade band.
+Here are the bands guideline for word count
+
+2-3: 200-800 words
+4-5: 200-800 words
+6-8: 400-1000 words
+9-10: 500-1500 words
+11-CCR: 1501 words and more
+
+Here is the formula for Flesch-Kincaid Grade Level:
+Flesch-Kincaid Grade Level = 0.39 * (total words / total sentences) + 11.8 * (total syllables / total words) - 15.59
+
+
+2. Determine the qualitative complexity using this text complexity rubric:
+TEXT STRUCTURE
+
+Exceedingly Complex
+	•	Deep, intricate, often ambiguous connections between many ideas/processes/events
+	•	Organization is intricate or discipline-specific
+	•	Text features are essential for understanding
+	•	Graphics are intricate, extensive, and integral to meaning; may convey unique information
+
+Very Complex
+	•	Expanded ideas/processes/events with implicit or subtle connections
+	•	Organization may have multiple pathways or discipline-specific traits
+	•	Text features directly enhance understanding
+	•	Graphics support or are integral to understanding
+
+Moderately Complex
+	•	Some implicit/subtle connections between ideas/events
+	•	Organization is evident and generally sequential or chronological
+	•	Text features enhance understanding
+	•	Graphics are mostly supplementary
+
+Slightly Complex
+	•	Explicit and clear connections between ideas/events
+	•	Organization is chronological, sequential, or predictable
+	•	Text features help navigation but are not essential
+	•	Graphics are simple, not necessary, but may assist understanding
+
+⸺
+
+LANGUAGE FEATURES
+
+Exceedingly Complex
+	•	Dense, abstract, ironic, and/or figurative language
+	•	Complex, unfamiliar, archaic, subject-specific, or ambiguous vocabulary
+	•	Mainly complex sentences with multiple subordinate clauses and transitions
+
+Very Complex
+	•	Fairly complex; some abstract, ironic, and/or figurative language
+	•	Some unfamiliar, archaic, or overly academic vocabulary
+	•	Many complex sentences with subordinate phrases/clauses
+
+Moderately Complex
+	•	Mostly explicit language with some complex meaning
+	•	Mostly familiar and conversational vocabulary
+	•	Primarily simple and compound sentences, with some complex ones
+
+Slightly Complex
+	•	Explicit, literal, straightforward language
+	•	Contemporary, familiar, conversational vocabulary
+	•	Mainly simple sentences
+
+⸺
+
+PURPOSE
+
+Exceedingly Complex
+	•	Subtle, intricate, and difficult to determine
+	•	Includes many theoretical or abstract elements
+
+Very Complex
+	•	Implicit or subtle, fairly easy to infer
+	•	More theoretical or abstract than concrete
+
+Moderately Complex
+	•	Implied but easy to identify based on context or source
+
+Slightly Complex
+	•	Explicitly stated, clear, concrete, and narrowly focused
+
+⸺
+
+KNOWLEDGE DEMANDS
+
+Exceedingly Complex
+	•	Requires extensive discipline-specific or theoretical knowledge
+	•	Many references/allusions to other texts or ideas
+
+Very Complex
+	•	Requires moderate discipline-specific knowledge
+	•	Some references/allusions to other texts or ideas
+
+Moderately Complex
+	•	Requires common knowledge and some discipline-specific knowledge
+	•	Few references/allusions
+
+Slightly Complex
+	•	Requires everyday, practical knowledge
+	•	No references/allusions
+
+3. Background knowledge:
+At which grade level would student have enough background knowledge to understand the text?
+
+4. Use your judgement of the above three steps. First use the quantitative signal to get first signal of the appropriate grade level range, then use qualitative analysis to refine your decisions and consider if student at such grade will have enough background knowledge to arrive at a final grade level band. Also consider if the text can be for a lower grade with additional scaffolding.
+
+<begin of text to evaluate>
+<text>Trees are important plants that grow in many parts of the world. They have roots that go deep into the ground to find water and nutrients. Their leaves use sunlight to make food through a process called photosynthesis. Trees provide homes for birds and animals. They also give us wood for building homes and making furniture. Some trees produce fruit that people and animals eat. Forests made of many trees help keep the air clean and fresh.</text>
+<end of text to evaluate>
+
+When providing your response, first think out loud of your reasoning and then provide your answer from one of the grade band options above. Your reasoning and answer needs to be in JSON format. Strictly follow the following format for your response.
+
+Your final answer should be in the "grade" property for the target grade band for the text aimed for independent reading.  If there is alternative appropriate grade students can read and comprehend with scaffold (eg. picture, graph, additional context, etc) or for read-aloud purposes for lower grade, provide it in the "alternative_grade" property and provide the types of scaffolding in the "scaffolding_needed" property.
+
+In your reasoning, provide numbered bullet points for each of the analyses in each of the 3 steps. At the end, give me the 4th bullet point called "synthesis" to summarize your analysis from the above 3 steps that help you arrive at the final decision.
+
+STRICT OUTPUT FORMAT:
+- Return only the JSON value that conforms to the schema. Do not include any additional text, explanations, headings, or separators.
+- Do not wrap the JSON in Markdown or code fences (no ``` or ```json).
+- Do not prepend or append any text (e.g., do not write "Here is the JSON:").
+- The response must be a single top-level JSON value exactly as required by the schema (object/array/etc.), with no trailing commas or comments.
+
+The output should be formatted as a JSON instance that conforms to the JSON schema below.
+
+As an example, for the schema {"properties": {"foo": {"title": "Foo", "description": "a list of strings", "type": "array", "items": {"type": "string"}}}, "required": ["foo"]} the object {"foo": ["bar", "baz"]} is a well-formatted instance of the schema. The object {"properties": {"foo": ["bar", "baz"]}} is not well-formatted.
+
+Here is the output schema (shown in a code block for readability only — do not include any backticks or Markdown in your output):
+```
+{"description": "Raw LLM output for grade level appropriateness evaluation.", "properties": {"reasoning": {"description": "Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis.", "title": "Reasoning", "type": "string"}, "grade": {"description": "The appropriate grade level for the text", "enum": ["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"], "title": "Grade", "type": "string"}, "alternative_grade": {"description": "An alternative grade level for the text", "enum": ["K-1", "2-3", "4-5", "6-8", "9-10", "11-CCR"], "title": "Alternative Grade", "type": "string"}, "scaffolding_needed": {"description": "Scaffolding needed for the text to be appropriate for the alternative grade", "title": "Scaffolding Needed", "type": "string"}}, "required": ["reasoning", "grade", "alternative_grade", "scaffolding_needed"]}
+```
+'''
+llm_response = '''
+{
+  "reasoning": "1. Quantitative analysis: The text has approximately 75 words across 7 sentences. Applying the FK formula: (75/7) ≈ 10.7 words per sentence; estimating syllables at ~105, (105/75) ≈ 1.4 syllables per word. FK = 0.39 * 10.7 + 11.8 * 1.4 - 15.59 = 4.17 + 16.52 - 15.59 ≈ 5.1. This suggests approximately grade 5. Word count (75 words) is below the 200-800 range for grades 4-5, pointing to a simpler text.\n2. Qualitative complexity: TEXT STRUCTURE - Slightly Complex: explicit, sequential sentences about tree characteristics with no implicit connections. LANGUAGE FEATURES - Slightly to Moderately Complex: mostly familiar, conversational vocabulary with one technical term ('photosynthesis'). Simple sentences predominate. PURPOSE - Slightly Complex: explicitly stated informational purpose. KNOWLEDGE DEMANDS - Slightly Complex: everyday knowledge about plants and nature, no references or allusions.\n3. Background knowledge: Students in grade 2 or above would have sufficient background knowledge about trees, plants, and basic nature concepts to understand this text. The term 'photosynthesis' may require grade 4+ science exposure.\n4. Synthesis: Quantitative analysis yields FK ≈ 5, but the short word count and simple sentence structure indicate a text well within the lower range of grades 4-5. Qualitatively, the text is explicit and largely simple. The single technical term 'photosynthesis' distinguishes it from K-1 or 2-3 texts. Grade 4-5 is appropriate for independent reading; grade 2-3 is achievable with scaffolding around the science vocabulary.",
+  "grade": "4-5",
+  "alternative_grade": "2-3",
+  "scaffolding_needed": "Pre-teach the term 'photosynthesis' with a simple diagram or analogy (e.g., leaves as tiny solar-powered kitchens) before students read independently."
+}'''
+
+[cases.trees.expected_result]
+grade = "4-5"
+alternative_grade = "2-3"
+scaffolding_needed = "Pre-teach the term 'photosynthesis' with a simple diagram or analogy (e.g., leaves as tiny solar-powered kitchens) before students read independently."
+reasoning = '''1. Quantitative analysis: The text has approximately 75 words across 7 sentences. Applying the FK formula: (75/7) ≈ 10.7 words per sentence; estimating syllables at ~105, (105/75) ≈ 1.4 syllables per word. FK = 0.39 * 10.7 + 11.8 * 1.4 - 15.59 = 4.17 + 16.52 - 15.59 ≈ 5.1. This suggests approximately grade 5. Word count (75 words) is below the 200-800 range for grades 4-5, pointing to a simpler text.
+2. Qualitative complexity: TEXT STRUCTURE - Slightly Complex: explicit, sequential sentences about tree characteristics with no implicit connections. LANGUAGE FEATURES - Slightly to Moderately Complex: mostly familiar, conversational vocabulary with one technical term ('photosynthesis'). Simple sentences predominate. PURPOSE - Slightly Complex: explicitly stated informational purpose. KNOWLEDGE DEMANDS - Slightly Complex: everyday knowledge about plants and nature, no references or allusions.
+3. Background knowledge: Students in grade 2 or above would have sufficient background knowledge about trees, plants, and basic nature concepts to understand this text. The term 'photosynthesis' may require grade 4+ science exposure.
+4. Synthesis: Quantitative analysis yields FK ≈ 5, but the short word count and simple sentence structure indicate a text well within the lower range of grades 4-5. Qualitatively, the text is explicit and largely simple. The single technical term 'photosynthesis' distinguishes it from K-1 or 2-3 texts. Grade 4-5 is appropriate for independent reading; grade 2-3 is achievable with scaffolding around the science vocabulary.'''

--- a/sdks/settings/grade-level-appropriateness/settings.toml
+++ b/sdks/settings/grade-level-appropriateness/settings.toml
@@ -1,0 +1,152 @@
+[evaluator_metadata]
+id = "grade-level-appropriateness"
+version = "0.1"
+name = "Grade Level Appropriateness"
+description = "Grade Level Appropriateness Evaluator"
+maturity = "early_access"
+
+[[evaluator_metadata.inputs]]
+name = "text"
+type = "TextInputField"
+min_text_length = 10
+max_text_length = 100000
+
+[prompts]
+system_prompt = """
+You are an expert in English literature education for K-12.
+Your job is to help evaluate the grade level appropriateness of a given text.
+
+You will be given a text and you should determine which grade level the text is appropriate for (grade levels include: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR)
+
+IMPORTANT: You should pay attention to the vocabulary used, topics of the text and readability of text.
+
+Please first reason out loud about the vocabulary complexity of the text and then provide an answer between grade level options: K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR.
+
+"""
+
+human_prompt = """
+Use these steps to determine appropriate grade level for a text:
+1. Calculate word count and Flesch-Kincaid Grade Level of the text, and generate a grade band.
+Here are the bands guideline for word count
+
+2-3: 200-800 words
+4-5: 200-800 words
+6-8: 400-1000 words
+9-10: 500-1500 words
+11-CCR: 1501 words and more
+
+Here is the formula for Flesch-Kincaid Grade Level:
+Flesch-Kincaid Grade Level = 0.39 * (total words / total sentences) + 11.8 * (total syllables / total words) - 15.59
+
+
+2. Determine the qualitative complexity using this text complexity rubric:
+TEXT STRUCTURE
+
+Exceedingly Complex
+	•	Deep, intricate, often ambiguous connections between many ideas/processes/events
+	•	Organization is intricate or discipline-specific
+	•	Text features are essential for understanding
+	•	Graphics are intricate, extensive, and integral to meaning; may convey unique information
+
+Very Complex
+	•	Expanded ideas/processes/events with implicit or subtle connections
+	•	Organization may have multiple pathways or discipline-specific traits
+	•	Text features directly enhance understanding
+	•	Graphics support or are integral to understanding
+
+Moderately Complex
+	•	Some implicit/subtle connections between ideas/events
+	•	Organization is evident and generally sequential or chronological
+	•	Text features enhance understanding
+	•	Graphics are mostly supplementary
+
+Slightly Complex
+	•	Explicit and clear connections between ideas/events
+	•	Organization is chronological, sequential, or predictable
+	•	Text features help navigation but are not essential
+	•	Graphics are simple, not necessary, but may assist understanding
+
+⸺
+
+LANGUAGE FEATURES
+
+Exceedingly Complex
+	•	Dense, abstract, ironic, and/or figurative language
+	•	Complex, unfamiliar, archaic, subject-specific, or ambiguous vocabulary
+	•	Mainly complex sentences with multiple subordinate clauses and transitions
+
+Very Complex
+	•	Fairly complex; some abstract, ironic, and/or figurative language
+	•	Some unfamiliar, archaic, or overly academic vocabulary
+	•	Many complex sentences with subordinate phrases/clauses
+
+Moderately Complex
+	•	Mostly explicit language with some complex meaning
+	•	Mostly familiar and conversational vocabulary
+	•	Primarily simple and compound sentences, with some complex ones
+
+Slightly Complex
+	•	Explicit, literal, straightforward language
+	•	Contemporary, familiar, conversational vocabulary
+	•	Mainly simple sentences
+
+⸺
+
+PURPOSE
+
+Exceedingly Complex
+	•	Subtle, intricate, and difficult to determine
+	•	Includes many theoretical or abstract elements
+
+Very Complex
+	•	Implicit or subtle, fairly easy to infer
+	•	More theoretical or abstract than concrete
+
+Moderately Complex
+	•	Implied but easy to identify based on context or source
+
+Slightly Complex
+	•	Explicitly stated, clear, concrete, and narrowly focused
+
+⸺
+
+KNOWLEDGE DEMANDS
+
+Exceedingly Complex
+	•	Requires extensive discipline-specific or theoretical knowledge
+	•	Many references/allusions to other texts or ideas
+
+Very Complex
+	•	Requires moderate discipline-specific knowledge
+	•	Some references/allusions to other texts or ideas
+
+Moderately Complex
+	•	Requires common knowledge and some discipline-specific knowledge
+	•	Few references/allusions
+
+Slightly Complex
+	•	Requires everyday, practical knowledge
+	•	No references/allusions
+
+3. Background knowledge:
+At which grade level would student have enough background knowledge to understand the text?
+
+4. Use your judgement of the above three steps. First use the quantitative signal to get first signal of the appropriate grade level range, then use qualitative analysis to refine your decisions and consider if student at such grade will have enough background knowledge to arrive at a final grade level band. Also consider if the text can be for a lower grade with additional scaffolding.
+
+<begin of text to evaluate>
+<text>{text}</text>
+<end of text to evaluate>
+
+When providing your response, first think out loud of your reasoning and then provide your answer from one of the grade band options above. Your reasoning and answer needs to be in JSON format. Strictly follow the following format for your response.
+
+Your final answer should be in the "grade" property for the target grade band for the text aimed for independent reading.  If there is alternative appropriate grade students can read and comprehend with scaffold (eg. picture, graph, additional context, etc) or for read-aloud purposes for lower grade, provide it in the "alternative_grade" property and provide the types of scaffolding in the "scaffolding_needed" property.
+
+In your reasoning, provide numbered bullet points for each of the analyses in each of the 3 steps. At the end, give me the 4th bullet point called "synthesis" to summarize your analysis from the above 3 steps that help you arrive at the final decision.
+
+{format_instructions}
+"""
+
+[evaluation_settings.prompt_settings_step_gla_evaluation]
+provider_type = "GOOGLE"
+model = "gemini-2.5-pro"
+temperature = 0.25


### PR DESCRIPTION
## Summary

- Adds `GradeLevelAppropriatenessEvaluator` to the Python SDK
- New types: `GradeLevelAppropriatenessOutput`, `GradeLevelAnswer` (grade band enum), `GradeLevelAppropriatenessResult`, `GradeLevelAppropriatenessEvaluationSettings`

## Test plan

- [x] 274/274 existing tests pass (no regressions)
- [x] 7 unit tests covering evaluator, input validation, output schema, and all 6 grade band enum members
- [x] 1 contract test verifying prompt fidelity (model, temperature, fully-formatted system + user prompts) and result parsing
- [x] `python scripts/generate_settings.py --check` exits clean