### PR TITLE
chore: add pre-commit hook and CONTRIBUTING for local check harness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@
 # (or `pip install pre-commit && pre-commit install`). CI runs the same
 # checks regardless, so `git commit --no-verify` is a safe bypass.
 #
-# Declaring the stages here means a single `pre-commit install` also covers
-# any commit-msg / pre-push hooks we add later — no reinstall needed.
+# Declaring the git hook types here means a single `pre-commit install` also
+# covers any commit-msg / pre-push hooks we add later — no reinstall needed.
 default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-# Local check hooks. Enable once per clone with `scripts/setup.sh`
-# (or `pip install pre-commit && pre-commit install`). CI runs the same
-# checks regardless, so `git commit --no-verify` is a safe bypass.
+# Local check hooks. Enable once per clone with `scripts/setup.sh` (it also
+# installs the harness deps so `scripts/check.py` can be run directly). CI runs
+# the same checks regardless, so `git commit --no-verify` is a safe bypass.
 #
 # Declaring the git hook types here means a single `pre-commit install` also
 # covers any commit-msg / pre-push hooks we add later — no reinstall needed.
@@ -12,7 +12,7 @@ repos:
       - id: repo-checks
         name: repo checks (scripts/check.py)
         # --fix auto-strips notebooks and reports anything else to fix by hand.
-        entry: python scripts/check.py --fix
+        entry: python3 scripts/check.py --fix
         language: python
         additional_dependencies: ["nbstripout==0.9.1", "jsonschema==4.23.0"]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Local check hooks. Enable once per clone with `scripts/setup.sh`
+# (or `pip install pre-commit && pre-commit install`). CI runs the same
+# checks regardless, so `git commit --no-verify` is a safe bypass.
+#
+# Declaring the stages here means a single `pre-commit install` also covers
+# any commit-msg / pre-push hooks we add later — no reinstall needed.
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
+
+repos:
+  - repo: local
+    hooks:
+      - id: repo-checks
+        name: repo checks (scripts/check.py)
+        # --fix auto-strips notebooks and reports anything else to fix by hand.
+        entry: python scripts/check.py --fix
+        language: python
+        additional_dependencies: ["nbstripout==0.9.1", "jsonschema==4.23.0"]
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,12 @@
 
 ## One-time setup (per clone)
 
-Enable the local check hooks:
+Enable the local check hooks (installs `pre-commit` + the harness deps and
+wires up the git hook):
 
 ```shell
 scripts/setup.sh
 ```
-
-(equivalently: `pip install pre-commit && pre-commit install`)
 
 ## Before committing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,6 @@
 # Contributing
 
