### PR TITLE
chore: remove release-as pin from Python SDK config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,7 +58,6 @@
             "release-type": "python",
             "changelog-path": "CHANGELOG.md",
             "component": "sdks-python",
-            "release-as": "0.1.0",
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true
         },


### PR DESCRIPTION
Removes the `release-as: "0.1.0"` pin from the Python SDK release-please config. This was a one-time override to force the initial release to `0.1.0`, but with that release shipped it now blocks all future version bumps.

After merge, release-please will recalculate the version from commits since `sdks-python-v0.1.0` and update the open release PR accordingly (expected: `0.2.0` due to the GLA evaluator feat commit).