### PR TITLE
fix: harden Knowledge Graph client pagination, code normalization, and ambiguity detection

### DIFF
--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -90,6 +90,12 @@ export interface MathStandardsAlignmentEvaluatorConfig extends BaseEvaluatorConf
 const DETAIL_MODEL: string = STEP.model.name;
 const TEMPERATURE: number = STEP.generation.temperature;
 const KG_SUBJECT = 'Mathematics';
+/**
+ * Above this many question/standard pairs, evaluateByGrade warns. A grade can carry
+ * over a thousand standards in some jurisdictions, so a handful of questions is
+ * enough to run into five figures of LLM calls.
+ */
+const BY_GRADE_WARN_PAIRS = 500;
 
 // ---------------------------------------------------------------------------
 // Evaluator
@@ -183,7 +189,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     if (useCoarseFilter) {
       await Promise.all(
         allCodes.map((code) =>
-          this.kgClient.getLearningComponentsByCode(code, { jurisdiction, academicSubject: KG_SUBJECT, limit: 1 })
+          this.kgClient.getLearningComponentsByCode(code, { jurisdiction, academicSubject: KG_SUBJECT })
             .then((result) => lcCache.set(code, result))
             .catch(() => undefined),
         ),
@@ -270,10 +276,26 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       jurisdiction,
       academicSubject: KG_SUBJECT,
     });