-This repository is **public but not open to external contributions.** It's the
-published export of evaluators developed internally at Learning Commons, so we
-don't accept outside pull requests. For questions or feedback, please
-[open an issue](https://github.com/learning-commons-org/evaluators/issues) or
-reach us at [support@learningcommons.org](mailto:support@learningcommons.org).
-
-## For Learning Commons contributors
-
-### One-time setup (per clone)
+## One-time setup (per clone)
 
 Enable the local check hooks:
 
@@ -18,7 +10,7 @@ scripts/setup.sh
 
 (equivalently: `pip install pre-commit && pre-commit install`)
 
-### Before committing
+## Before committing
 
 The pre-commit hook runs `python scripts/check.py --fix` automatically — it
 strips notebook outputs and validates evaluator `config.json` / schemas /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+This repository is **public but not open to external contributions.** It's the
+published export of evaluators developed internally at Learning Commons, so we
+don't accept outside pull requests. For questions or feedback, please
+[open an issue](https://github.com/learning-commons-org/evaluators/issues) or
+reach us at [support@learningcommons.org](mailto:support@learningcommons.org).
+
+## For Learning Commons contributors
+
+### One-time setup (per clone)
+
+Enable the local check hooks:
+
+```shell
+scripts/setup.sh
+```
+
+(equivalently: `pip install pre-commit && pre-commit install`)
+
+### Before committing
+
+The pre-commit hook runs `python scripts/check.py --fix` automatically — it
+strips notebook outputs and validates evaluator `config.json` / schemas /
+fixtures against the shared contract. You can also run it by hand at any time:
+
+```shell
+python scripts/check.py --fix
+```
+
+If the hook ever gets in your way, `git commit --no-verify` bypasses it for one
+commit — CI runs the same checks on every PR, so nothing unsafe can slip
+through. See [`scripts/README.md`](./scripts/README.md) for the full check list
+and how to add one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,12 @@ scripts/setup.sh
 
 ## Before committing
 
-The pre-commit hook runs `python scripts/check.py --fix` automatically — it
+The pre-commit hook runs `python3 scripts/check.py --fix` automatically — it
 strips notebook outputs and validates evaluator `config.json` / schemas /
 fixtures against the shared contract. You can also run it by hand at any time:
 
 ```shell
-python scripts/check.py --fix
+python3 scripts/check.py --fix
 ```
 
 If the hook ever gets in your way, `git commit --no-verify` bypasses it for one

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Jupyter will open in your web browser (usually at `http://localhost:8888`).
 
 If you prefer using an IDE with Python and Jupyter notebook support, such as VSCode with Microsoft's Python and Jupyter extensions, please refer to Microsoft's instructions for their installation and configuration.
 
+## Contributing
+
+This repository is public but **not open to external contributions** — it's the published export of internally-developed evaluators. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Support & feedback
 
 We want to hear from you. For questions or feedback, please [open an issue](https://github.com/learning-commons-org/evaluators/issues) or reach out to us at [support@learningcommons.org](mailto:support@learningcommons.org)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Evaluators and the supporting datasets are built in collaboration with leading l
 | :------------------------ | :--------------------------------------------------------------- |
 | [`evals`](./evals/)       | Evaluators code and prompts                                      |
 | [`datasets`](./datasets/) | Expert annotated datasets used to create and validate evaluators |
-| [`scripts`](./scripts/)   | Repo check harness — run `python scripts/check.py --fix` before committing (see [scripts/README](./scripts/README.md)) |
+| [`scripts`](./scripts/)   | Repo check harness — run `python3 scripts/check.py --fix` before committing (see [scripts/README](./scripts/README.md)) |
 | [`LICENSE`](./LICENSE.md) | Open source license details                                      |
 
 Check out the [Evaluators docs](https://docs.learningcommons.org/evaluators) for complete setup instructions and usage examples.

--- a/README.md
+++ b/README.md
@@ -172,10 +172,6 @@ Jupyter will open in your web browser (usually at `http://localhost:8888`).
 
 If you prefer using an IDE with Python and Jupyter notebook support, such as VSCode with Microsoft's Python and Jupyter extensions, please refer to Microsoft's instructions for their installation and configuration.
 
-## Contributing
-
-This repository is public but **not open to external contributions** — it's the published export of internally-developed evaluators. See [CONTRIBUTING.md](./CONTRIBUTING.md).
-
 ## Support & feedback
 
 We want to hear from you. For questions or feedback, please [open an issue](https://github.com/learning-commons-org/evaluators/issues) or reach out to us at [support@learningcommons.org](mailto:support@learningcommons.org)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,10 +51,12 @@ This is the seed of a broader self-service harness. Planned additions:
 
 ## Running before every commit
 
-`scripts/setup.sh` (once per clone) installs a pre-commit hook that runs
-`python scripts/check.py --fix` on each commit. It's opt-in convenience —
-`git commit --no-verify` bypasses it and CI runs the same checks regardless.
-See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+`scripts/setup.sh` (once per clone) installs `pre-commit` + the harness deps and
+enables a hook that runs `python scripts/check.py --fix` on each commit (the hook
+runs in pre-commit's own pinned, isolated env). Because setup also installs the
+deps, you can run it directly too: `python scripts/check.py --fix`. It's opt-in
+convenience — `git commit --no-verify` bypasses it, and CI runs the same checks
+regardless. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ## Adding a check
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,13 +12,13 @@ pip install -r scripts/requirements.txt   # one-time; pinned tools the checks us
 ## Usage
 
 ```bash
-python scripts/check.py          # check everything (what CI runs)
-python scripts/check.py --fix    # auto-fix what's safe, report the rest
-python scripts/check.py --list   # list available checks
-python scripts/check.py strip-notebooks   # run a single check
+python3 scripts/check.py          # check everything (what CI runs)
+python3 scripts/check.py --fix    # auto-fix what's safe, report the rest
+python3 scripts/check.py --list   # list available checks
+python3 scripts/check.py strip-notebooks   # run a single check
 ```
 
-**Run `python scripts/check.py --fix` before you commit.** It catches issues
+**Run `python3 scripts/check.py --fix` before you commit.** It catches issues
 early with clear messages and fixes what it can. CI runs the same harness and
 fails the PR (it never auto-fixes) — so fixing locally saves a round-trip.
 
@@ -52,9 +52,9 @@ This is the seed of a broader self-service harness. Planned additions:
 ## Running before every commit
 
 `scripts/setup.sh` (once per clone) installs `pre-commit` + the harness deps and
-enables a hook that runs `python scripts/check.py --fix` on each commit (the hook
+enables a hook that runs `python3 scripts/check.py --fix` on each commit (the hook
 runs in pre-commit's own pinned, isolated env). Because setup also installs the
-deps, you can run it directly too: `python scripts/check.py --fix`. It's opt-in
+deps, you can run it directly too: `python3 scripts/check.py --fix`. It's opt-in
 convenience — `git commit --no-verify` bypasses it, and CI runs the same checks
 regardless. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,8 +49,12 @@ This is the seed of a broader self-service harness. Planned additions:
   `sdks/python` Makefile) so one local command covers everything. CI keeps the
   per-SDK workflows separate for parallelism and path-filtered signal.
 
-> **TODO**: the root `README.md` links here for discoverability; give this a
-> proper home in a `CONTRIBUTING.md` once one exists.
+## Running before every commit
+
+`scripts/setup.sh` (once per clone) installs a pre-commit hook that runs
+`python scripts/check.py --fix` on each commit. It's opt-in convenience —
+`git commit --no-verify` bypasses it and CI runs the same checks regardless.
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ## Adding a check
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# One-time local setup (run once per clone): install pre-commit and enable the
-# repo check hooks so `python scripts/check.py --fix` runs before each commit.
+# One-time local setup (run once per clone): install pre-commit + the harness
+# deps and enable the repo check hooks so `python scripts/check.py --fix` runs
+# before each commit.
 set -euo pipefail
 
+# Resolve repo root from this script's location so it works from any cwd.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Invoke via `python3 -m` so it works even if pip installs to a dir not on PATH.
 python3 -m pip install --quiet --upgrade pre-commit
-pre-commit install
+python3 -m pip install --quiet -r scripts/requirements.txt
+python3 -m pre_commit install
 
 echo "✓ pre-commit hooks installed — repo checks will run on each commit."
 echo "  Run manually anytime: python scripts/check.py --fix"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# One-time local setup (run once per clone): install pre-commit and enable the
+# repo check hooks so `python scripts/check.py --fix` runs before each commit.
+set -euo pipefail
+
+python3 -m pip install --quiet --upgrade pre-commit
+pre-commit install
+
+echo "✓ pre-commit hooks installed — repo checks will run on each commit."
+echo "  Run manually anytime: python scripts/check.py --fix"
+echo "  Bypass once if needed: git commit --no-verify (CI runs the same checks)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # One-time local setup (run once per clone): install pre-commit + the harness
-# deps and enable the repo check hooks so `python scripts/check.py --fix` runs
+# deps and enable the repo check hooks so `python3 scripts/check.py --fix` runs
 # before each commit.
 set -euo pipefail
 
@@ -13,5 +13,5 @@ python3 -m pip install --quiet -r scripts/requirements.txt
 python3 -m pre_commit install
 
 echo "✓ pre-commit hooks installed — repo checks will run on each commit."
-echo "  Run manually anytime: python scripts/check.py --fix"
+echo "  Run manually anytime: python3 scripts/check.py --fix"
 echo "  Bypass once if needed: git commit --no-verify (CI runs the same checks)"


### PR DESCRIPTION
## What

Lets contributors run the repo check harness locally via a **pre-commit hook**, so issues (dirty notebooks, non-conforming eval configs) are caught *before* commit instead of at CI.

- `.pre-commit-config.yaml` — a local hook running `python3 scripts/check.py --fix` on each commit, in pre-commit's own isolated env with pinned deps (`nbstripout`, `jsonschema`).
- `scripts/setup.sh` — one-time setup: installs `pre-commit` **and** the harness deps (`scripts/requirements.txt`) — so both the hook and a direct `python3 scripts/check.py` run work — then runs `pre-commit install`.
- `CONTRIBUTING.md` — one-time setup + before-committing workflow.
- README / `scripts/README` pointers.

## 📣 After this merges — one-time action for the team

Each contributor runs this **once per clone** (existing clones included):

```shell
scripts/setup.sh
```

That's it. **You won't need to re-run it when we add more checks** — the hook just calls `scripts/check.py`, so new checks in the registry are picked up automatically. (`default_install_hook_types` also pre-covers any future commit-msg/pre-push hooks, so no reinstall there either.)

## How it behaves

- On commit, `scripts/check.py --fix` auto-strips notebook outputs and reports anything else to fix by hand.
- **Bypass anytime:** `git commit --no-verify` (or `SKIP=repo-checks git commit`). Safe — **CI runs the same checks on every PR**, so the hook is opt-in convenience, not the enforcement gate.

## Verified

End-to-end in a fresh isolated clone: `scripts/setup.sh` (from any cwd) installs the hook + deps; a clean commit passes; a dirty notebook is auto-stripped and the commit blocked until re-staged; `--no-verify` bypasses; and the direct `python3 scripts/check.py --fix` works after setup.
