### PR TITLE
feat: add public StandardsCatalog for listing and validating academic standards

### DIFF
--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -164,9 +164,21 @@ export class NetworkError extends APIError {
  * Knowledge Graph error - thrown when KG API calls fail
  */
 export class KnowledgeGraphError extends EvaluatorError {
-  constructor(message: string, public readonly statusCode?: number) {
-    super(message, 'KNOWLEDGE_GRAPH_ERROR');
+  constructor(message: string, public readonly statusCode?: number, code = 'KNOWLEDGE_GRAPH_ERROR') {
+    super(message, code);
     this.name = 'KnowledgeGraphError';
+  }
+}
+
+/**
+ * Thrown when a statement code does not exist in the requested jurisdiction.
+ * Distinct from other KG failures because it reflects the caller's input rather
+ * than the service.
+ */
+export class StandardNotFoundError extends KnowledgeGraphError {
+  constructor(message: string, public readonly statementCode: string) {
+    super(message, undefined, 'STANDARD_NOT_FOUND');
+    this.name = 'StandardNotFoundError';
   }
 }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -18,10 +18,20 @@ export {
   NetworkError,
   TimeoutError,
   KnowledgeGraphError,
+  StandardNotFoundError,
 } from './errors.js';
 
 // Knowledge Graph
-export { Jurisdiction } from './knowledge-graph/index.js';
+export { Jurisdiction, StandardsCatalog, normalizeStatementCode } from './knowledge-graph/index.js';
+export type {
+  StandardsCatalogConfig,
+  StandardsLookupOptions,
+  CodeValidation,
+  CodeResolutionStatus,
+  StandardCandidate,
+  AcademicStandard,
+  StandardInfo,
+} from './knowledge-graph/index.js';
 
 // Logger
 export type { Logger, LogContext } from './logger.js';

--- a/sdks/typescript/src/knowledge-graph/client.ts
+++ b/sdks/typescript/src/knowledge-graph/client.ts
@@ -2,6 +2,7 @@ import pLimit from 'p-limit';
 import createClient, { type Middleware } from 'openapi-fetch';
 import {
   KnowledgeGraphError,
+  StandardNotFoundError,
   AuthenticationError,
   RateLimitError,
   NetworkError,
@@ -131,7 +132,7 @@ export class KnowledgeGraphClient {
       if (this.standardInfoCache.get(cacheKey) === p) this.standardInfoCache.delete(cacheKey);
       // Thrown per caller, not inside the shared request, so concurrent callers with
       // different spellings each see their own in the message.
-      throw new KnowledgeGraphError(`Standard not found: "${statementCode}"`);
+      throw new StandardNotFoundError(`Standard not found: "${statementCode}"`, normalized);
     }
     // Copies: a caller sorting these to choose would otherwise reorder the cache.
     return candidates.map((c) => ({ ...c }));

--- a/sdks/typescript/src/knowledge-graph/index.ts
+++ b/sdks/typescript/src/knowledge-graph/index.ts
@@ -2,3 +2,11 @@ export type { AcademicStandard, LearningComponent, StandardInfo } from './types.
 export { Jurisdiction } from './types.js';
 export { KnowledgeGraphClient, normalizeStatementCode } from './client.js';
 export type { StandardInfoOptions, StandardsByGradeOptions } from './client.js';
+export { StandardsCatalog } from './standards-catalog.js';
+export type {
+  StandardsCatalogConfig,
+  StandardsLookupOptions,
+  CodeValidation,
+  CodeResolutionStatus,
+  StandardCandidate,
+} from './standards-catalog.js';

--- a/sdks/typescript/src/knowledge-graph/standards-catalog.ts
+++ b/sdks/typescript/src/knowledge-graph/standards-catalog.ts
@@ -1,0 +1,313 @@
+import pLimit from 'p-limit';
+import {
+  ConfigurationError,
+  StandardNotFoundError,
+  AuthenticationError,
+  ValidationError,
+  KnowledgeGraphError,
+} from '../errors.js';
+import { KnowledgeGraphClient, normalizeStatementCode, STANDARD_SEARCH_LIMIT } from './client.js';
+import { Jurisdiction, type AcademicStandard, type StandardInfo } from './types.js';
+
+/** From evals/standards/math-question-alignment/input_schema.json. */
+const MAX_STATEMENT_CODE_LENGTH = 50;
+
+/** Rejects locally what the KG cannot usefully answer. Returns null when the code is plausible. */
+function localCodeProblem(normalizedCode: string): string | null {
+  if (normalizedCode === '') return 'Statement code is empty';
+  if (normalizedCode.length > MAX_STATEMENT_CODE_LENGTH) {
+    return `Statement code exceeds ${MAX_STATEMENT_CODE_LENGTH} characters — check for a mis-split column`;
+  }
+  return null;
+}
+
+export interface StandardsCatalogConfig {
+  /** Learning Commons platform API key, used for Knowledge Graph access. */
+  platformApiKey: string;
+  /**
+   * Default subject filter for all lookups (e.g. 'Mathematics'). No default,
+   * because omitting it makes the result subject-dependent rather than wrong in a
+   * predictable way: Multi-State returns standards across subjects, while another
+   * jurisdiction resolves to whichever of its per-subject frameworks comes first.
+   */
+  academicSubject?: string;
+  /** Max concurrent Knowledge Graph requests. Defaults to 20. */
+  concurrency?: number;
+}
+
+export interface StandardsLookupOptions {
+  /** Defaults to Multi-State (Common Core). */
+  jurisdiction?: Jurisdiction;
+  /** Overrides the catalog-level academicSubject for this call. */
+  academicSubject?: string;
+}
+
+/**
+ * A statement code does not always identify one standard: a jurisdiction may reuse
+ * the same code across courses. These outcomes distinguish the cases a caller must
+ * act on differently.
+ *
+ * - `resolved` — exactly one candidate carries learning components.
+ * - `no-learning-components` — the code exists but nothing is authored against it,
+ *   so an evaluation would score 0 of 0. Not a failure, and not non-alignment.
+ * - `ambiguous` — several candidates carry *different* learning components; the
+ *   caller must pick a `uuid` from `candidates`.
+ * - `not-found` — no such code in this jurisdiction.
+ * - `unchecked` — no verdict could be reached, so this says nothing about the code.
+ *   Either the lookup failed (network, 429, 5xx) or it succeeded but its answer is
+ *   not supportable — a candidate list capped at the search limit where none of the
+ *   visible candidates had learning components. Check `error` for which.
+ */
+export type CodeResolutionStatus =
+  | 'resolved'
+  | 'no-learning-components'
+  | 'ambiguous'
+  | 'not-found'
+  | 'unchecked';
+
+/** One standard a code matched, with the learning components attached to it. */
+export interface StandardCandidate extends StandardInfo {
+  learningComponentCount: number;
+}
+
+export interface CodeValidation {
+  /** The code exactly as supplied by the caller. */
+  input: string;
+  /** The KG's spelling when resolved; otherwise the normalized form. */
+  statementCode: string;
+  /** Canonical lookup key — dedupe and join on this. */
+  normalizedCode: string;
+  status: CodeResolutionStatus;
+  /** The chosen standard, when `status` is `resolved`. */
+  uuid?: string;
+  /** Echoed so a wrong-but-resolvable code is visible to the user. */
+  description?: string;
+  /**
+   * Populated when `status` is `ambiguous`: every candidate with learning
+   * components, so the caller can choose one by `uuid`.
+   */
+  candidates?: StandardCandidate[];
+  /** True when the candidate list may have been cut off at the search limit. */
+  truncated?: boolean;
+  /** Present unless `status` is `resolved`. */
+  error?: string;
+}
+
+/**
+ * Read-only access to the Learning Commons academic standards catalog.
+ *
+ * Wraps the Knowledge Graph client so callers get standards lookup without
+ * depending on the client's cache or concurrency internals.
+ */
+export class StandardsCatalog {
+  private readonly kg: KnowledgeGraphClient;
+  private readonly academicSubject?: string;
+  private readonly concurrency: number;
+
+  constructor(config: StandardsCatalogConfig) {
+    if (!config.platformApiKey?.trim()) {
+      throw new ConfigurationError('platformApiKey is required to access the standards catalog.');
+    }
+    const concurrency = config.concurrency ?? 20;
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new ConfigurationError(`concurrency must be a positive integer, received ${config.concurrency}`);
+    }
+    // Whitespace would be sent as a subject filter and silently match nothing.
+    const academicSubject = config.academicSubject?.trim();
+
+    this.concurrency = concurrency;
+    this.kg = new KnowledgeGraphClient(config.platformApiKey, concurrency);
+    this.academicSubject = academicSubject || undefined;
+  }
+
+  /** All instructional standards for a grade, across every result page. */
+  listStandards(grade: string, opts?: StandardsLookupOptions): Promise<AcademicStandard[]> {
+    return this.kg.getStandardsByGrade(grade, {
+      jurisdiction: opts?.jurisdiction ?? Jurisdiction.MultiState,
+      academicSubject: opts?.academicSubject ?? this.academicSubject,
+    });
+  }
+
+  /**
+   * Resolve a single statement code. Throws `ValidationError` for a code the KG
+   * cannot answer for, and `StandardNotFoundError` when it does not exist.
+   */
+  // async so a rejected code rejects rather than throwing synchronously, which
+  // would force callers into both try/catch and .catch().
+  async getStandard(statementCode: string, opts?: StandardsLookupOptions): Promise<StandardInfo> {
+    const problem = localCodeProblem(normalizeStatementCode(statementCode));
+    if (problem) throw new ValidationError(problem);
+
+    return this.kg.getStandardInfo(statementCode, {
+      jurisdiction: opts?.jurisdiction ?? Jurisdiction.MultiState,
+      academicSubject: opts?.academicSubject ?? this.academicSubject,
+    });
+  }
+
+  /**
+   * Resolve a code to the one standard worth evaluating, discarding candidates with
+   * no learning components.
+   *
+   * Candidates sharing an identical learning-component set are interchangeable, so
+   * any of them resolves. Only differing sets are genuinely `ambiguous`; comparing
+   * descriptions is not sufficient, since codes exist whose candidates read
+   * identically but carry different components.
+   *
+   * Throws only for failures that doom every lookup (`AuthenticationError`,
+   * `ConfigurationError`); anything else yields `unchecked`.
+   */
+  async resolveStandard(
+    statementCode: string,
+    opts?: StandardsLookupOptions,
+  ): Promise<CodeValidation> {
+    const normalized = normalizeStatementCode(statementCode);
+    const base = { input: statementCode, statementCode: normalized, normalizedCode: normalized };
+
+    const problem = localCodeProblem(normalized);
+    if (problem) return { ...base, status: 'not-found', error: problem };
+
+    const lookup = {
+      jurisdiction: opts?.jurisdiction ?? Jurisdiction.MultiState,
+      academicSubject: opts?.academicSubject ?? this.academicSubject,
+    };
+
+    try {
+      const found = await this.kg.getStandardCandidates(normalized, lookup);
+      const truncated = found.length === STANDARD_SEARCH_LIMIT;
+
+      const resolved = await Promise.all(
+        found.map(async (candidate) => {
+          const components = await this.kg.getLearningComponents(candidate.uuid);
+          return {
+            candidate: { ...candidate, learningComponentCount: components.length },
+            signature: components.map((c) => c.identifier).sort().join('|'),
+          };
+        }),
+      );
+
+      const populated = resolved.filter((r) => r.candidate.learningComponentCount > 0);
+      const withComponents = populated.map((r) => r.candidate);
+      const distinctSets = new Set(populated.map((r) => r.signature));
+
+      if (withComponents.length === 0) {
+        // A truncated list cannot support the definitive claim: an unseen candidate
+        // beyond the cap may well carry components.
+        if (truncated) {
+          return {
+            ...base,
+            statementCode: found[0].statementCode,
+            status: 'unchecked',
+            truncated: true,
+            error:
+              `None of the first ${STANDARD_SEARCH_LIMIT} matches have learning components, ` +
+              'and the candidate list was capped, so others may',
+          };
+        }
+        return {
+          ...base,
+          statementCode: found[0].statementCode,
+          status: 'no-learning-components',
+          uuid: found[0].uuid,
+          ...(found[0].description !== undefined ? { description: found[0].description } : {}),
+          error: 'No learning components are authored against this standard',
+        };
+      }
+
+      if (withComponents.length === 1 || distinctSets.size === 1) {
+        const chosen = withComponents[0];
+        return {
+          ...base,
+          statementCode: chosen.statementCode,
+          status: 'resolved',
+          uuid: chosen.uuid,
+          ...(chosen.description !== undefined ? { description: chosen.description } : {}),
+          ...(truncated ? { truncated: true } : {}),
+        };
+      }
+
+      // One representative per distinct component set: candidates sharing a set are
+      // interchangeable, so offering all of them would overstate the real choice.
+      const bySignature = new Map<string, StandardCandidate>();
+      for (const { signature, candidate } of populated) {
+        if (!bySignature.has(signature)) bySignature.set(signature, candidate);
+      }
+      const choices = [...bySignature.values()];
+
+      return {
+        ...base,
+        statementCode: choices[0].statementCode,
+        status: 'ambiguous',
+        candidates: choices,
+        ...(truncated ? { truncated: true } : {}),
+        error:
+          `Matched ${choices.length} standards with different learning components — ` +
+          'pass a uuid to choose one',
+      };
+    } catch (err) {
+      if (err instanceof StandardNotFoundError) {
+        return { ...base, status: 'not-found', error: err.message };
+      }
+      if (err instanceof AuthenticationError || err instanceof ConfigurationError) {
+        throw err;
+      }
+      // A 400 means the request itself was malformed. `jurisdiction` is enum-typed,
+      // so the realistic cause is an unrecognised `academicSubject` — which fails
+      // identically for every code. Not fatal, because a 400 could still be specific
+      // to one code, and aborting would discard every other result.
+      if (err instanceof KnowledgeGraphError && err.statusCode === 400) {
+        return {
+          ...base,
+          status: 'unchecked',
+          error:
+            'Knowledge Graph rejected the request as malformed (400) — check academicSubject ' +
+            `and jurisdiction, which fail for every code when wrong. ${err.message}`,
+        };
+      }
+      return { ...base, status: 'unchecked', error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Check many codes at once. Returns one result per distinct normalized code, in
+   * first-seen input order; repeats cost one request.
+   *
+   * Only `AuthenticationError` and `ConfigurationError` throw, since those doom
+   * every other lookup identically. Other failures yield `'unchecked'`.
+   */
+  async validateCodes(
+    statementCodes: string[],
+    opts?: StandardsLookupOptions,
+  ): Promise<CodeValidation[]> {
+    // First-seen input wins, so the reported `input` matches what the user wrote.
+    const distinct = new Map<string, string>();
+    for (const code of statementCodes) {
+      const normalized = normalizeStatementCode(code);
+      if (!distinct.has(normalized)) distinct.set(normalized, code);
+    }
+
+    // A bad key fails every code identically, so stop scheduling once one throws.
+    // The check must sit behind the limiter: without it every lookup would already
+    // have been issued before the first rejection arrived.
+    const limit = pLimit(this.concurrency);
+    let fatal: unknown;
+
+    const settled = await Promise.allSettled(
+      [...distinct.values()].map((input) =>
+        limit(async (): Promise<CodeValidation> => {
+          if (fatal !== undefined) throw fatal;
+          try {
+            return { ...(await this.resolveStandard(input, opts)), input };
+          } catch (err) {
+            fatal = err;
+            throw err;
+          }
+        }),
+      ),
+    );
+
+    const rejected = settled.find((s): s is PromiseRejectedResult => s.status === 'rejected');
+    if (rejected) throw rejected.reason;
+
+    return (settled as PromiseFulfilledResult<CodeValidation>[]).map((s) => s.value);
+  }
+}

--- a/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StandardsCatalog } from '../../../src/knowledge-graph/standards-catalog.js';
+import { Jurisdiction } from '../../../src/knowledge-graph/types.js';
+import { ConfigurationError, AuthenticationError, ValidationError } from '../../../src/errors.js';
+
+function okResponse(body: unknown) {
+  const text = JSON.stringify(body);
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(text),
+  };
+}
+
+function errorResponse(status: number, body = 'error') {
+  return {
+    ok: false,
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(body),
+  };
+}
+
+beforeEach(() => { vi.unstubAllGlobals(); });
+
+const API_KEY = 'test-key';
+const catalog = () => new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: 'Mathematics' });
+
+/** One learning component per identifier, in the paginated shape the LC endpoint returns. */
+function lcPage(...identifiers: string[]) {
+  return {
+    data: identifiers.map((identifier) => ({ identifier, description: `LC ${identifier}` })),
+    pagination: { hasMore: false, nextCursor: null },
+  };
+}
+
+/**
+ * Resolution reads the search endpoint and then the learning components of each
+ * candidate, so tests must answer both. `lcsByUuid` maps a candidate uuid to its
+ * learning-component identifiers; a uuid absent from the map has none.
+ */
+function stubResolution(candidates: unknown[], lcsByUuid: Record<string, string[]> = {}) {
+  const fetchMock = vi.fn().mockImplementation((req: Request) => {
+    const { url } = req;
+    if (url.includes('/learning-components')) {
+      const uuid = decodeURIComponent(url.split('/academic-standards/')[1].split('/')[0]);
+      return Promise.resolve(okResponse(lcPage(...(lcsByUuid[uuid] ?? []))));
+    }
+    return Promise.resolve(okResponse(candidates));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('StandardsCatalog - construction', () => {
+  it.each(['', '   '])('throws ConfigurationError for a blank platform API key (%j)', (platformApiKey) => {
+    expect(() => new StandardsCatalog({ platformApiKey })).toThrow(ConfigurationError);
+  });
+
+  it.each([0, -1, 2.5])('rejects concurrency %s with a clear error rather than a p-limit crash', (concurrency) => {
+    expect(() => new StandardsCatalog({ platformApiKey: API_KEY, concurrency })).toThrow(
+      /concurrency must be a positive integer/,
+    );
+  });
+
+  it.each(['   ', 'x'.repeat(51)])(
+    'getStandard rejects a code the KG cannot answer for (%j) without a request',
+    async (code) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      await expect(catalog().getStandard(code)).rejects.toThrow(ValidationError);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('treats a whitespace-only academicSubject as absent rather than filtering on it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [], pagination: { hasMore: false } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: '   ' }).listStandards('3');
+    expect((fetchMock.mock.calls[0][0] as Request).url).not.toContain('academicSubject');
+  });
+});
+
+describe('StandardsCatalog - listStandards', () => {
+  it('returns standards for a grade and applies the subject filter', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({
+      data: [{ caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.D', gradeLevel: ['3'] }],
+      pagination: { hasMore: false, nextCursor: null },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await catalog().listStandards('3');
+    expect(results).toHaveLength(1);
+    expect(results[0].statementCode).toBe('3.MD.C.7.D');
+    const url = (fetchMock.mock.calls[0][0] as Request).url;
+    expect(url).toContain('academicSubject=Mathematics');
+    expect(url).toContain('normalizedStatementType=Standard');
+  });
+
+  it('accumulates across cursor pages', async () => {
+    let call = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      call++;
+      return Promise.resolve(okResponse({
+        data: [{ caseIdentifierUUID: `u${call}`, statementCode: `3.MD.C.7.${call}`, gradeLevel: ['3'] }],
+        pagination: { hasMore: call === 1, nextCursor: call === 1 ? 'p2' : null },
+      }));
+    }));
+    const results = await catalog().listStandards('3');
+    expect(results).toHaveLength(2);
+  });
+
+  it('resolves a non-Multi-State framework before listing', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(okResponse({ data: [{ caseIdentifierUUID: 'tx-framework' }] }))
+      .mockResolvedValueOnce(okResponse({ data: [], pagination: { hasMore: false, nextCursor: null } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await catalog().listStandards('3', { jurisdiction: Jurisdiction.Texas });
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('/standards-frameworks');
+    expect((fetchMock.mock.calls[1][0] as Request).url).toContain('tx-framework');
+  });
+
+  it('per-call academicSubject overrides the catalog default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [], pagination: { hasMore: false } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await catalog().listStandards('3', { academicSubject: 'English Language Arts' });
+    expect((fetchMock.mock.calls[0][0] as Request).url).toContain('academicSubject=English%20Language%20Arts');
+  });
+});
+
+describe('StandardsCatalog - validateCodes', () => {
+  it('resolves a known code and echoes the description', async () => {
+    stubResolution([{ caseIdentifierUUID: 'u1', description: 'Recognize area as additive' }], { u1: ['lc-1'] });
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('resolved');
+    expect(result.input).toBe('3.MD.C.7.d');
+    expect(result.normalizedCode).toBe('3.MD.C.7.D');
+    expect(result.uuid).toBe('u1');
+    expect(result.description).toBe('Recognize area as additive');
+  });
+
+  it('reports the KG canonical spelling, not the uppercased lookup key', async () => {
+    stubResolution([{ caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d' }], { u1: ['lc-1'] });
+    const [result] = await catalog().validateCodes(['3.md.c.7.D']);
+    expect(result.statementCode).toBe('3.MD.C.7.d');
+    expect(result.normalizedCode).toBe('3.MD.C.7.D');
+  });
+
+  it('marks an unknown code not-found without throwing', async () => {
+    stubResolution([]);
+    const [result] = await catalog().validateCodes(['X.YZ.A.1']);
+    expect(result.status).toBe('not-found');
+    expect(result.error).toContain('Standard not found');
+    expect(result.uuid).toBeUndefined();
+  });
+
+  it('reports every bad code rather than failing on the first', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((req: Request) => {
+      if (req.url.includes('/learning-components')) return Promise.resolve(okResponse(lcPage('lc-1')));
+      return Promise.resolve(req.url.includes('GOOD') ? okResponse([{ caseIdentifierUUID: 'u1' }]) : okResponse([]));
+    }));
+    const results = await catalog().validateCodes(['BAD.1', 'GOOD.1', 'BAD.2']);
+    expect(results.map((r) => r.status)).toEqual(['not-found', 'resolved', 'not-found']);
+  });
+
+  it('discards candidates with no learning components and resolves the survivor', async () => {
+    stubResolution(
+      [{ caseIdentifierUUID: 'empty' }, { caseIdentifierUUID: 'populated', description: 'the real one' }],
+      { populated: ['lc-1', 'lc-2'] },
+    );
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('resolved');
+    expect(result.uuid).toBe('populated');
+    expect(result.description).toBe('the real one');
+  });
+
+  it('treats candidates sharing a learning-component set as interchangeable', async () => {
+    stubResolution([{ caseIdentifierUUID: 'a' }, { caseIdentifierUUID: 'b' }], {
+      a: ['lc-1', 'lc-2'],
+      b: ['lc-2', 'lc-1'],
+    });
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('resolved');
+    expect(result.candidates).toBeUndefined();
+  });
+
+  it('offers one candidate per distinct component set, not per matching standard', async () => {
+    // 'dup' shares sec-1's component set, so it is not a separate choice and must
+    // not inflate either the candidate list or the count in the message.
+    stubResolution(
+      [
+        { caseIdentifierUUID: 'sec-1', description: 'Graph exponential functions' },
+        { caseIdentifierUUID: 'dup', description: 'Graph exponential functions, other course' },
+        { caseIdentifierUUID: 'precalc', description: 'Define a curve parametrically' },
+      ],
+      { 'sec-1': ['lc-1'], dup: ['lc-1'], precalc: ['lc-9', 'lc-8'] },
+    );
+    const [result] = await catalog().validateCodes(['F.IF.7.b']);
+    expect(result.status).toBe('ambiguous');
+    expect(result.candidates?.map((c) => c.uuid)).toEqual(['sec-1', 'precalc']);
+    expect(result.candidates?.map((c) => c.learningComponentCount)).toEqual([1, 2]);
+    expect(result.error).toContain('Matched 2 standards');
+    expect(result.error).toContain('pass a uuid');
+  });
+
+  it('distinguishes a standard with no learning components from a bad code', async () => {
+    stubResolution([{ caseIdentifierUUID: 'u1', description: 'real but unauthored' }]);
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('no-learning-components');
+    expect(result.uuid).toBe('u1');
+    expect(result.error).toContain('No learning components');
+  });
+
+  it('flags a candidate list that hit the search limit as possibly truncated', async () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({ caseIdentifierUUID: `u${i}` }));
+    stubResolution(many, { u0: ['lc-1'] });
+    const [result] = await catalog().validateCodes(['PS.7']);
+    expect(result.status).toBe('resolved');
+    expect(result.truncated).toBe(true);
+  });
+
+  it('will not claim no-learning-components when the candidate list was capped', async () => {
+    // An unseen candidate past the cap may carry components, so the definitive
+    // answer is unsupportable.
+    const many = Array.from({ length: 50 }, (_, i) => ({ caseIdentifierUUID: `u${i}` }));
+    stubResolution(many);
+    const [result] = await catalog().validateCodes(['PS.7']);
+    expect(result.status).toBe('unchecked');
+    expect(result.truncated).toBe(true);
+    expect(result.error).toContain('capped');
+  });
+
+  it('rejects an over-long code locally without issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const [result] = await catalog().validateCodes(['x'.repeat(51)]);
+    expect(result.status).toBe('not-found');
+    expect(result.error).toContain('exceeds 50 characters');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('dedupes case and whitespace variants to one request and one result', async () => {
+    const fetchMock = stubResolution([{ caseIdentifierUUID: 'u1' }], { u1: ['lc-1'] });
+    const results = await catalog().validateCodes(['3.MD.C.7.d', '3.md.c.7.D', '  3.MD.C.7.D  ']);
+    expect(results).toHaveLength(1);
+    // One search plus one learning-component fetch, both cached across variants.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(results[0].input).toBe('3.MD.C.7.d');
+  });
+
+  it('preserves input order of distinct codes', async () => {
+    stubResolution([{ caseIdentifierUUID: 'u1' }], { u1: ['lc-1'] });
+    const results = await catalog().validateCodes(['C.3', 'A.1', 'B.2']);
+    expect(results.map((r) => r.normalizedCode)).toEqual(['C.3', 'A.1', 'B.2']);
+  });
+
+  it('marks an empty code not-found without issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const [result] = await catalog().validateCodes(['   ']);
+    expect(result.status).toBe('not-found');
+    expect(result.error).toContain('empty');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('stops issuing lookups once a fatal error is seen', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse(401, 'Unauthorized'));
+    vi.stubGlobal('fetch', fetchMock);
+    const codes = Array.from({ length: 40 }, (_, i) => `CODE.${i}`);
+
+    await expect(
+      new StandardsCatalog({ platformApiKey: API_KEY, concurrency: 2 }).validateCodes(codes),
+    ).rejects.toThrow(AuthenticationError);
+
+    // Without the early abort every one of the 40 codes would have been requested.
+    expect(fetchMock.mock.calls.length).toBeLessThan(codes.length);
+  });
+
+  it('propagates authentication failures instead of blaming the code', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(401, 'Unauthorized')));
+    await expect(catalog().validateCodes(['3.MD.C.7.d'])).rejects.toThrow(AuthenticationError);
+  });
+
+  it('marks a rate-limited code unchecked rather than invalid', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(429, 'Too Many Requests')));
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('unchecked');
+    expect(result.error).toContain('rate limit');
+  });
+
+  it('marks a server error unchecked rather than invalid', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(500, 'Server Error')));
+    const [result] = await catalog().validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('unchecked');
+  });
+
+  it('points a 400 at the request filters rather than blaming the code', async () => {
+    // The realistic cause is an unrecognised academicSubject, which fails for every
+    // code — so "we could not check this" alone would send the user hunting the code.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(400, 'Bad Request')));
+    const [result] = await new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: 'Maths' })
+      .validateCodes(['3.MD.C.7.d']);
+    expect(result.status).toBe('unchecked');
+    expect(result.error).toContain('academicSubject');
+  });
+
+  it('keeps results for codes that resolved when another code hits a transient failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((req: Request) =>
+      req.url.includes('/learning-components')
+        ? Promise.resolve(okResponse(lcPage('lc-1')))
+        : Promise.resolve(
+            req.url.includes('FLAKY')
+              ? errorResponse(503, 'Service Unavailable')
+              : okResponse([{ caseIdentifierUUID: 'u1' }]),
+          ),
+    ));
+    const results = await catalog().validateCodes(['GOOD.1', 'FLAKY.1', 'GOOD.2']);
+    expect(results.map((r) => r.status)).toEqual(['resolved', 'unchecked', 'resolved']);
+  });
+
+  it('returns an empty array for no input', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await catalog().validateCodes([])).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why
Nothing public can list, validate, or resolve standards — `src/index.ts` exported only `Jurisdiction`. Batch can't check a `statement_codes` column before spending LLM calls, and consumers reimplement the REST calls (`demos/typescript/server/kg.ts` even carried the pagination bug #148 fixed).