-    // statementCode is nullable in the spec — skip standards without one
-    const codes = academicStandards
-      .map((s) => s.statementCode)
-      .filter((c): c is string => c != null);
+    // statementCode is nullable in the spec — skip standards without one. Deduped
+    // because a jurisdiction reusing a code across courses returns one item per
+    // course, which would otherwise repeat that code in byStandard.
+    const codes = [...new Set(
+      academicStandards
+        .map((s) => s.statementCode)
+        .filter((c): c is string => c != null),
+    )];
+
+    const pairs = questions.length * codes.length;
+    if (pairs > BY_GRADE_WARN_PAIRS) {
+      this.logger.warn('Large grade-wide evaluation; each pair costs an LLM call', {
+        evaluator: EVALUATOR_ID,
+        grade,
+        jurisdiction,
+        questions: questions.length,
+        standards: codes.length,
+        pairs,
+      });
+    }
 
     if (codes.length === 0) {
       return {
@@ -313,11 +335,22 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      const { components } = await this.kgClient.getLearningComponentsByCode(statementCode, {
-        jurisdiction,
-        academicSubject: KG_SUBJECT,
-        limit: 1,
-      });
+      const { components, ambiguous, uuid, description } = await this.kgClient.getLearningComponentsByCode(
+        statementCode,
+        { jurisdiction, academicSubject: KG_SUBJECT },
+      );
+
+      // Interim: first match wins until candidate resolution lands. Warn so the
+      // choice, not the model, is the suspect when a result looks wrong.
+      if (ambiguous) {
+        this.logger.warn('Statement code matched multiple standards; evaluating the first', {
+          evaluator: EVALUATOR_ID,
+          statementCode,
+          jurisdiction,
+          chosenUuid: uuid,
+          chosenDescription: description,
+        });
+      }
 
       if (components.length === 0) {
         return { statementCode, learningComponents: [], alignedCount: 0, totalCount: 0 };
@@ -441,13 +474,13 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       // reason about rather than opaque codes like "3.MD.C.7.d".
       const infos = await Promise.all(
         statementCodes.map((code) =>
-          this.kgClient.getStandardInfo(code, { jurisdiction, academicSubject: KG_SUBJECT, limit: 1 })
-            .catch(() => ({ uuid: '', description: undefined }))
+          this.kgClient.getStandardInfo(code, { jurisdiction, academicSubject: KG_SUBJECT })
+            .catch(() => null)
         ),
       );
       const standardList = statementCodes
         .map((code, i) => {
-          const desc = infos[i].description;
+          const desc = infos[i]?.description;
           return desc ? `${code}: ${desc}` : code;
         })
         .join('\n');
@@ -468,6 +501,12 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       for (const code of statementCodes) {
         if (!returnedCodes.has(code)) relevant.add(code);
       }
+      // An ambiguous code was described by one arbitrary candidate, so filtering on
+      // that description could drop a code a sibling candidate makes relevant. Fail
+      // open and let detail evaluation decide, which also surfaces the warning.
+      statementCodes.forEach((code, i) => {
+        if (infos[i]?.ambiguous) relevant.add(code);
+      });
       return relevant;
     } catch (err) {
       this.logger.warn('Coarse filter failed, passing all standards to detail eval', {

--- a/sdks/typescript/src/knowledge-graph/client.ts
+++ b/sdks/typescript/src/knowledge-graph/client.ts
@@ -6,7 +6,7 @@ import {
   RateLimitError,
   NetworkError,
 } from '../errors.js';
-import type { AcademicStandard, LearningComponent, StandardInfo } from './types.js';
+import type { AcademicStandard, LearningComponent, LearningComponentSet, StandardInfo } from './types.js';
 import type { paths, components } from './kg-api.js';
 
 const KG_BASE_URL = 'https://api.learningcommons.org/knowledge-graph/v0';
@@ -87,7 +87,7 @@ export class KnowledgeGraphClient {
   // Cache key: `${normalizedCode}:${jurisdiction}:${academicSubject}`
   // Holds every candidate, so resolving an ambiguous code costs no extra request.
   private readonly standardInfoCache = new Map<string, Promise<StandardInfo[]>>();
-  private readonly lcCache = new Map<string, Promise<LearningComponent[]>>();
+  private readonly lcCache = new Map<string, Promise<LearningComponentSet>>();
   // Cache key: `${jurisdiction}:${academicSubject}`
   private readonly frameworkUuidCache = new Map<string, Promise<string>>();
 
@@ -137,7 +137,13 @@ export class KnowledgeGraphClient {
     return candidates.map((c) => ({ ...c }));
   }
 
-  getLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
+  /** Evaluable components only. See {@link getLearningComponentSet} to tell an
+   * empty standard apart from one whose components have no descriptions. */
+  async getLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
+    return (await this.getLearningComponentSet(caseIdentifierUUID)).components;
+  }
+
+  getLearningComponentSet(caseIdentifierUUID: string): Promise<LearningComponentSet> {
     let p = this.lcCache.get(caseIdentifierUUID);
     if (!p) {
       p = this.limit(() => this._fetchLearningComponents(caseIdentifierUUID));
@@ -313,8 +319,9 @@ export class KnowledgeGraphClient {
     }));
   }
 
-  private _fetchLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
-    return this._paginate(`UUID ${caseIdentifierUUID}`, async (cursor) => {
+  private async _fetchLearningComponents(caseIdentifierUUID: string): Promise<LearningComponentSet> {
+    let undescribedCount = 0;
+    const components = await this._paginate(`UUID ${caseIdentifierUUID}`, async (cursor) => {
       const query: { limit: number; cursor?: string } = { limit: LC_PAGE_SIZE };
       if (cursor) query.cursor = cursor;
 
@@ -327,10 +334,14 @@ export class KnowledgeGraphClient {
       for (const item of data.data ?? []) {
         if (item.description != null) {
           items.push({ identifier: item.identifier, description: item.description });
+        } else {
+          undescribedCount++;
         }
       }
 
       return { items, hasMore: data.pagination?.hasMore, nextCursor: data.pagination?.nextCursor };
     });
+
+    return { components, undescribedCount };
   }
 }

--- a/sdks/typescript/src/knowledge-graph/client.ts
+++ b/sdks/typescript/src/knowledge-graph/client.ts
@@ -12,6 +12,21 @@ import type { paths, components } from './kg-api.js';
 const KG_BASE_URL = 'https://api.learningcommons.org/knowledge-graph/v0';
 const CCSS_FRAMEWORK_UUID = 'c6496676-d7cb-11e8-824f-0242ac160002';
 const KG_TIMEOUT_MS = 30_000;
+const STANDARDS_PAGE_SIZE = 500;
+const LC_PAGE_SIZE = 100;
+/** The search endpoint's maximum. Explicit because its default is 5, not the cap. */
+export const STANDARD_SEARCH_LIMIT = 50;
+/** Generous: the largest grade needs 3 pages of 500. */
+const MAX_PAGES = 200;
+
+/**
+ * Canonical lookup form: trimmed, interior whitespace collapsed, uppercased.
+ * Safe because the KG documents statementCode search as "case-insensitive exact
+ * match only" (`searchAcademicStandards` in kg-api.d.ts).
+ */
+export function normalizeStatementCode(statementCode: string): string {
+  return statementCode.trim().replace(/\s+/g, ' ').toUpperCase();
+}
 
 // Adds per-request timeout and maps network/timeout errors to domain types.
 async function kgFetchFn(input: Request, init?: Parameters<typeof fetch>[1]): Promise<Response> {
@@ -51,7 +66,6 @@ const httpErrorMiddleware: Middleware = {
 export interface StandardInfoOptions {
   jurisdiction?: string;
   academicSubject?: string;
-  limit?: number;
 }
 
 export interface StandardsByGradeOptions {
@@ -70,8 +84,9 @@ export class KnowledgeGraphClient {
   private readonly limit: ReturnType<typeof pLimit>;
   private readonly http: ReturnType<typeof createClient<paths>>;
 
-  // Cache key: `${statementCode}:${jurisdiction}`
-  private readonly standardInfoCache = new Map<string, Promise<StandardInfo>>();
+  // Cache key: `${normalizedCode}:${jurisdiction}:${academicSubject}`
+  // Holds every candidate, so resolving an ambiguous code costs no extra request.
+  private readonly standardInfoCache = new Map<string, Promise<StandardInfo[]>>();
   private readonly lcCache = new Map<string, Promise<LearningComponent[]>>();
   // Cache key: `${jurisdiction}:${academicSubject}`
   private readonly frameworkUuidCache = new Map<string, Promise<string>>();
@@ -86,16 +101,40 @@ export class KnowledgeGraphClient {
     this.http.use(httpErrorMiddleware);
   }
 
-  getStandardInfo(statementCode: string, opts?: StandardInfoOptions): Promise<StandardInfo> {
+  /** The first matching standard. Sets `ambiguous` when the code matched more than one. */
+  async getStandardInfo(statementCode: string, opts?: StandardInfoOptions): Promise<StandardInfo> {
+    const candidates = await this.getStandardCandidates(statementCode, opts);
+    return { ...candidates[0], ...(candidates.length > 1 ? { ambiguous: true } : {}) };
+  }
+
+  /**
+   * Every standard matching the code, in Knowledge Graph order. More than one means
+   * the code is reused (typically across courses) and the caller must choose. A
+   * length of {@link STANDARD_SEARCH_LIMIT} may be truncated — search takes no cursor.
+   */
+  async getStandardCandidates(statementCode: string, opts?: StandardInfoOptions): Promise<StandardInfo[]> {
+    const normalized = normalizeStatementCode(statementCode);
     const jurisdiction = opts?.jurisdiction ?? 'Multi-State';
-    const cacheKey = `${statementCode}:${jurisdiction}`;
+    const cacheKey = `${normalized}:${jurisdiction}:${opts?.academicSubject ?? ''}`;
     let p = this.standardInfoCache.get(cacheKey);
     if (!p) {
-      p = this.limit(() => this._fetchStandardInfo(statementCode, opts));
+      p = this.limit(() => this._fetchStandardCandidates(normalized, opts));
       p = p.catch((err) => { this.standardInfoCache.delete(cacheKey); throw err; });
       this.standardInfoCache.set(cacheKey, p);
     }
-    return p;
+
+    const candidates = await p;
+    if (candidates.length === 0) {
+      // Evict: an empty result fulfils rather than rejects, so the eviction above
+      // never fires and a transient empty response would be cached for the life of
+      // the client. Guarded on identity so a concurrent retry is not discarded.
+      if (this.standardInfoCache.get(cacheKey) === p) this.standardInfoCache.delete(cacheKey);
+      // Thrown per caller, not inside the shared request, so concurrent callers with
+      // different spellings each see their own in the message.
+      throw new KnowledgeGraphError(`Standard not found: "${statementCode}"`);
+    }
+    // Copies: a caller sorting these to choose would otherwise reorder the cache.
+    return candidates.map((c) => ({ ...c }));
   }
 
   getLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
@@ -114,48 +153,99 @@ export class KnowledgeGraphClient {
       opts?.academicSubject,
     );
 
-    const { data } = await this.http.GET('/academic-standards', {
-      params: {
-        query: {
-          limit: 500,
-          standardsFrameworkCaseIdentifierUUID: frameworkUuid,
-          gradeLevel: [grade] as components['parameters']['GradeLevelParam'],
-          normalizedStatementType: 'Standard' as components['schemas']['NormalizedStatementTypeENUM'],
-          ...(opts?.academicSubject
-            ? { academicSubject: opts.academicSubject as components['schemas']['AcademicSubjectENUM'] }
-            : {}),
-        },
-      },
-    }).catch(wrapJsonError);
-    if (data === undefined) throw new KnowledgeGraphError('Unexpected empty response from Knowledge Graph');
+    type StandardsQuery = NonNullable<
+      paths['/academic-standards']['get']['parameters']['query']
+    >;
 
-    if (data.pagination?.hasMore) {
-      throw new KnowledgeGraphError(
-        `getStandardsByGrade returned a paginated result for grade "${grade}" — ` +
-        `increase limit or implement cursor pagination to retrieve all standards.`,
-      );
-    }
+    return this._paginate(`grade "${grade}"`, async (cursor) => {
+      const query: StandardsQuery = {
+        limit: STANDARDS_PAGE_SIZE,
+        standardsFrameworkCaseIdentifierUUID: frameworkUuid,
+        gradeLevel: [grade] as components['parameters']['GradeLevelParam'],
+        normalizedStatementType: 'Standard' as components['schemas']['NormalizedStatementTypeENUM'],
+        ...(opts?.academicSubject
+          ? { academicSubject: opts.academicSubject as components['schemas']['AcademicSubjectENUM'] }
+          : {}),
+        ...(cursor ? { cursor } : {}),
+      };
 
-    return (data.data ?? []).map((item) => ({
-      caseIdentifierUUID: item.caseIdentifierUUID,
-      statementCode: item.statementCode ?? null,
-      description: item.description ?? null,
-      statementType: item.statementType ?? null,
-      normalizedStatementType: item.normalizedStatementType ?? null,
-      gradeLevel: item.gradeLevel ?? [],
-    }));
+      const { data } = await this.http.GET('/academic-standards', {
+        params: { query },
+      }).catch(wrapJsonError);
+      if (data === undefined) throw new KnowledgeGraphError('Unexpected empty response from Knowledge Graph');
+
+      return {
+        items: (data.data ?? []).map((item) => ({
+          caseIdentifierUUID: item.caseIdentifierUUID,
+          statementCode: item.statementCode ?? null,
+          description: item.description ?? null,
+          statementType: item.statementType ?? null,
+          normalizedStatementType: item.normalizedStatementType ?? null,
+          gradeLevel: item.gradeLevel ?? [],
+        })),
+        hasMore: data.pagination?.hasMore,
+        nextCursor: data.pagination?.nextCursor,
+      };
+    });
   }
 
   async getLearningComponentsByCode(
     statementCode: string,
     opts?: StandardInfoOptions,
-  ): Promise<{ uuid: string; description?: string; components: LearningComponent[] }> {
-    const { uuid, description } = await this.getStandardInfo(statementCode, opts);
-    const components = await this.getLearningComponents(uuid);
-    return { uuid, description, components };
+  ): Promise<StandardInfo & { components: LearningComponent[] }> {
+    const info = await this.getStandardInfo(statementCode, opts);
+    const components = await this.getLearningComponents(info.uuid);
+    return { ...info, components };
   }
 
   // ---------------------------------------------------------------------------
+
+  /**
+   * Walks cursor-paginated KG endpoints until exhausted. `context` labels the
+   * error thrown when a page's pagination fields are self-contradictory, which
+   * would otherwise loop forever or truncate silently.
+   */
+  private async _paginate<T>(
+    context: string,
+    fetchPage: (cursor: string | null) => Promise<{
+      items: T[];
+      hasMore?: boolean;
+      nextCursor?: string | null;
+    }>,
+  ): Promise<T[]> {
+    const results: T[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+
+    do {
+      const { items, hasMore, nextCursor } = await fetchPage(cursor);
+      results.push(...items);
+
+      if (hasMore && !nextCursor) {
+        throw new KnowledgeGraphError(
+          `Knowledge Graph pagination error: hasMore=true but nextCursor is null for ${context}`,
+        );
+      }
+      cursor = hasMore ? (nextCursor ?? null) : null;
+
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          throw new KnowledgeGraphError(
+            `Knowledge Graph pagination error: cursor "${cursor}" repeated for ${context}`,
+          );
+        }
+        seenCursors.add(cursor);
+        // The repeat check above misses a server minting a fresh cursor per page.
+        if (seenCursors.size > MAX_PAGES) {
+          throw new KnowledgeGraphError(
+            `Knowledge Graph pagination error: exceeded ${MAX_PAGES} pages for ${context}`,
+          );
+        }
+      }
+    } while (cursor !== null);
+
+    return results;
+  }
 
   private _getFrameworkUuid(jurisdiction: string, academicSubject?: string): Promise<string> {
     if (jurisdiction === 'Multi-State') return Promise.resolve(CCSS_FRAMEWORK_UUID);
@@ -194,13 +284,17 @@ export class KnowledgeGraphClient {
     return frameworks[0].caseIdentifierUUID;
   }
 
-  private async _fetchStandardInfo(statementCode: string, opts?: StandardInfoOptions): Promise<StandardInfo> {
+  /** Empty when the code does not exist; the caller raises the not-found error. */
+  private async _fetchStandardCandidates(
+    normalizedCode: string,
+    opts?: StandardInfoOptions,
+  ): Promise<StandardInfo[]> {
     const { data } = await this.http.GET('/academic-standards/search', {
       params: {
         query: {
-          statementCode,
+          statementCode: normalizedCode,
           jurisdiction: (opts?.jurisdiction ?? 'Multi-State') as components['schemas']['JurisdictionENUM'],
-          limit: opts?.limit ?? 1,
+          limit: STANDARD_SEARCH_LIMIT,
           ...(opts?.academicSubject
             ? { academicSubject: opts.academicSubject as components['schemas']['AcademicSubjectENUM'] }
             : {}),
@@ -209,18 +303,19 @@ export class KnowledgeGraphClient {
     }).catch(wrapJsonError);
     if (data === undefined) throw new KnowledgeGraphError('Unexpected empty response from Knowledge Graph');
 
-    if (data.length === 0) {
-      throw new KnowledgeGraphError(`Standard not found: "${statementCode}"`);
-    }
-    return { uuid: data[0].caseIdentifierUUID, description: data[0].description ?? undefined };
+    return data.map((item) => ({
+      uuid: item.caseIdentifierUUID,
+      description: item.description ?? undefined,
+      // The KG's spelling: CCSS sub-standards are lowercase (3.MD.C.7.d), so the
+      // uppercased lookup key is not a valid code. Fallback is defensive only.
+      statementCode: item.statementCode ?? normalizedCode,
+      normalizedCode,
+    }));
   }
 
-  private async _fetchLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
-    const results: LearningComponent[] = [];
-    let cursor: string | null = null;
-
-    do {
-      const query: { limit: number; cursor?: string } = { limit: 100 };
+  private _fetchLearningComponents(caseIdentifierUUID: string): Promise<LearningComponent[]> {
+    return this._paginate(`UUID ${caseIdentifierUUID}`, async (cursor) => {
+      const query: { limit: number; cursor?: string } = { limit: LC_PAGE_SIZE };
       if (cursor) query.cursor = cursor;
 
       const { data } = await this.http.GET('/academic-standards/{caseIdentifierUUID}/learning-components', {
@@ -228,21 +323,14 @@ export class KnowledgeGraphClient {
       }).catch(wrapJsonError);
       if (data === undefined) throw new KnowledgeGraphError('Unexpected empty response from Knowledge Graph');
 
+      const items: LearningComponent[] = [];
       for (const item of data.data ?? []) {
         if (item.description != null) {
-          results.push({ identifier: item.identifier, description: item.description });
+          items.push({ identifier: item.identifier, description: item.description });
         }
       }
 
-      const { hasMore, nextCursor } = data.pagination ?? {};
-      if (hasMore && !nextCursor) {
-        throw new KnowledgeGraphError(
-          `Knowledge Graph pagination error: hasMore=true but nextCursor is null for UUID ${caseIdentifierUUID}`,
-        );
-      }
-      cursor = hasMore ? (nextCursor ?? null) : null;
-    } while (cursor !== null);
-
-    return results;
+      return { items, hasMore: data.pagination?.hasMore, nextCursor: data.pagination?.nextCursor };
+    });
   }
 }

--- a/sdks/typescript/src/knowledge-graph/index.ts
+++ b/sdks/typescript/src/knowledge-graph/index.ts
@@ -1,4 +1,4 @@
 export type { AcademicStandard, LearningComponent, StandardInfo } from './types.js';
 export { Jurisdiction } from './types.js';
-export { KnowledgeGraphClient } from './client.js';
+export { KnowledgeGraphClient, normalizeStatementCode } from './client.js';
 export type { StandardInfoOptions, StandardsByGradeOptions } from './client.js';

--- a/sdks/typescript/src/knowledge-graph/types.ts
+++ b/sdks/typescript/src/knowledge-graph/types.ts
@@ -86,6 +86,18 @@ export interface LearningComponent {
   description: string;
 }
 
+/**
+ * A standard's learning components, split by usability. The KG documents
+ * `description` as optional (`LearningComponent` in kg-api.d.ts), and alignment
+ * is judged from that text, so an undescribed component cannot be evaluated.
+ * `undescribedCount` keeps the two cases distinguishable: a standard with
+ * nothing authored against it, versus one whose components lack descriptions.
+ */
+export interface LearningComponentSet {
+  components: LearningComponent[];
+  undescribedCount: number;
+}
+
 /** Resolved info from a standard code lookup. */
 export interface StandardInfo {
   uuid: string;

--- a/sdks/typescript/src/knowledge-graph/types.ts
+++ b/sdks/typescript/src/knowledge-graph/types.ts
@@ -90,4 +90,10 @@ export interface LearningComponent {
 export interface StandardInfo {
   uuid: string;
   description?: string;
+  /** The KG's spelling — use for display and joins. CCSS sub-standards are lowercase. */
+  statementCode: string;
+  /** Canonical lookup key (see normalizeStatementCode) — dedupe on this. */
+  normalizedCode: string;
+  /** Code matched multiple standards; uuid/description are the first match. */
+  ambiguous?: boolean;
 }

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -110,6 +110,47 @@ describe('MathStandardsAlignmentEvaluator - constructor', () => {
 // evaluate
 // ---------------------------------------------------------------------------
 
+describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
+  function makeLogger() {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  }
+
+  it('warns which standard was chosen when a code matches several', async () => {
+    const logger = makeLogger();
+    const repo = makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockResolvedValue({
+        uuid: 'uuid-abc',
+        statementCode: STATEMENT_CODE,
+        normalizedCode: '3.MD.C.7.D',
+        description: 'Graph exponential functions',
+        ambiguous: true,
+        components: LC_COMPONENTS,
+      }),
+    });
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo, logger }));
+
+    await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [message, context] = logger.warn.mock.calls[0];
+    expect(message).toContain('matched multiple standards');
+    expect(context).toMatchObject({
+      statementCode: STATEMENT_CODE,
+      chosenUuid: 'uuid-abc',
+      chosenDescription: 'Graph exponential functions',
+    });
+  });
+
+  it('stays silent when the code resolves to one standard', async () => {
+    const logger = makeLogger();
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ logger }));
+
+    await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
 describe('MathStandardsAlignmentEvaluator - evaluate', () => {
   it('returns StandardAlignmentResult with correct shape on happy path', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
@@ -134,7 +175,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
 
     expect(kgClient.getLearningComponentsByCode).toHaveBeenCalledWith(
       STATEMENT_CODE,
-      { jurisdiction: Jurisdiction.California, academicSubject: 'Mathematics', limit: 1 },
+      { jurisdiction: Jurisdiction.California, academicSubject: 'Mathematics' },
     );
   });
 
@@ -347,6 +388,37 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     expect(evaluated.learningComponents).toHaveLength(2);
   });
 
+  it('does not let the coarse filter drop an ambiguous code', async () => {
+    // The filter only sees one arbitrary candidate's description, so a sibling
+    // candidate could be the relevant one. Filtering it out would be a false negative.
+    const repo = makeMockKgClient({
+      getStandardInfo: vi.fn().mockResolvedValue({
+        uuid: 'uuid-abc',
+        statementCode: '3.OA.A.1',
+        normalizedCode: '3.OA.A.1',
+        description: 'an arbitrary sibling description',
+        ambiguous: true,
+      }),
+    });
+    vi.mocked(mockProvider.generateStructured)
+      .mockResolvedValueOnce({
+        data: { standards: [{ standard: '3.OA.A.1', relevant: false }] },
+        model: 'anthropic:claude-haiku-4-5-20251001', usage: { inputTokens: 50, outputTokens: 20 }, latencyMs: 200,
+      })
+      .mockResolvedValue(MOCK_BATCH_RESPONSE);
+
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: ['3.OA.A.1'] }],
+      JURISDICTION,
+      { useCoarseFilter: true },
+    );
+
+    const result = results[0].standards[0];
+    expect(result.coarseFiltered).toBeUndefined();
+    expect(result.learningComponents).toHaveLength(2);
+  });
+
   it('falls back to all standards relevant when coarse filter LLM throws', async () => {
     vi.mocked(mockProvider.generateStructured)
       .mockRejectedValueOnce(new Error('coarse filter failed'))
@@ -423,10 +495,13 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
     await expect(evaluator.evaluateByGrade([QUESTION], '13', JURISDICTION)).rejects.toThrow(ValidationError);
   });
 
-  it('fetches standards for grade and jurisdiction and runs M×N evaluation', async () => {
+  it('fetches standards for grade and jurisdiction, deduping codes reused across courses', async () => {
+    // A jurisdiction reusing one code across courses returns an item per course.
+    // Without deduping, byStandard would repeat that code.
     const repo = makeMockKgClient({
       getStandardsByGrade: vi.fn().mockResolvedValue([
         { caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d', description: 'Area', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
+        { caseIdentifierUUID: 'u1b', statementCode: '3.MD.C.7.d', description: 'Area, other course', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
         { caseIdentifierUUID: 'u2', statementCode: '3.OA.A.1', description: 'Products', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
       ]),
     });
@@ -434,8 +509,28 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
     const result = await evaluator.evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
 
     expect(repo.getStandardsByGrade).toHaveBeenCalledWith('3', { jurisdiction: JURISDICTION, academicSubject: 'Mathematics' });
-    expect(result.byStandard).toHaveLength(2);
+    expect(result.byStandard.map((s) => s.statementCode)).toEqual(['3.MD.C.7.d', '3.OA.A.1']);
     expect(result.byQuestion[0].standards).toHaveLength(2);
+  });
+
+  it('warns when the grade-wide fan-out is large, and stays quiet when it is not', async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const manyStandards = Array.from({ length: 501 }, (_, i) => ({
+      caseIdentifierUUID: `u${i}`, statementCode: `3.XX.${i}`, description: 'd',
+      statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'],
+    }));
+
+    const small = makeMockKgClient();
+    await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: small, logger }))
+      .evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    const large = makeMockKgClient({ getStandardsByGrade: vi.fn().mockResolvedValue(manyStandards) });
+    await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: large, logger }))
+      .evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][1]).toMatchObject({ questions: 1, standards: 501, pairs: 501 });
   });
 
   it('returns byStandard with coverageCount counting questions with alignedCount > 0', async () => {

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -274,22 +274,34 @@ describe('KnowledgeGraphClient - getLearningComponents', () => {
     expect(lcs[0].description).toBe('Recognize area as additive');
   });
 
-  it('filters out null descriptions', async () => {
+  it('filters out null descriptions but reports how many were dropped', async () => {
     mockFetch(200, { data: [{ description: 'Valid' }, { description: null }, { description: 'Also valid' }], pagination: { hasMore: false, nextCursor: null } });
-    const lcs = await new KnowledgeGraphClient(API_KEY).getLearningComponents('uuid-abc');
-    expect(lcs).toHaveLength(2);
+    // The count is what lets a caller say "components exist but are undescribed"
+    // instead of "nothing is authored against this standard".
+    const set = await new KnowledgeGraphClient(API_KEY).getLearningComponentSet('uuid-abc');
+    expect(set.components).toHaveLength(2);
+    expect(set.undescribedCount).toBe(1);
+  });
+
+  it('reports undescribedCount with no evaluable components at all', async () => {
+    mockFetch(200, { data: [{ description: null }, { description: null }], pagination: { hasMore: false, nextCursor: null } });
+    const set = await new KnowledgeGraphClient(API_KEY).getLearningComponentSet('uuid-abc');
+    expect(set.components).toEqual([]);
+    expect(set.undescribedCount).toBe(2);
   });
 
   it('follows cursor pagination across pages, sending the cursor and the uuid', async () => {
     let call = 0;
     const fetchMock = vi.fn().mockImplementation(() => {
       call++;
-      const body = { data: [{ description: `LC ${call}` }], pagination: { hasMore: call === 1, nextCursor: call === 1 ? 'page-2' : null } };
+      const body = { data: [{ description: `LC ${call}` }, { description: null }], pagination: { hasMore: call === 1, nextCursor: call === 1 ? 'page-2' : null } };
       return Promise.resolve(okResponse(body));
     });
     vi.stubGlobal('fetch', fetchMock);
-    const lcs = await new KnowledgeGraphClient(API_KEY).getLearningComponents('uuid-abc');
-    expect(lcs).toHaveLength(2);
+    const set = await new KnowledgeGraphClient(API_KEY).getLearningComponentSet('uuid-abc');
+    expect(set.components).toHaveLength(2);
+    // Accumulated across pages, not reset per page.
+    expect(set.undescribedCount).toBe(2);
     expect(call).toBe(2);
     expect((fetchMock.mock.calls[0][0] as Request).url).toContain('uuid-abc');
     expect((fetchMock.mock.calls[0][0] as Request).url).not.toContain('cursor=');
@@ -303,6 +315,8 @@ describe('KnowledgeGraphClient - getLearningComponents', () => {
     const client = new KnowledgeGraphClient(API_KEY);
     await Promise.all([client.getLearningComponents('uuid-abc'), client.getLearningComponents('uuid-abc')]);
     await client.getLearningComponents('uuid-abc');
+    // Both accessors share one cache entry, so asking for the count is free.
+    await client.getLearningComponentSet('uuid-abc');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -50,10 +50,170 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
     await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('X.YZ.A.1')).rejects.toThrow(KnowledgeGraphError);
   });
 
-  it('returns first result when multiple results returned (caller uses limit=1 to avoid this)', async () => {
+  it('returns the first match and flags ambiguity when a code matches multiple standards', async () => {
     mockFetch(200, [{ caseIdentifierUUID: 'a' }, { caseIdentifierUUID: 'b' }]);
-    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD');
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d');
     expect(info.uuid).toBe('a');
+    expect(info.ambiguous).toBe(true);
+  });
+
+  it('does not flag ambiguity for a single match', async () => {
+    mockFetch(200, [{ caseIdentifierUUID: 'a' }]);
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d');
+    expect(info.ambiguous).toBeUndefined();
+  });
+
+  it('requests the search endpoint maximum, since its default of 5 would truncate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d');
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('limit=50');
+  });
+
+  it('normalizes the code for lookup: uppercases, trims, collapses interior whitespace', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('  3.md.c\t7.d  ');
+    expect(info.normalizedCode).toBe('3.MD.C 7.D');
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('statementCode=3.MD.C%207.D');
+  });
+
+  it('collapses a run of interior whitespace to a single space', async () => {
+    mockFetch(200, [{ caseIdentifierUUID: 'u1' }]);
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C \t 7.D');
+    expect(info.normalizedCode).toBe('3.MD.C 7.D');
+  });
+
+  it('defaults the jurisdiction to Multi-State', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d');
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('jurisdiction=Multi-State');
+  });
+
+  it('exposes every candidate, not just the chosen one', async () => {
+    mockFetch(200, [
+      { caseIdentifierUUID: 'a', statementCode: 'F.IF.7.b', description: 'Graph exponential functions' },
+      { caseIdentifierUUID: 'b', statementCode: 'F.IF.7.b', description: 'Graph piecewise-defined functions' },
+      { caseIdentifierUUID: 'c', statementCode: 'F.IF.7.b', description: 'Define a curve parametrically' },
+    ]);
+    const candidates = await new KnowledgeGraphClient(API_KEY).getStandardCandidates('F.IF.7.b');
+    expect(candidates).toHaveLength(3);
+    expect(candidates.map((c) => c.uuid)).toEqual(['a', 'b', 'c']);
+    expect(candidates[1].description).toBe('Graph piecewise-defined functions');
+    expect(candidates.every((c) => c.normalizedCode === 'F.IF.7.B')).toBe(true);
+  });
+
+  it('serves getStandardInfo and getStandardCandidates from one request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse([{ caseIdentifierUUID: 'a' }, { caseIdentifierUUID: 'b' }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    const info = await client.getStandardInfo('3.MD.C.7.d');
+    const candidates = await client.getStandardCandidates('3.MD.C.7.d');
+    expect(info.ambiguous).toBe(true);
+    expect(candidates).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  
+  it('survives a caller mutating the returned candidate list', async () => {
+    mockFetch(200, [
+      { caseIdentifierUUID: 'a', description: 'first' },
+      { caseIdentifierUUID: 'b', description: 'second' },
+    ]);
+    const client = new KnowledgeGraphClient(API_KEY);
+
+    const first = await client.getStandardCandidates('3.MD.C.7.d');
+    first.reverse();
+    first[0].description = 'mutated';
+
+    const second = await client.getStandardCandidates('3.MD.C.7.d');
+    expect(second.map((c) => c.uuid)).toEqual(['a', 'b']);
+    expect(second[0].description).toBe('first');
+    expect((await client.getStandardInfo('3.MD.C.7.d')).uuid).toBe('a');
+  });
+
+  it('reports not-found using the code as the caller spelled it', async () => {
+    mockFetch(200, []);
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.md.c.7.d').catch((e) => e);
+    expect(err.message).toContain('"3.md.c.7.d"');
+  });
+
+  it('re-queries after an empty result rather than caching not-found', async () => {
+    // An empty search response fulfils, so it bypasses the rejection-eviction path.
+    // A transient empty (index warm-up, replica lag) must not poison the code.
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(okResponse([]))
+      .mockResolvedValue(okResponse([{ caseIdentifierUUID: 'appeared-later' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+
+    await expect(client.getStandardInfo('3.MD.C.7.d')).rejects.toThrow(/Standard not found/);
+    const info = await client.getStandardInfo('3.MD.C.7.d');
+
+    expect(info.uuid).toBe('appeared-later');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives concurrent callers their own spelling in the not-found error', async () => {
+    // Both share one in-flight request, so the message cannot be built inside it.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+
+    const [lower, upper] = await Promise.all([
+      client.getStandardInfo('3.md.c.7.d').catch((e) => e),
+      client.getStandardInfo('3.MD.C.7.D').catch((e) => e),
+    ]);
+
+    expect(lower.message).toContain('"3.md.c.7.d"');
+    expect(upper.message).toContain('"3.MD.C.7.D"');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches an omitted jurisdiction and an explicit Multi-State as one entry', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    await client.getStandardInfo('3.MD.C.7.d');
+    await client.getStandardInfo('3.MD.C.7.d', { jurisdiction: 'Multi-State' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the KG canonical code, preserving lowercase sub-standard letters', async () => {
+    mockFetch(200, [{ caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d' }]);
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.md.c.7.D');
+    expect(info.statementCode).toBe('3.MD.C.7.d');
+    expect(info.normalizedCode).toBe('3.MD.C.7.D');
+  });
+
+  it('falls back to the normalized code when the KG omits statementCode', async () => {
+    mockFetch(200, [{ caseIdentifierUUID: 'u1' }]);
+    const info = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.md.c.7.d');
+    expect(info.statementCode).toBe('3.MD.C.7.D');
+  });
+
+  it('collapses case and whitespace variants onto one cached request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    await Promise.all([
+      client.getStandardInfo('3.MD.C.7.d'),
+      client.getStandardInfo('3.md.c.7.D'),
+      client.getStandardInfo('  3.MD.C.7.D  '),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not collide cache entries across academicSubject', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    await client.getStandardInfo('3.MD.C.7.d', { academicSubject: 'Mathematics' });
+    await client.getStandardInfo('3.MD.C.7.d', { academicSubject: 'English Language Arts' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('throws AuthenticationError on 401', async () => {
@@ -120,16 +280,30 @@ describe('KnowledgeGraphClient - getLearningComponents', () => {
     expect(lcs).toHaveLength(2);
   });
 
-  it('follows cursor pagination across pages', async () => {
+  it('follows cursor pagination across pages, sending the cursor and the uuid', async () => {
     let call = 0;
-    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+    const fetchMock = vi.fn().mockImplementation(() => {
       call++;
       const body = { data: [{ description: `LC ${call}` }], pagination: { hasMore: call === 1, nextCursor: call === 1 ? 'page-2' : null } };
       return Promise.resolve(okResponse(body));
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
     const lcs = await new KnowledgeGraphClient(API_KEY).getLearningComponents('uuid-abc');
     expect(lcs).toHaveLength(2);
     expect(call).toBe(2);
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('uuid-abc');
+    expect((fetchMock.mock.calls[0][0] as Request).url).not.toContain('cursor=');
+    expect((fetchMock.mock.calls[1][0] as Request).url).toContain('cursor=page-2');
+  });
+
+  it('serves a repeated uuid from cache', async () => {
+    const body = { data: [{ description: 'LC one' }], pagination: { hasMore: false, nextCursor: null } };
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(body));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    await Promise.all([client.getLearningComponents('uuid-abc'), client.getLearningComponents('uuid-abc')]);
+    await client.getLearningComponents('uuid-abc');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('throws KnowledgeGraphError if hasMore=true but nextCursor is null', async () => {
@@ -163,10 +337,45 @@ describe('KnowledgeGraphClient - getStandardsByGrade', () => {
     expect(results[0].statementCode).toBe('3.MD.C.7.d');
   });
 
-  it('throws KnowledgeGraphError if hasMore=true (pagination not implemented for standards)', async () => {
-    mockFetch(200, { data: [], pagination: { hasMore: true, nextCursor: 'page-2' } });
+  it('resolves Multi-State to the CCSS framework without a lookup request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [], pagination: { hasMore: false } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = (fetchMock.mock.calls[0][0] as Request).url;
+    expect(url).toContain('/academic-standards?');
+    expect(url).toContain('standardsFrameworkCaseIdentifierUUID=c6496676-d7cb-11e8-824f-0242ac160002');
+  });
+
+  it('follows cursor pagination across pages and accumulates all standards', async () => {
+    let call = 0;
+    const fetchMock = vi.fn().mockImplementation(() => {
+      call++;
+      return Promise.resolve(okResponse({
+        data: [{ caseIdentifierUUID: `u${call}`, statementCode: `3.MD.C.7.${call}`, gradeLevel: ['3'] }],
+        pagination: { hasMore: call < 3, nextCursor: call < 3 ? `page-${call + 1}` : null },
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const results = await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3');
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.statementCode)).toEqual(['3.MD.C.7.1', '3.MD.C.7.2', '3.MD.C.7.3']);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect((fetchMock.mock.calls[1][0] as Request).url).toContain('cursor=page-2');
+    expect((fetchMock.mock.calls[0][0] as Request).url).not.toContain('cursor=');
+  });
+
+  it('throws KnowledgeGraphError if hasMore=true but nextCursor is null', async () => {
+    mockFetch(200, { data: [], pagination: { hasMore: true, nextCursor: null } });
     await expect(new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3'))
       .rejects.toThrow(KnowledgeGraphError);
+  });
+
+  it('throws KnowledgeGraphError if the API repeats a cursor', async () => {
+    mockFetch(200, { data: [], pagination: { hasMore: true, nextCursor: 'same-page' } });
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3').catch((e) => e);
+    expect(err).toBeInstanceOf(KnowledgeGraphError);
+    expect(err.message).toContain('repeated');
   });
 });
 
@@ -182,4 +391,5 @@ describe('KnowledgeGraphClient - getLearningComponentsByCode', () => {
     expect(result.components[0].description).toBe('LC one');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
-});
+
+  });


### PR DESCRIPTION
First of four foundational SDK PRs preparing the batch CLI to run Math Standards Alignment over CSV. Scope: the Knowledge Graph client and its evaluator call sites.

## Three fixes
1. **Pagination** — `getStandardsByGrade` hard-threw on any grade with >500 standards; now walks cursors.
2. **Code normalization** — the KG matches codes case-insensitively, so `3.md.c.7.d` and `3.MD.C.7.d` were the same standard billed as two cache entries and two round trips.
3. **Ambiguity** — one code can match several standards; the client picked the first silently. Now surfaced via `ambiguous`.

## Validated against the KG (read-only scan), not assumed
| Fix | Evidence (Mathematics) |
|---|---|
| Pagination | 16 (jurisdiction, grade) buckets exceed 500 standards (max 1,127) — every one hard-threw before. |
| Normalization | 25% of codes (11,702 / 46,359) contain lowercase — echoing the uppercased lookup key would corrupt a quarter of reported codes. |
| Ambiguity | 1,950 / 43,019 (jurisdiction, code) pairs match multiple standards; 82 still genuinely ambiguous after dropping zero-LC and duplicate candidates. E.g. Utah `F.IF.7.b` → 5 standards, distinguishable only by course (not queryable via search) — so detection is the only lever. |

## Compatibility
No change to published exports — the package exposes only `.` and `./batch`; `KnowledgeGraphClient` / `StandardInfoOptions` are not published entry points. The one break vector is a consumer holding a *typed* mock of the `@internal` `_kgClient` seam: `StandardInfo` gained required `statementCode` / `normalizedCode`, `getStandardCandidates` / `getLearningComponentSet` are new, and `StandardInfoOptions.limit` is gone. Cast mocks (`as unknown as KnowledgeGraphClient`, as our tests do) are unaffected.

## Key design notes
- **`limit` removed from `StandardInfoOptions`**; the request now fixes `limit: 50`. The endpoint default is 5 (not the cap), so omitting it truncated candidate lists that reach 40 — and the cache key excluded `limit`, so a caller-set value poisoned shared entries.
- **`getStandardInfo` is unchanged externally** — first match, sets `ambiguous`. The cache holds every candidate so the #149 resolver reuses one request. The evaluator's three `limit: 1` call sites (which made ambiguity unreachable on the live path) are updated, and it now warns with the chosen uuid/description on an ambiguous code.
- **`getLearningComponentSet` → `{ components, undescribedCount }`** distinguishes an unauthored standard from one whose components lack descriptions (alignment is judged from that text). `getLearningComponents` is unchanged and still returns evaluable components only.
- **`evaluateByGrade`**: the >500 throw was the de-facto fan-out cap; removing it, a 1,127-standard grade × 10 questions ≈ 11k LLM calls. Rather than re-cap (which would re-break the grades this fixes), it now **warns above 500 projected pairs**; hard limits stay in the batch layer. It also dedupes the code list, fixing duplicate `byStandard` rows (LLM cost was already unaffected — only the report).
- Latent fix: the `getStandardInfo` cache key omitted `academicSubject`, so the same code under Mathematics vs ELA returned whichever landed first.

## Verification
`lint` (0 errors), `typecheck`, `test:unit` — 343 passing (KG suite 19 → 40). Stryker: 82% on covered code (149 killed, 33 survivors).
