### PR TITLE
test: cover Anthropic provider override across all text-complexity evaluators

### DIFF
--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -53,6 +53,15 @@ export interface TelemetryOptions {
  * `ConfigurationError` at evaluation time when the provider rejects it.
  *
  * Results may vary; evaluators are validated against their recommended models.
+ *
+ * Two things to know before overriding:
+ *
+ * - The override is evaluator-wide, not per call site. `VocabularyEvaluator`
+ *   deliberately uses three models (Gemini 2.5 Pro for grades 3-4, GPT-4.1 for
+ *   5-12, GPT-4o for background knowledge); an override collapses all three.
+ * - `PurposeEvaluator` takes its model from the shared cross-language eval config
+ *   (`evals/prompts/purpose/config.json`), so overriding it diverges from that
+ *   rather than from a hardcoded default.
  */
 export interface ModelOverride {
   provider: Provider;

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -18,16 +18,13 @@ import { VocabularyEvaluator } from '../../src/evaluators/vocabulary.js';
 
 const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 
-// A missing key when integration tests were explicitly requested is a
-// misconfiguration, not a reason to quietly pass.
-if (RUN_INTEGRATION && !process.env.ANTHROPIC_API_KEY) {
-  throw new Error(
-    'ANTHROPIC_API_KEY is required when RUN_INTEGRATION_TESTS=true. ' +
-    'Set it, or unset RUN_INTEGRATION_TESTS to skip integration tests.',
-  );
-}
-
-const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+// Anthropic is an *optional* provider: no evaluator defaults to it, and CI
+// supplies only OPENAI/GOOGLE. So a missing key skips this suite rather than
+// failing a run that has keys for every other one — unlike the suites whose
+// provider key is required, which throw. Same policy as the optional keys in
+// math-standards-alignment.integration.test.ts.
+const describeIntegration =
+  RUN_INTEGRATION && process.env.ANTHROPIC_API_KEY ? describe : describe.skip;
 
 const TEST_TIMEOUT_MS = 3 * 60 * 1000;
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_TEST_MODEL ?? 'claude-haiku-4-5-20251001';

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { Provider, type BaseEvaluatorConfig } from '../../src/evaluators/base.js';
+import type { EvaluationResult } from '../../src/schemas/index.js';
+import { GradeLevelAppropriatenessEvaluator } from '../../src/evaluators/grade-level-appropriateness.js';
+import { ConventionalityEvaluator } from '../../src/evaluators/conventionality.js';
+import { SmkEvaluator } from '../../src/evaluators/smk.js';
+import { SentenceStructureEvaluator } from '../../src/evaluators/sentence-structure.js';
+import { PurposeEvaluator } from '../../src/evaluators/purpose.js';
+import { VocabularyEvaluator } from '../../src/evaluators/vocabulary.js';
+
+/**
+ * Anthropic provider integration tests (live API). Structured output on Anthropic is
+ * tool-call based, so only a live call proves the larger nested schemas round-trip.
+ * Verifies the provider works, not evaluation quality.
+ *
+ * `ANTHROPIC_API_KEY=... RUN_INTEGRATION_TESTS=true npm run test:integration`
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass.
+if (RUN_INTEGRATION && !process.env.ANTHROPIC_API_KEY) {
+  throw new Error(
+    'ANTHROPIC_API_KEY is required when RUN_INTEGRATION_TESTS=true. ' +
+    'Set it, or unset RUN_INTEGRATION_TESTS to skip integration tests.',
+  );
+}
+
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 3 * 60 * 1000;
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_TEST_MODEL ?? 'claude-haiku-4-5-20251001';
+const GRADE = '5';
+
+const SAMPLE_TEXT =
+  'The water cycle describes how water moves around our planet. When the sun heats lakes and ' +
+  'oceans, some water turns into vapour and rises into the air. High above the ground it cools ' +
+  'and forms clouds. Eventually the droplets grow heavy and fall back down as rain or snow, and ' +
+  'the cycle begins again.';
+
+function anthropicConfig(): BaseEvaluatorConfig {
+  return {
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
+    modelOverride: { provider: Provider.Anthropic, model: ANTHROPIC_MODEL },
+    telemetry: false,
+  };
+}
+
+/** Per-entry `run` so each evaluator is called with its real arity — GLA takes only `text`. */
+const EVALUATORS: Array<{
+  name: string;
+  run: (config: BaseEvaluatorConfig) => Promise<EvaluationResult<string, unknown>>;
+}> = [
+  {
+    name: 'GradeLevelAppropriateness',
+    run: (c) => new GradeLevelAppropriatenessEvaluator(c).evaluate(SAMPLE_TEXT),
+  },
+  { name: 'Conventionality', run: (c) => new ConventionalityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { name: 'Smk', run: (c) => new SmkEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { name: 'SentenceStructure', run: (c) => new SentenceStructureEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { name: 'Purpose', run: (c) => new PurposeEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { name: 'Vocabulary', run: (c) => new VocabularyEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+];
+
+describeIntegration('Anthropic provider — all text-complexity evaluators (live API)', () => {
+  for (const { name, run } of EVALUATORS) {
+    it(
+      `${name} completes on Anthropic and returns a structured result`,
+      async () => {
+        const result = await run(anthropicConfig());
+
+        expect(result.score).toBeDefined();
+        expect(typeof result.score).toBe('string');
+        expect((result.score as string).length).toBeGreaterThan(0);
+        expect(typeof result.reasoning).toBe('string');
+        expect(result.metadata.model).toContain('anthropic');
+        expect(result.metadata.model).toContain(ANTHROPIC_MODEL);
+      },
+      TEST_TIMEOUT_MS,
+    );
+  }
+});

--- a/sdks/typescript/tests/integration/batch.integration.test.ts
+++ b/sdks/typescript/tests/integration/batch.integration.test.ts
@@ -20,8 +20,8 @@ import type { BatchInput } from '../../src/batch/index.js';
 const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 
 if (RUN_INTEGRATION) {
-  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
-  if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 
 const SKIP_INTEGRATION = !RUN_INTEGRATION;

--- a/sdks/typescript/tests/integration/batch.integration.test.ts
+++ b/sdks/typescript/tests/integration/batch.integration.test.ts
@@ -24,8 +24,7 @@ if (RUN_INTEGRATION) {
   if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 
-const SKIP_INTEGRATION = !RUN_INTEGRATION;
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 // Test timeout: 2 minutes (generous for API calls)
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;

--- a/sdks/typescript/tests/integration/conventionality.integration.test.ts
+++ b/sdks/typescript/tests/integration/conventionality.integration.test.ts
@@ -28,8 +28,13 @@ import {
  * ```
  */
 
-const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
-                         !process.env.GOOGLE_API_KEY;
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
+  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+}
+const SKIP_INTEGRATION = !RUN_INTEGRATION;
 
 const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
 

--- a/sdks/typescript/tests/integration/conventionality.integration.test.ts
+++ b/sdks/typescript/tests/integration/conventionality.integration.test.ts
@@ -32,7 +32,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 // A missing key when integration tests were explicitly requested is a
 // misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
 if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
-  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 const SKIP_INTEGRATION = !RUN_INTEGRATION;
 

--- a/sdks/typescript/tests/integration/conventionality.integration.test.ts
+++ b/sdks/typescript/tests/integration/conventionality.integration.test.ts
@@ -34,9 +34,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
   throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
-const SKIP_INTEGRATION = !RUN_INTEGRATION;
-
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 // Test timeout: 2 minutes per test case (allows for 3 attempts with API latency)
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;
@@ -141,11 +139,6 @@ describeIntegration.concurrent('Conventionality Evaluator - Comprehensive Test S
   let evaluator: ConventionalityEvaluator;
 
   beforeAll(() => {
-    if (SKIP_INTEGRATION) {
-      console.log('⏭️  Skipping integration tests (no API keys or RUN_INTEGRATION_TESTS not set)');
-      return;
-    }
-
     evaluator = new ConventionalityEvaluator({
       googleApiKey: process.env.GOOGLE_API_KEY!,
     });

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -20,7 +20,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 // A missing key when integration tests were explicitly requested is a
 // misconfiguration, not a reason to quietly pass — matches batch/anthropic-provider.
 if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
-  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 
 const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -15,10 +15,11 @@ import { Provider } from '../../src/evaluators/base.js';
  * ```
  */
 
-const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
-                         !process.env.OPENAI_API_KEY;
+// Both required: with `&&` this ran whenever RUN_INTEGRATION_TESTS was set and
+// failed on the missing key instead of skipping.
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true' && !!process.env.OPENAI_API_KEY;
 
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;
 

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -15,9 +15,13 @@ import { Provider } from '../../src/evaluators/base.js';
  * ```
  */
 
-// Both required: with `&&` this ran whenever RUN_INTEGRATION_TESTS was set and
-// failed on the missing key instead of skipping.
-const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true' && !!process.env.OPENAI_API_KEY;
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass — matches batch/anthropic-provider.
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+}
 
 const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 

--- a/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
+++ b/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
@@ -24,7 +24,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 // A missing key when integration tests were explicitly requested is a
 // misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
 if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
-  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 const SKIP_INTEGRATION = !RUN_INTEGRATION;
 

--- a/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
+++ b/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
@@ -20,8 +20,13 @@ import {
  * ```
  */
 
-const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
-                         !process.env.OPENAI_API_KEY;
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+}
+const SKIP_INTEGRATION = !RUN_INTEGRATION;
 
 const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
 

--- a/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
+++ b/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
@@ -26,9 +26,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
-const SKIP_INTEGRATION = !RUN_INTEGRATION;
-
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 // Test timeout: 2 minutes per test case (allows for 3 attempts with API latency)
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;
@@ -78,11 +76,6 @@ describeIntegration.concurrent('Sentence Structure Evaluator - Comprehensive Tes
   let evaluator: SentenceStructureEvaluator;
 
   beforeAll(() => {
-    if (SKIP_INTEGRATION) {
-      console.log('⏭️  Skipping integration tests (no API keys or RUN_INTEGRATION_TESTS not set)');
-      return;
-    }
-
     evaluator = new SentenceStructureEvaluator({
       openaiApiKey: process.env.OPENAI_API_KEY!,
     });

--- a/sdks/typescript/tests/integration/smk.integration.test.ts
+++ b/sdks/typescript/tests/integration/smk.integration.test.ts
@@ -26,7 +26,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 // A missing key when integration tests were explicitly requested is a
 // misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
 if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
-  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 const SKIP_INTEGRATION = !RUN_INTEGRATION;
 

--- a/sdks/typescript/tests/integration/smk.integration.test.ts
+++ b/sdks/typescript/tests/integration/smk.integration.test.ts
@@ -22,8 +22,13 @@ import {
  * ```
  */
 
-const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
-                         !process.env.GOOGLE_API_KEY;
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
+  throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+}
+const SKIP_INTEGRATION = !RUN_INTEGRATION;
 
 const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
 

--- a/sdks/typescript/tests/integration/smk.integration.test.ts
+++ b/sdks/typescript/tests/integration/smk.integration.test.ts
@@ -28,9 +28,7 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 if (RUN_INTEGRATION && !process.env.GOOGLE_API_KEY) {
   throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
-const SKIP_INTEGRATION = !RUN_INTEGRATION;
-
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 // Test timeout: 2 minutes per test case (allows for 3 attempts with API latency)
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;
@@ -125,11 +123,6 @@ describeIntegration.concurrent('SMK Evaluator - Comprehensive Test Suite', () =>
   let evaluator: SmkEvaluator;
 
   beforeAll(() => {
-    if (SKIP_INTEGRATION) {
-      console.log('⏭️  Skipping integration tests (no API keys or RUN_INTEGRATION_TESTS not set)');
-      return;
-    }
-
     evaluator = new SmkEvaluator({
       googleApiKey: process.env.GOOGLE_API_KEY!,
     });

--- a/sdks/typescript/tests/integration/vocabulary.integration.test.ts
+++ b/sdks/typescript/tests/integration/vocabulary.integration.test.ts
@@ -27,9 +27,7 @@ if (RUN_INTEGRATION) {
   if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
   if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
-const SKIP_INTEGRATION = !RUN_INTEGRATION;
-
-const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
 
 // Test timeout: 2 minutes per test case (allows for 3 attempts with API latency)
 const TEST_TIMEOUT_MS = 2 * 60 * 1000;
@@ -91,11 +89,6 @@ describeIntegration.concurrent('Vocabulary Evaluator - Comprehensive Test Suite'
   let evaluator: VocabularyEvaluator;
 
   beforeAll(() => {
-    if (SKIP_INTEGRATION) {
-      console.log('⏭️  Skipping integration tests (no API keys or RUN_INTEGRATION_TESTS not set)');
-      return;
-    }
-
     evaluator = new VocabularyEvaluator({
       googleApiKey: process.env.GOOGLE_API_KEY!,
       openaiApiKey: process.env.OPENAI_API_KEY!,

--- a/sdks/typescript/tests/integration/vocabulary.integration.test.ts
+++ b/sdks/typescript/tests/integration/vocabulary.integration.test.ts
@@ -20,8 +20,14 @@ import {
  * ```
  */
 
-const SKIP_INTEGRATION = !process.env.RUN_INTEGRATION_TESTS &&
-                         (!process.env.OPENAI_API_KEY || !process.env.GOOGLE_API_KEY);
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION) {
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+}
+const SKIP_INTEGRATION = !RUN_INTEGRATION;
 
 const describeIntegration = SKIP_INTEGRATION ? describe.skip : describe;
 

--- a/sdks/typescript/tests/integration/vocabulary.integration.test.ts
+++ b/sdks/typescript/tests/integration/vocabulary.integration.test.ts
@@ -24,8 +24,8 @@ const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
 // A missing key when integration tests were explicitly requested is a
 // misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
 if (RUN_INTEGRATION) {
-  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS is set');
-  if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS is set');
+  if (!process.env.OPENAI_API_KEY) throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  if (!process.env.GOOGLE_API_KEY) throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
 }
 const SKIP_INTEGRATION = !RUN_INTEGRATION;
 

--- a/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider, type BaseEvaluatorConfig } from '../../../src/evaluators/base.js';
+import { GradeLevelAppropriatenessEvaluator } from '../../../src/evaluators/grade-level-appropriateness.js';
+import { ConventionalityEvaluator } from '../../../src/evaluators/conventionality.js';
+import { SmkEvaluator } from '../../../src/evaluators/smk.js';
+import { SentenceStructureEvaluator } from '../../../src/evaluators/sentence-structure.js';
+import { PurposeEvaluator } from '../../../src/evaluators/purpose.js';
+import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
+
+/**
+ * Wiring only: every evaluator must accept an Anthropic override with just an
+ * Anthropic key. Live behaviour is in anthropic-provider.integration.test.ts.
+ */
+
+// Hoisted for vi.mock's factory. The declared parameter is what types mock.calls.
+const { createProvider, mockProvider } = vi.hoisted(() => {
+  const mockProvider = {
+    label: 'mock:model',
+    generateStructured: vi.fn(),
+    generateText: vi.fn(),
+  };
+  return {
+    mockProvider,
+    createProvider: vi.fn((_config: { type: string; model: string; apiKey?: string }) => mockProvider),
+  };
+});
+
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), createProvider };
+});
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class {
+    send = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+const ANTHROPIC_MODEL = 'claude-haiku-4-5-20251001';
+
+function anthropicOnlyConfig(): BaseEvaluatorConfig {
+  return {
+    anthropicApiKey: 'sk-ant-test',
+    modelOverride: { provider: Provider.Anthropic, model: ANTHROPIC_MODEL },
+    telemetry: false,
+  };
+}
+
+const EVALUATORS = [
+  { name: 'GradeLevelAppropriateness', Ctor: GradeLevelAppropriatenessEvaluator },
+  { name: 'Conventionality', Ctor: ConventionalityEvaluator },
+  { name: 'Smk', Ctor: SmkEvaluator },
+  { name: 'SentenceStructure', Ctor: SentenceStructureEvaluator },
+  { name: 'Purpose', Ctor: PurposeEvaluator },
+  { name: 'Vocabulary', Ctor: VocabularyEvaluator },
+] as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Anthropic modelOverride — plumbing', () => {
+  for (const { name, Ctor } of EVALUATORS) {
+    it(`${name} constructs with only an Anthropic key`, () => {
+      expect(() => new Ctor(anthropicOnlyConfig())).not.toThrow();
+      // Consumed, not merely called: mockReset would otherwise leave this passing.
+      expect(createProvider).toHaveReturnedWith(mockProvider);
+    });
+
+    it(`${name} routes every provider to Anthropic with the override model`, () => {
+      new Ctor(anthropicOnlyConfig());
+
+      expect(createProvider).toHaveBeenCalled();
+      for (const [arg] of createProvider.mock.calls) {
+        expect(arg.type).toBe(Provider.Anthropic);
+        expect(arg.model).toBe(ANTHROPIC_MODEL);
+        expect(arg.apiKey).toBe('sk-ant-test');
+      }
+    });
+  }
+
+  it('rejects an Anthropic override when the Anthropic key is missing', () => {
+    expect(
+      () =>
+        new SentenceStructureEvaluator({
+          openaiApiKey: 'sk-openai-test',
+          modelOverride: { provider: Provider.Anthropic, model: ANTHROPIC_MODEL },
+          telemetry: false,
+        }),
+    ).toThrow(/Anthropic API key is required/);
+  });
+});
+
+describe('Anthropic modelOverride — vocabulary multi-model collapse', () => {
+  // Vocabulary deliberately uses three models; an override collapses all three.
+  // Asserted so the CLI can warn rather than surprise users.
+  it('collapses all three vocabulary call sites onto the single override model', () => {
+    new VocabularyEvaluator(anthropicOnlyConfig());
+
+    expect(createProvider).toHaveBeenCalledTimes(3);
+    const models = createProvider.mock.calls.map(([arg]) => arg.model);
+    expect(models).toEqual([ANTHROPIC_MODEL, ANTHROPIC_MODEL, ANTHROPIC_MODEL]);
+  });
+
+  it('uses three distinct models across two providers without an override', () => {
+    new VocabularyEvaluator({
+      googleApiKey: 'g-test',
+      openaiApiKey: 'o-test',
+      telemetry: false,
+    });
+
+    const calls = createProvider.mock.calls.map(([arg]) => arg);
+    expect(calls.map((c) => c.type)).toEqual([Provider.Google, Provider.OpenAI, Provider.OpenAI]);
+    expect(new Set(calls.map((c) => c.model)).size).toBe(3);
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
@@ -13,14 +13,13 @@ import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
  */
 
 // Hoisted for vi.mock's factory. The declared parameter is what types mock.calls.
-const { createProvider, mockProvider } = vi.hoisted(() => {
+const { createProvider } = vi.hoisted(() => {
   const mockProvider = {
     label: 'mock:model',
     generateStructured: vi.fn(),
     generateText: vi.fn(),
   };
   return {
-    mockProvider,
     createProvider: vi.fn((_config: { type: string; model: string; apiKey?: string }) => mockProvider),
   };
 });
@@ -63,8 +62,9 @@ describe('Anthropic modelOverride — plumbing', () => {
   for (const { name, Ctor } of EVALUATORS) {
     it(`${name} constructs with only an Anthropic key`, () => {
       expect(() => new Ctor(anthropicOnlyConfig())).not.toThrow();
-      // Consumed, not merely called: mockReset would otherwise leave this passing.
-      expect(createProvider).toHaveReturnedWith(mockProvider);
+      // The routing test below asserts the arguments; a `toHaveReturnedWith`
+      // check here would be tautological, since the mock always returns it.
+      expect(createProvider).toHaveBeenCalled();
     });
 
     it(`${name} routes every provider to Anthropic with the override model`, () => {


### PR DESCRIPTION
Fourth of four foundational SDK PRs. Independent — rebased on current main.

**Why:** the batch CLI is about to offer user-selectable providers. Today Anthropic is only reachable via `--model-override anthropic:<model>` — `requiredProviders` never returns it otherwise — so once the CLI advertises provider choice, users will run every evaluator on Anthropic assuming it's supported.

**What:** unit tests that all six text-complexity evaluators accept an Anthropic override with **only** an `anthropicApiKey` and route every provider construction to Anthropic — a path untested per-evaluator until now, because `validateApiKeys` short-circuits on `modelOverride` and checks only that provider's key. Plus a gated live-API test, and override caveats documented on `ModelOverride`.

## Two pre-existing surprises, now test-covered so the CLI can warn
- `VocabularyEvaluator` deliberately uses three models (Gemini 2.5 Pro for grades 3–4, GPT-4.1 for 5–12, GPT-4o for background knowledge); a run-level override collapses all three.
- `PurposeEvaluator` takes its model from the shared cross-language eval config (`evals/prompts/purpose/config.json`), so an override diverges from that rather than from a hardcoded default.

## Live API
All six evaluators passed against the real Anthropic API (2026-08-07, `claude-haiku-4-5-20251001`, ~80s run). The risk this PR existed to check — Anthropic tool-call structured output against the larger nested schemas (`vocabulary`, `sentence-structure`, `purpose`) — did not materialise; every schema round-tripped.

```bash
ANTHROPIC_API_KEY=... RUN_INTEGRATION_TESTS=true npm run test:integration
```

This does **not** establish evaluation *quality* on Anthropic — scores were asserted for shape, not correctness; evaluators remain validated against their recommended models, and the Vocabulary/Purpose override caveats still apply.

## Adjacent cleanup (outside the original scope, separate commits)
Verifying the Anthropic path surfaced pre-existing problems in how the integration suites gate themselves. Not the intended scope, but cheap to fix correctly while here — one commit each:

1. **Latent `&&` gate** in `conventionality` / `sentence-structure` / `smk` / `vocabulary`: it skipped only when *both* `RUN_INTEGRATION_TESTS` and the key were unset, so it also **ran when a key happened to be exported but integration wasn't requested** — a plain `npm test` with `OPENAI_API_KEY` set fired live calls. Verified before/after: same command went from 4 tests running-and-failing to 4 skipped.
2. **Gate policy, now two-tier.** A suite whose provider key is *required* throws when `RUN_INTEGRATION_TESTS=true` and the key is missing (a misconfiguration shouldn't quietly pass). A suite for an *optional* provider skips. Anthropic is optional — no evaluator defaults to it and the CI job supplies only `OPENAI`/`GOOGLE` (`.github/workflows/test-sdk-typescript.yml:128-131`) — so hard-requiring `ANTHROPIC_API_KEY` would have made it a prerequisite for the *whole* suite, killing a run that has keys for every other one at module load. This matches how `math-standards-alignment` already treats its optional keys.
3. **Dead code / accuracy.** Removed `if (SKIP_INTEGRATION)` branches inside `beforeAll` that could never execute (`describe.skip` registers hooks without running them) and whose message no longer matched the gate; all suites now share one idiom (`RUN_INTEGRATION ? describe : describe.skip`). Corrected the thrown messages, which said "when `RUN_INTEGRATION_TESTS` is set" while every gate compares against the literal `'true'`. Dropped a tautological `toHaveReturnedWith` assertion in the unit test (the mock always returns that value, so it asserted nothing beyond `toHaveBeenCalled()`).

Behavior verified in both directions: flag unset → all 8 suites skip; flag set without keys → required-key suites throw with an accurate message, the optional-provider suite skips.

## Verification
`lint` (0 errors), `typecheck`, `test:unit` — 409 passing. (Integration suites are gated and not part of `test:unit`.)