## What
`StandardsCatalog` with `listStandards`, `getStandard`, `resolveStandard`, `validateCodes`. `KnowledgeGraphClient` stays internal so its cache/concurrency semantics don't become API.

## The resolver — five states, because a code isn't 1:1 with a standard
From a read-only scan of the production KG, Mathematics has **1,950 / 43,019** (jurisdiction, code) pairs matching multiple standards (worst case 40). E.g. Utah `F.IF.7.b` → five standards differing only by course, which search can't filter on — so it must be resolved client-side. `resolveStandard` fetches all candidates, drops those with no learning components, and classifies the rest:

| Status | Meaning | Math codes |
|---|---|---|
| `resolved` | one candidate has components — or several share an identical set, so any is equivalent | 732 + 245 |
| `no-learning-components` | code is real but nothing evaluable is authored (an eval scores 0/0 — not a failure, not non-alignment) | 891 |
| `ambiguous` | candidates carry *different* component sets; `candidates[]` is returned for the caller to pick a `uuid` | 82 |
| `not-found` | no such code in this jurisdiction | — |
| `unchecked` | no verdict reachable (network/5xx, or a truncated list where no visible candidate had components) — says nothing about the code | — |

That cuts genuine guessing from 1,950 to **82** and makes `0/0` mean one thing. Interchangeability is decided on component *sets*, not descriptions: 13 Math codes have candidates that read identically but carry different components (Georgia `A.PAR.4.1`: 14 vs 2).

