### PR TITLE
fix: isolate per-pair failures in evaluateItems instead of discarding the batch

### DIFF
--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -52,5 +52,6 @@ export {
   type StandardAlignmentResult,
   type QuestionItem,
   type QuestionBankResult,
+  type QuestionResult,
   type QuestionBankOptions,
 } from './math/standards-alignment.js';

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -38,6 +38,23 @@ export interface StandardAlignmentResult {
   alignedCount: number;
   totalCount: number;
   coarseFiltered?: boolean;
+  /**
+   * Set when this pair could not be evaluated. Produced only by evaluateItems and
+   * evaluateByGrade; evaluate() throws instead.
+   *
+   * Not evidence of non-alignment: alignedCount is 0 because nothing was
+   * measured, not because nothing aligned.
+   *
+   * `code` and `name` are both carried because subclasses can share a code, and a
+   * report grouping failures by kind needs the narrower one.
+   */
+  error?: {
+    message: string;
+    code?: string;
+    name?: string;
+    statusCode?: number;
+    retryable?: boolean;
+  };
 }
 
 export interface QuestionItem {
@@ -45,11 +62,15 @@ export interface QuestionItem {
   statementCodes: string[];
 }
 
+/** One question's results. `error` is set when the question itself could not be used. */
+export interface QuestionResult {
+  question: string;
+  standards: StandardAlignmentResult[];
+  error?: StandardAlignmentResult['error'];
+}
+
 export interface QuestionBankResult {
-  byQuestion: Array<{
-    question: string;
-    standards: StandardAlignmentResult[];
-  }>;
+  byQuestion: QuestionResult[];
   byStandard: Array<{
     statementCode: string;
     coveredBy: Array<{
@@ -58,10 +79,25 @@ export interface QuestionBankResult {
       totalCount: number;
     }>;
     coverageCount: number;
+    /**
+     * Denominators for coverageCount. The four sum to the number of questions, so a
+     * zero coverageCount can be attributed: measured and unaligned (evaluatedCount),
+     * never measured (errorCount, filteredCount, noComponentsCount).
+     */
+    evaluatedCount: number;
+    errorCount: number;
+    filteredCount: number;
+    /** Standard exists but nothing is authored against it, so nothing was measurable. */
+    noComponentsCount: number;
   }>;
 }
 
 export interface QuestionBankOptions {
+  /**
+   * Max concurrent LLM calls for this call only. Omit to share the evaluator-wide
+   * limit (config.concurrency); supplying it lets N concurrent calls each run this
+   * many in flight.
+   */
   concurrency?: number;
   useCoarseFilter?: boolean;
   onProgress?: (completed: number, total: number) => void;
@@ -97,6 +133,19 @@ const KG_SUBJECT = 'Mathematics';
  */
 const BY_GRADE_WARN_PAIRS = 500;
 
+/** Flattens a thrown value into the reportable shape, keeping what a report can group on. */
+function describeFailure(err: unknown): NonNullable<StandardAlignmentResult['error']> {
+  if (!(err instanceof Error)) return { message: String(err) };
+  const api = err as Partial<APIError>;
+  return {
+    message: err.message,
+    name: err.name,
+    ...(err instanceof EvaluatorError && err.code ? { code: err.code } : {}),
+    ...(typeof api.statusCode === 'number' ? { statusCode: api.statusCode } : {}),
+    ...(typeof api.retryable === 'boolean' ? { retryable: api.retryable } : {}),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Evaluator
 // ---------------------------------------------------------------------------
@@ -113,7 +162,8 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   private readonly kgClient: KnowledgeGraphClient;
   private readonly detailProvider: LLMProvider;
   private readonly coarseProvider: LLMProvider;
-  private readonly llmConcurrency: number;
+  // Instance-wide so concurrent evaluateItems calls share one budget.
+  private readonly llmLimit: ReturnType<typeof pLimit>;
 
   constructor(config: MathStandardsAlignmentEvaluatorConfig) {
     // If partnerKey isn't set, fall back to platformApiKey — same LC platform key,
@@ -127,7 +177,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     }
 
     this.kgClient = config._kgClient ?? new KnowledgeGraphClient(config.platformApiKey!, config.kgConcurrency ?? 20);
-    this.llmConcurrency = config.concurrency ?? 10;
+    this.llmLimit = pLimit(config.concurrency ?? 10);
 
     this.detailProvider = this.createConfiguredProvider(
       Provider.Anthropic,
@@ -169,17 +219,31 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     items: QuestionItem[],
     jurisdiction: Jurisdiction,
     options?: QuestionBankOptions,
-  ): Promise<Array<{ question: string; standards: StandardAlignmentResult[] }>> {
+  ): Promise<QuestionResult[]> {
     if (items.length === 0) return [];
-    items.forEach((item) => this.validateQuestion(item.question));
 
-    const dedupedItems = items.map((item) => ({
-      question: item.question,
-      statementCodes: [...new Set(item.statementCodes)],
-    }));
+    // Per item, not a precondition for the whole call — an invalid item's
+    // standards come back carrying the error.
+    const dedupedItems = items.map((item) => {
+      let validationError: EvaluatorError | undefined;
+      try {
+        this.validateQuestion(item.question);
+      } catch (err) {
+        // Only a domain error is a per-item validation failure. Anything else is a
+        // bug here, and turning it into a ValidationError would report it as bad
+        // user input.
+        if (!(err instanceof EvaluatorError)) throw err;
+        validationError = err;
+      }
+      return {
+        question: item.question,
+        statementCodes: [...new Set(item.statementCodes)],
+        validationError,
+      };
+    });
 
     const useCoarseFilter = options?.useCoarseFilter ?? false;
-    const bankLimit = pLimit(options?.concurrency ?? this.llmConcurrency);
+    const bankLimit = options?.concurrency != null ? pLimit(options.concurrency) : this.llmLimit;
 
     // Pre-fetch LC data for all unique codes — needed to report totalCount on coarse-filtered results.
     const allCodes = [...new Set(dedupedItems.flatMap((i) => i.statementCodes))];
@@ -196,13 +260,20 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       );
     }
 
-    // Coarse filter: per-item, against that item's own statementCodes.
+    // Coarse filter: per-item, against that item's own statementCodes. Invalid
+    // items get an empty set so they stay out of the progress denominator.
     let relevanceMaps: Map<number, Set<string>>;
     if (!useCoarseFilter) {
-      relevanceMaps = new Map(dedupedItems.map((item, i) => [i, new Set(item.statementCodes)]));
+      relevanceMaps = new Map(
+        dedupedItems.map((item, i) => [i, item.validationError ? new Set<string>() : new Set(item.statementCodes)]),
+      );
     } else {
       const filterResults = await Promise.all(
-        dedupedItems.map((item) => bankLimit(() => this.runCoarseFilter(item.question, item.statementCodes, jurisdiction))),
+        dedupedItems.map((item) =>
+          item.validationError
+            ? Promise.resolve(new Set<string>())
+            : bankLimit(() => this.runCoarseFilter(item.question, item.statementCodes, jurisdiction)),
+        ),
       );
       relevanceMaps = new Map(dedupedItems.map((_, i) => [i, filterResults[i]]));
     }
@@ -210,11 +281,29 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     const total = dedupedItems.reduce((sum, _, i) => sum + (relevanceMaps.get(i)?.size ?? 0), 0);
     let completed = 0;
 
-    const settled = await Promise.allSettled(
+    // Failures are isolated to the pair that caused them.
+    return Promise.all(
       dedupedItems.map(async (item, i) => {
+        if (item.validationError) {
+          const failure = describeFailure(item.validationError);
+          return {
+            question: item.question,
+            // Also at item level: an item with no statement codes has nowhere else to
+            // carry the failure, and the question itself is what failed.
+            error: failure,
+            standards: item.statementCodes.map((statementCode) => ({
+              statementCode,
+              learningComponents: [],
+              alignedCount: 0,
+              totalCount: 0,
+              error: failure,
+            })),
+          };
+        }
+
         const relevant = relevanceMaps.get(i) ?? new Set(item.statementCodes);
 
-        const standardSettled = await Promise.allSettled(
+        const standards = await Promise.all(
           item.statementCodes.map(async (code): Promise<StandardAlignmentResult> => {
             if (!relevant.has(code)) {
               const cached = lcCache.get(code);
@@ -226,33 +315,32 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
                 coarseFiltered: true,
               };
             }
-            const result = await bankLimit(() => this._evaluateCore(item.question, code, jurisdiction));
+            let result: StandardAlignmentResult;
+            try {
+              result = await bankLimit(() => this._evaluateCore(item.question, code, jurisdiction));
+            } catch (err) {
+              result = {
+                statementCode: code,
+                learningComponents: [],
+                alignedCount: 0,
+                // Report the real component count when the pre-fetch knows it, so an
+                // errored pair is not mistaken for a standard with no components.
+                totalCount: lcCache.get(code)?.components.length ?? 0,
+                error: describeFailure(err),
+              };
+            }
+
+            // Outside the try: counting inside it let a throwing callback discard a
+            // finished result, count the pair twice, and reject the whole call.
             completed++;
-            options?.onProgress?.(completed, total);
+            this.notifyProgress(options?.onProgress, completed, total);
             return result;
           }),
         );
 
-        const errors = standardSettled
-          .filter((s): s is PromiseRejectedResult => s.status === 'rejected')
-          .map((s) => s.reason instanceof Error ? s.reason : new Error(String(s.reason)));
-        if (errors.length > 0) throw errors[0];
-
-        return {
-          question: item.question,
-          standards: standardSettled.map((s) =>
-            s.status === 'fulfilled' ? s.value : { statementCode: '', learningComponents: [], alignedCount: 0, totalCount: 0 }
-          ),
-        };
+        return { question: item.question, standards };
       }),
     );
-
-    const errors = settled
-      .filter((s): s is PromiseRejectedResult => s.status === 'rejected')
-      .map((s) => s.reason instanceof Error ? s.reason : new Error(String(s.reason)));
-    if (errors.length > 0) throw errors[0];
-
-    return (settled as Array<PromiseFulfilledResult<{ question: string; standards: StandardAlignmentResult[] }>>).map((s) => s.value);
   }
 
   // -------------------------------------------------------------------------
@@ -308,12 +396,34 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     const byQuestion = await this.evaluateItems(items, jurisdiction, options);
 
     const byStandard = codes.map((code) => {
-      const coveredBy = byQuestion.flatMap(({ question, standards }) => {
-        const result = standards.find((s) => s.statementCode === code);
-        if (!result || result.alignedCount === 0) return [];
+      const results = byQuestion.map(({ question, standards }) => ({
+        question,
+        result: standards.find((s) => s.statementCode === code),
+      }));
+
+      const coveredBy = results.flatMap(({ question, result }) => {
+        // An errored pair measured nothing, so it is neither coverage nor
+        // evidence against it.
+        if (!result || result.error || result.alignedCount === 0) return [];
         return [{ question, alignedCount: result.alignedCount, totalCount: result.totalCount }];
       });
-      return { statementCode: code, coveredBy, coverageCount: coveredBy.length };
+
+      return {
+        statementCode: code,
+        coveredBy,
+        coverageCount: coveredBy.length,
+        // totalCount > 0 required: a standard with no learning components measured
+        // nothing, so counting it as evaluated would make "0 aligned of 1 evaluated"
+        // read as a judgement rather than an absence of data.
+        evaluatedCount: results.filter(
+          ({ result }) => result && !result.error && !result.coarseFiltered && result.totalCount > 0,
+        ).length,
+        errorCount: results.filter(({ result }) => result?.error).length,
+        filteredCount: results.filter(({ result }) => result?.coarseFiltered).length,
+        noComponentsCount: results.filter(
+          ({ result }) => result && !result.error && !result.coarseFiltered && result.totalCount === 0,
+        ).length,
+      };
     });
 
     return { byQuestion, byStandard };
@@ -515,6 +625,23 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         error: err instanceof Error ? err : new Error(String(err)),
       });
       return new Set(statementCodes);
+    }
+  }
+
+  /** A caller's progress callback must not be able to fail an evaluation. */
+  private notifyProgress(
+    onProgress: ((completed: number, total: number) => void) | undefined,
+    completed: number,
+    total: number,
+  ): void {
+    if (!onProgress) return;
+    try {
+      onProgress(completed, total);
+    } catch (err) {
+      this.logger.warn('onProgress callback threw; continuing', {
+        evaluator: EVALUATOR_ID,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
     }
   }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -103,6 +103,7 @@ export {
   type StandardAlignmentResult,
   type QuestionItem,
   type QuestionBankResult,
+  type QuestionResult,
   type QuestionBankOptions,
   Provider,
   type BaseEvaluatorConfig,

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -4,7 +4,7 @@ import {
   Jurisdiction,
   type MathStandardsAlignmentEvaluatorConfig,
 } from '../../../../src/evaluators/math/standards-alignment.js';
-import { ConfigurationError, ValidationError, APIError } from '../../../../src/errors.js';
+import { ConfigurationError, ValidationError, APIError, KnowledgeGraphError, RateLimitError } from '../../../../src/errors.js';
 import type { LLMProvider } from '../../../../src/providers/base.js';
 import type { KnowledgeGraphClient } from '../../../../src/knowledge-graph/client.js';
 
@@ -382,6 +382,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     const filtered = results[0].standards.find((s) => s.statementCode === '3.OA.A.1')!;
     expect(filtered.coarseFiltered).toBe(true);
     expect(filtered.learningComponents).toHaveLength(0);
+    // Reported from the pre-fetch, so "skipped" is not confused with "has none".
+    expect(filtered.totalCount).toBe(2);
 
     const evaluated = results[0].standards.find((s) => s.statementCode === '3.MD.C.7.d')!;
     expect(evaluated.coarseFiltered).toBeUndefined();
@@ -417,6 +419,28 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     const result = results[0].standards[0];
     expect(result.coarseFiltered).toBeUndefined();
     expect(result.learningComponents).toHaveLength(2);
+  });
+
+  it('reports the known component count on an errored pair when the pre-fetch has it', async () => {
+    // Otherwise totalCount 0 would read as "this standard has no components".
+    vi.mocked(mockProvider.generateStructured)
+      .mockResolvedValueOnce({
+        data: { standards: [{ standard: STATEMENT_CODE, relevant: true }] },
+        model: 'anthropic:claude-haiku-4-5-20251001', usage: { inputTokens: 50, outputTokens: 20 }, latencyMs: 200,
+      })
+      .mockRejectedValue(new APIError('rate limited', 429));
+
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE] }],
+      JURISDICTION,
+      { useCoarseFilter: true },
+    );
+
+    const errored = results[0].standards[0];
+    expect(errored.error?.message).toContain('rate limited');
+    expect(errored.alignedCount).toBe(0);
+    expect(errored.totalCount).toBe(2);
   });
 
   it('falls back to all standards relevant when coarse filter LLM throws', async () => {
@@ -575,5 +599,274 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
     await evaluator.evaluateByGrade([QUESTION], '5', Jurisdiction.California);
 
     expect(repo.getStandardsByGrade).toHaveBeenCalledWith('5', { jurisdiction: Jurisdiction.California, academicSubject: 'Mathematics' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error isolation
+// ---------------------------------------------------------------------------
+
+describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () => {
+  function failingCodeClient(badCode: string): KnowledgeGraphClient {
+    return makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockImplementation((code: string) =>
+        code === badCode
+          ? Promise.reject(new KnowledgeGraphError(`Standard not found: "${badCode}"`))
+          : Promise.resolve({ uuid: 'uuid-abc', description: 'Area additive', components: LC_COMPONENTS }),
+      ),
+    });
+  }
+
+  it('isolates a failing standard without discarding its siblings', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: failingCodeClient('BAD.CODE') }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE, 'BAD.CODE'] }],
+      JURISDICTION,
+    );
+
+    expect(results).toHaveLength(1);
+    const [good, bad] = results[0].standards;
+    expect(good.error).toBeUndefined();
+    expect(good.alignedCount).toBe(2);
+    expect(bad.error?.message).toContain('Standard not found');
+  });
+
+  it('attributes the error to the correct statementCode and carries a machine-readable code', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: failingCodeClient('BAD.CODE') }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE, 'BAD.CODE'] }],
+      JURISDICTION,
+    );
+
+    const errored = results[0].standards.filter((s) => s.error);
+    expect(errored).toHaveLength(1);
+    expect(errored[0].statementCode).toBe('BAD.CODE');
+    // A report needs to group failures by kind, not by message text.
+    expect(errored[0].error?.code).toBe('KNOWLEDGE_GRAPH_ERROR');
+    expect(errored[0].error?.name).toBe('KnowledgeGraphError');
+  });
+
+  it('carries statusCode and retryable through so a report can separate transient failures', async () => {
+    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(new RateLimitError('slow down'));
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE] }],
+      JURISDICTION,
+    );
+
+    expect(results[0].standards[0].error).toMatchObject({
+      name: 'RateLimitError',
+      code: 'RATE_LIMIT_ERROR',
+      statusCode: 429,
+      retryable: true,
+    });
+  });
+
+  it('does not discard other items when one item fails entirely', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: failingCodeClient('BAD.CODE') }));
+
+    const results = await evaluator.evaluateItems(
+      [
+        { question: 'Q1', statementCodes: ['BAD.CODE'] },
+        { question: 'Q2', statementCodes: [STATEMENT_CODE] },
+      ],
+      JURISDICTION,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].standards[0].error).toBeDefined();
+    expect(results[1].standards[0].error).toBeUndefined();
+    expect(results[1].standards[0].alignedCount).toBe(2);
+  });
+
+  it('surfaces an LLM failure as a per-pair error rather than rejecting', async () => {
+    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(new APIError('rate limited', 429));
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE] }],
+      JURISDICTION,
+    );
+
+    expect(results[0].standards[0].error?.message).toContain('rate limited');
+    expect(results[0].standards[0].alignedCount).toBe(0);
+  });
+
+  it('a throwing progress callback cannot corrupt results, counts, or the batch', async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const onProgress = vi.fn(() => { throw new Error('progress bar blew up'); });
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ logger }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE, 'OTHER.CODE'] }],
+      JURISDICTION,
+      { onProgress },
+    );
+
+    // Successful pairs stay successful, each pair is counted once, nothing rejects.
+    expect(results[0].standards.every((s) => s.error === undefined)).toBe(true);
+    expect(results[0].standards.every((s) => s.alignedCount === 2)).toBe(true);
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports progress for failed pairs too, so totals reconcile', async () => {
+    const repo = makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockRejectedValue(new KnowledgeGraphError('nope')),
+    });
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
+    const onProgress = vi.fn();
+
+    await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE, 'OTHER.CODE'] }],
+      JURISDICTION,
+      { onProgress },
+    );
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2);
+  });
+
+  it('evaluate() still throws for a single pair', async () => {
+    const repo = makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockRejectedValue(new KnowledgeGraphError('nope')),
+    });
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
+    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow();
+  });
+
+  it('isolates a validation failure to the offending item', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const results = await evaluator.evaluateItems(
+      [
+        { question: '', statementCodes: [STATEMENT_CODE] },
+        { question: QUESTION, statementCodes: [STATEMENT_CODE] },
+      ],
+      JURISDICTION,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].standards[0].error?.code).toBe('VALIDATION_ERROR');
+    // Same shape as every other failure, so grouping by name does not miss these.
+    expect(results[0].standards[0].error?.name).toBe('ValidationError');
+    expect(results[0].standards[0].statementCode).toBe(STATEMENT_CODE);
+    expect(results[1].standards[0].error).toBeUndefined();
+    expect(results[1].standards[0].alignedCount).toBe(2);
+  });
+
+  it('surfaces a validation failure even when the item has no statement codes', async () => {
+    // Nothing to map over, so without an item-level error the failure vanishes.
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const results = await evaluator.evaluateItems(
+      [{ question: '', statementCodes: [] }],
+      JURISDICTION,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].standards).toEqual([]);
+    expect(results[0].error).toMatchObject({ code: 'VALIDATION_ERROR', name: 'ValidationError' });
+  });
+
+  it('excludes an invalid item from the progress denominator', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+    const onProgress = vi.fn();
+
+    await evaluator.evaluateItems(
+      [
+        { question: '', statementCodes: [STATEMENT_CODE] },
+        { question: QUESTION, statementCodes: [STATEMENT_CODE] },
+      ],
+      JURISDICTION,
+      { onProgress },
+    );
+
+    expect(onProgress).toHaveBeenLastCalledWith(1, 1);
+  });
+
+  it('distinguishes zero coverage caused by errors from genuine non-alignment', async () => {
+    const repo = makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockRejectedValue(new KnowledgeGraphError('nope')),
+    });
+    const errored = await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }))
+      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+
+    expect(errored.byQuestion[0].standards[0].error).toBeDefined();
+    expect(errored.byStandard[0].coveredBy).toEqual([]);
+    expect(errored.byStandard[0]).toMatchObject({
+      coverageCount: 0, errorCount: 1, evaluatedCount: 0, noComponentsCount: 0,
+    });
+
+    // Same zero coverage, but measured: every LC came back unaligned.
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue({
+      ...MOCK_BATCH_RESPONSE,
+      data: {
+        evaluations: MOCK_BATCH_RESPONSE.data.evaluations.map((e) => ({ ...e, answer: 'No' })),
+      },
+    });
+    const unaligned = await new MathStandardsAlignmentEvaluator(makeConfig())
+      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+
+    expect(unaligned.byStandard[0]).toMatchObject({
+      coverageCount: 0, errorCount: 0, evaluatedCount: 1, noComponentsCount: 0,
+    });
+
+    // Third way to reach zero coverage: never evaluated because the filter skipped it.
+    vi.mocked(mockProvider.generateStructured).mockReset();
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue({
+      data: { standards: [{ standard: STATEMENT_CODE, relevant: false }] },
+      model: 'anthropic:claude-haiku-4-5-20251001', usage: { inputTokens: 50, outputTokens: 20 }, latencyMs: 200,
+    });
+    const filtered = await new MathStandardsAlignmentEvaluator(makeConfig())
+      .evaluateByGrade(['Q1'], '3', JURISDICTION, { useCoarseFilter: true });
+
+    expect(filtered.byStandard[0]).toMatchObject({
+      coverageCount: 0, errorCount: 0, evaluatedCount: 0, filteredCount: 1,
+    });
+
+    // Fourth way: the standard exists but has no learning components, so nothing was
+    // measured. Counting it as evaluated would read as a judgement.
+    const noComponents = makeMockKgClient({
+      getLearningComponentsByCode: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', components: [] }),
+    });
+    const unauthored = await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: noComponents }))
+      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+
+    // Its own counter, so all-zeros is never the only signal.
+    expect(unauthored.byStandard[0]).toMatchObject({
+      coverageCount: 0, errorCount: 0, evaluatedCount: 0, filteredCount: 0, noComponentsCount: 1,
+    });
+  });
+});
+
+describe('MathStandardsAlignmentEvaluator - shared concurrency', () => {
+  it('shares one LLM concurrency budget across concurrent evaluateItems calls', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    vi.mocked(mockProvider.generateStructured).mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight--;
+      return MOCK_BATCH_RESPONSE;
+    });
+
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ concurrency: 2 }));
+    const items = (prefix: string) =>
+      Array.from({ length: 4 }, (_, i) => ({ question: `${prefix}-${i}`, statementCodes: [STATEMENT_CODE] }));
+
+    await Promise.all([
+      evaluator.evaluateItems(items('A'), JURISDICTION),
+      evaluator.evaluateItems(items('B'), JURISDICTION),
+    ]);
+
+    // Exact: a per-call limiter would peak at 4, and "<= 2" alone would pass
+    // vacuously if everything serialized.
+    expect(peak).toBe(2);
   });
 });


