### PR TITLE
fix: require ai>=7 and @ai-sdk/* >=4 peers to match supported provider spec

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -65,10 +65,10 @@
   },
   "homepage": "https://github.com/learning-commons-org/evaluators/tree/main/sdks/typescript#readme",
   "peerDependencies": {
-    "@ai-sdk/anthropic": ">=3.0.0",
-    "@ai-sdk/google": ">=3.0.0",
-    "@ai-sdk/openai": ">=3.0.0",
-    "ai": ">=6.0.0"
+    "@ai-sdk/anthropic": ">=4.0.0",
+    "@ai-sdk/google": ">=4.0.0",
+    "@ai-sdk/openai": ">=4.0.0",
+    "ai": ">=7.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/openai": {


### PR DESCRIPTION
## What

Tighten the AI-provider peer ranges to the generation the SDK is actually built and tested against.

`ai` and `@ai-sdk/*` share a language-model spec version through `@ai-sdk/provider`: `ai@7` + adapters `@4` implement spec **v4**, while `ai@6` + adapters `@3` implement spec **v2**. The current peers (`ai >=6.0.0`, adapters `>=3.0.0`) allow mixing the two generations, which npm installs silently and then fails at runtime.

## Change

`package.json` peerDependencies: `ai >=6.0.0` → `>=7.0.0`, and `@ai-sdk/{anthropic,google,openai} >=3.0.0` → `>=4.0.0` (matches the devDependencies).

## Before / after

- **Before:** `npm i @learning-commons/evaluators ai@6 @ai-sdk/anthropic@4` installs cleanly, then throws at eval time: `Unsupported model version v4 ... AI SDK 5 only supports specification version "v2"`.
- **After:** the same install is rejected up front with `ERESOLVE ... peer ai@">=7.0.0"`; `ai@7 + @ai-sdk/anthropic@4` installs clean.

Surfaced while building the SDK demo app (#132).