### PR TITLE
fix: enforce strict semver for python SDK

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,8 +58,7 @@
             "release-type": "python",
             "changelog-path": "CHANGELOG.md",
             "component": "sdks-python",
-            "bump-minor-pre-major": true,
-            "bump-patch-for-minor-pre-major": true
+            "bump-minor-pre-major": true
         },
         "sdks/typescript": {
             "release-type": "node",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,8 +57,7 @@
         "sdks/python": {
             "release-type": "python",
             "changelog-path": "CHANGELOG.md",
-            "component": "sdks-python",
-            "bump-minor-pre-major": true
+            "component": "sdks-python"
         },
         "sdks/typescript": {
             "release-type": "node",


### PR DESCRIPTION
## Summary

- Removes both `bump-patch-for-minor-pre-major` and `bump-minor-pre-major` from the `sdks/python` config so the Python SDK follows strict semver
- `feat:` → minor bump (was incorrectly producing patch bumps, e.g. GLA evaluator in #92 produced `0.1.1` instead of `0.2.0`)
- `feat!:` / `BREAKING CHANGE` → major bump (intentional path to `1.0.0`)

## After merging

Release-please will regenerate PR #88 and should recalculate the Python SDK version as `0.2.0`.