### PR DESCRIPTION
Third of four foundational SDK PRs. Independent of #148/#149; rebased on current main (#148 merged).

**The bug:** `evaluateItems` collected per-pair outcomes with `Promise.allSettled`, then did `throw errors[0]` at both the pair and item level — so one typo'd code, one 429, or one malformed model response discarded every other pair's completed LLM work (**one bad row in 50 threw away the other 49**). The dead `{statementCode: '', ...}` fallback it left behind shows per-pair isolation was the original intent. `evaluateByGrade` inherits it and is the mode most likely to hit one dud standard in ~30.

## What changed
- Failing pairs return a result carrying `error` and the correct `statementCode` (recovered by index — the dead fallback used `''` because it had lost the mapping).
- Input validation is per item, not a whole-call precondition.
- `evaluate()` still throws — one pair wants an exception; 200 want a report.
- `byStandard` gains `evaluatedCount` / `errorCount` / `filteredCount` / `noComponentsCount`, which sum to the question count. `coverageCount: 0` previously conflated "all errored", "all filtered", and "genuinely unaligned" — presenting an unmeasured standard as uncovered.
- The LLM limiter moved to the instance (it was per-call, so N concurrent calls each got their own `pLimit(10)`).
- `error` carries `name`, `code`, `statusCode`, `retryable`, `message`, so a report can group failures by kind and separate transient ones.
- `onProgress` is counted once outside the try and runs behind a guard that logs and continues — a throwing callback can no longer discard a finished result or reject the whole call.

## Not marked breaking, deliberately
It is one strictly, but these methods have no external consumers (the only in-repo caller is the demo server, pinned to published `^0.8.0`), and `release-please-config.json` sets no `bump-minor-pre-major` — so a `!` would cut **1.0.0** and declare the SDK stable as a side effect of an error-handling fix. Add that setting first if a future change needs the marker. Old semantics: `standards.some(s => s.error)`.

## Downstream (demo server only; not until we bump its pin)
1. The shared instance limiter means a 30-standard request can delay the next interactive one — pass `options.concurrency` to opt out.
2. `/api/evaluate` relied on `evaluateItems` *rejecting* to return a 500; failures now resolve with per-standard `error` fields, so the handler must inspect them (follow-up).

## Verification
`lint` (0 errors), `typecheck`, `test:unit` — 361 passing. Stryker: 70.6% on covered code (216 killed, 90 survivors), every changed region fully killed.
