### PR TITLE
docs(prompts): reorder evaluators and add Purpose section

### DIFF
--- a/evals/prompts/README.md
+++ b/evals/prompts/README.md
@@ -7,18 +7,22 @@ In this folder, you will find prompt files designed for evaluating text complexi
 
 In file `gla_prompts.py`, we provide system and user prompts used in the Grade Level Appropriateness evaluator's code. You can also use these prompts as a reference for creating your own prompts.
 
-### Sentence Structure Evaluator
+### Subject Matter Knowledge Evaluator
 
-In file `sent_str_prompts.py`, we provide system and user prompts used in the Sentence Structure evaluator's code. These prompts help assess the syntactic and structural complexity of sentences and can be adapted for your own evaluation needs.
+In file `smk_prompts.py`, we provide system and user prompts used in the Subject Matter Knowledge (SMK) Evaluator's code. These prompts can help assess the background knowledge demands of texts and serve as a starting point for your own prompt development.
 
 ### Vocabulary Evaluator
 
 In file `vocab_prompts.py`, we provide system and user prompts used in the Vocabulary Evaluator's code. These prompts can help assess the difficulty of vocabulary in texts and serve as a starting point for your own prompt development.
 
-### Subject Matter Knowledge Evaluator
+### Sentence Structure Evaluator
 
-In file `smk_prompts.py`, we provide system and user prompts used in the Subject Matter Knowledge (SMK) Evaluator's code. These prompts can help assess the background knowledge demands of texts and serve as a starting point for your own prompt development.
+In file `sent_str_prompts.py`, we provide system and user prompts used in the Sentence Structure evaluator's code. These prompts help assess the syntactic and structural complexity of sentences and can be adapted for your own evaluation needs.
 
 ### Conventionality Evaluator
 
 In file `conventionality_prompts.py`, we provide system and user prompts used in the Conventionality Evaluator's code. These prompts help assess how explicit, literal, and straightforward a text's meaning is — measuring the degree to which language is conventional versus abstract, figurative, or ironic — and serve as a starting point for your own prompt development.
+
+### Purpose Evaluator
+
+In the `purpose/` directory, we provide the system and user prompts (`system.txt` and `user.txt`) used in the Purpose Evaluator's code. These prompts help assess how difficult it is for a reader to identify the author's purpose — distinguishing a text's topic from why the author wrote it — and serve as a starting point for your own prompt development.


### PR DESCRIPTION
## Summary

Tidies up the `evals/prompts/README.md`:

- **Reorders** the evaluator sections to match the dimension order: Grade Level Appropriateness → Subject Matter Knowledge → Vocabulary → Sentence Structure → Conventionality → Purpose.
- **Adds a Purpose Evaluator section**, which was previously missing despite the `purpose/` prompts existing in the directory.

## Release note

Carries a `Release-As: 1.6.0` footer to force a release-please release of the `evals-prompts` package. This intentionally cuts `evals-prompts` `1.5.0 → 1.6.0` so the package version catches up with the evaluators added in #113 and #114, whose paths (`evals/literacy/`, `evals/feedback/`) fall outside the package's currently-watched `evals/prompts/` path and therefore didn't trigger a release on their own.

Only `evals-prompts` is affected; `sdks/python` and `sdks/typescript` are untouched.