## Compatibility
Additive to the published surface — new exports: `StandardsCatalog`, `CodeValidation`, `CodeResolutionStatus`, `StandardCandidate`, `StandardsCatalogConfig`. `KnowledgeGraphClient` stays unexported.

## Key design notes
- **`validateCodes` returns the five states, not a boolean** — a network blip becomes `unchecked`, not "bad code". Only `AuthenticationError`/`ConfigurationError` throw (they doom every lookup); it aborts scheduling on the first fatal and sits behind `pLimit`, so queued lookups short-circuit rather than firing N doomed requests.
- **`StandardNotFoundError` carries `STANDARD_NOT_FOUND`** (not the inherited `KNOWLEDGE_GRAPH_ERROR`), so consumers can separate a typo from an outage.
- **`truncated`** flags a candidate list that hit the search limit (50); 5 pairs across all subjects exceed it (max 87), and search takes no cursor.
- **No `academicSubject` default** (an unfiltered grade listing mixes math and ELA). The constructor rejects non-integer/<1 `concurrency` and treats a whitespace-only subject as absent; empty and >50-char codes are rejected locally.
- Cost: for the 95.5% single-candidate codes, one extra LC fetch the evaluator would make anyway; ambiguous codes cost one cached fetch per candidate.

## Not included
- The evaluator still evaluates the first match; wiring `_evaluateCore` to the resolver is a follow-up so the behavior change stays independently revertable (#148 warns on ambiguity meanwhile).
- Updating the demo — depends on the published `^0.8.0`, so post-release.

## Verification
`lint` (0 errors), `typecheck`, `test:unit` — 380 passing (33 in the catalog suite). Stryker: 88% on covered code (classification branches, early-abort, and both constructor validations killed).
