### PR TITLE
feat(ts-sdk): family-adapter batch architecture + math standards-alignment family

### DIFF
--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -381,9 +381,11 @@ async function main() {
 
     let output;
     try {
-      output = await evaluator.evaluate(inputs, group.id, (result) => {
-        tracker.update(result);
-        tracker.display();
+      output = await evaluator.evaluate(inputs, group.id, {
+        onProgress: (result) => {
+          tracker.update(result);
+          tracker.display();
+        },
       });
     } finally {
       process.off('SIGINT', handleShutdown);

--- a/sdks/typescript/src/batch/csv.ts
+++ b/sdks/typescript/src/batch/csv.ts
@@ -2,24 +2,15 @@ import * as fs from 'fs';
 import { parse } from 'csv-parse/sync';
 import type { BatchInput } from './types.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findColumn(row: Record<string, any>, columnName: string): string | undefined {
-  const normalizedTarget = columnName.toLowerCase().trim();
-  for (const key of Object.keys(row)) {
-    if (key.toLowerCase().trim() === normalizedTarget) {
-      return key;
-    }
-  }
-  return undefined;
-}
-
 /**
- * Parse a CSV file into BatchInput rows.
+ * Parse a CSV file into raw {@link BatchInput} rows.
  *
- * Requires columns named "text" and "grade" (case-insensitive, whitespace-trimmed).
- * Rows missing either value are silently skipped.
+ * Family-agnostic: every column is read into `columns` keyed by its header
+ * (trimmed). Column requirements, aliases, and defaults are applied later by
+ * the selected family (see `normalizeRow`), so this loader imposes no schema.
+ * Fully empty rows are skipped.
  *
- * @throws {Error} If the file does not exist, is empty, or is missing required columns
+ * @throws {Error} If the file does not exist or is empty
  */
 export function parseCSV(csvPath: string): BatchInput[] {
   if (!fs.existsSync(csvPath)) {
@@ -37,33 +28,25 @@ export function parseCSV(csvPath: string): BatchInput[] {
     throw new Error('CSV file is empty');
   }
 
-  const firstRow = records[0];
-  const textColumn = findColumn(firstRow, 'text');
-  const gradeColumn = findColumn(firstRow, 'grade');
-
-  if (!textColumn) {
-    throw new Error('CSV must have a "text" column (case-insensitive)');
-  }
-  if (!gradeColumn) {
-    throw new Error('CSV must have a "grade" column (case-insensitive)');
-  }
-
   const inputs: BatchInput[] = [];
 
   for (let i = 0; i < records.length; i++) {
     const row = records[i];
-    const text = row[textColumn];
-    const grade = row[gradeColumn];
-
-    if (!text || !grade) {
-      console.warn(`Warning: skipping row ${i + 2} — missing text or grade`);
-      continue;
+    // Null-prototype: CSV headers are user-controlled, so a header like
+    // "__proto__" must not touch Object.prototype.
+    const columns: Record<string, string> = Object.create(null);
+    let hasValue = false;
+    for (const [key, value] of Object.entries(row)) {
+      const str = value == null ? '' : String(value).trim();
+      columns[key] = str;
+      if (str !== '') hasValue = true;
     }
 
+    if (!hasValue) continue; // skip fully-empty rows
+
     inputs.push({
-      text: String(text).trim(),
-      grade: String(grade).trim(),
       rowIndex: i + 2, // 1-based, offset by 1 for the header row
+      columns,
       originalRow: row,
     });
   }

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -1,14 +1,5 @@
 import pLimit from 'p-limit';
-import {
-  VocabularyEvaluator,
-  SentenceStructureEvaluator,
-  GradeLevelAppropriatenessEvaluator,
-  SmkEvaluator,
-  ConventionalityEvaluator,
-  PurposeEvaluator,
-} from '../evaluators/index.js';
-import type { BaseEvaluatorConfig } from '../evaluators/base.js';
-import type { EvaluationResult } from '../schemas/index.js';
+import { Provider } from '../evaluators/base.js';
 import type {
   BatchInput,
   BatchTask,
@@ -18,64 +9,52 @@ import type {
   BatchSummary,
   EvaluatorGroup,
 } from './types.js';
+import {
+  type EvaluatorFamily,
+  type FamilyRow,
+  type FamilyRunContext,
+  type FamilyRunner,
+  normalizeRow,
+  resolveMembers,
+  validateRequiredColumns,
+} from './families/family.js';
+import { getFamilies, getFamily } from './families/registry.js';
 
-interface SimpleEvaluator {
-  evaluate(text: string, grade: string): Promise<EvaluationResult<string, unknown>>;
-}
-
-type EvaluatorConstructor = new (config: BaseEvaluatorConfig) => SimpleEvaluator;
-
-/**
- * Map of evaluator IDs to their constructors — internal to this module.
- */
-const EVALUATOR_MAP = new Map<string, EvaluatorConstructor>([
-  [GradeLevelAppropriatenessEvaluator.metadata.id, GradeLevelAppropriatenessEvaluator],
-  [SmkEvaluator.metadata.id, SmkEvaluator],
-  [VocabularyEvaluator.metadata.id, VocabularyEvaluator],
-  [SentenceStructureEvaluator.metadata.id, SentenceStructureEvaluator],
-  [ConventionalityEvaluator.metadata.id, ConventionalityEvaluator],
-  [PurposeEvaluator.metadata.id, PurposeEvaluator],
-]);
+export { getFamilies, getFamily } from './families/registry.js';
 
 /**
- * Evaluator groups available for batch processing.
- * Each group runs a fixed set of evaluators and maps to a specific HTML report format.
+ * Backward-compatible view of families as the older "evaluator group" shape.
+ * @deprecated Use {@link getFamilies} — retained for the current CLI wiring.
  */
-// Note: this batch group is a superset of TextComplexityEvaluator — it also includes
-// GradeLevelAppropriateness and Purpose (early access), which the programmatic evaluator
-// does not expose. This is intentional: the batch surface evolves independently.
-const EVALUATOR_GROUPS: EvaluatorGroup[] = [
-  {
-    id: 'text-complexity',
-    name: 'Text Complexity Analysis',
-    description: 'Evaluates all dimensions of the Qualitative Text Complexity rubric',
-    evaluatorIds: [
-      GradeLevelAppropriatenessEvaluator.metadata.id,
-      SmkEvaluator.metadata.id,
-      VocabularyEvaluator.metadata.id,
-      SentenceStructureEvaluator.metadata.id,
-      ConventionalityEvaluator.metadata.id,
-      PurposeEvaluator.metadata.id,
-    ],
-    requiresGoogleKey: true,
-    requiresOpenAIKey: true,
-    maxInputRows: 50,
-  },
-];
-
 export function getAvailableGroups(): EvaluatorGroup[] {
-  return [...EVALUATOR_GROUPS];
+  return getFamilies().map((family) => {
+    const keys = family.requiredKeys(family.members.map((m) => m.id));
+    return {
+      id: family.id,
+      name: family.name,
+      description: family.description,
+      evaluatorIds: family.members.map((m) => m.id),
+      requiresGoogleKey: keys.includes(Provider.Google),
+      requiresOpenAIKey: keys.includes(Provider.OpenAI),
+      maxInputRows: family.maxInputRows,
+    };
+  });
+}
+
+export interface BatchRunOptions {
+  selectedMemberIds?: string[];
+  onProgress?: (result: BatchResult) => void;
 }
 
 /**
- * Batch evaluator class
- *
- * Processes multiple texts in parallel using all evaluators in a group.
+ * Batch evaluator: runs the selected members of one family over a set of input
+ * rows. Owns orchestration — concurrency, cancellation, timing, error handling
+ * — while each family owns how to invoke its evaluators and what columns/keys
+ * it needs.
  */
 export class BatchEvaluator {
   private config: BatchConfig;
   private limit: ReturnType<typeof pLimit>;
-  private evaluatorInstances = new Map<string, SimpleEvaluator>();
   private isCancelled = false;
   private completedResults: BatchResult[] = [];
 
@@ -87,144 +66,90 @@ export class BatchEvaluator {
       bypassRowLimit: false,
       ...config,
     };
-
     this.limit = pLimit(this.config.concurrency ?? 3);
   }
 
-  /**
-   * Cancel ongoing evaluation.
-   * Returns partial results collected so far.
-   */
+  /** Cancel ongoing evaluation. Returns partial results collected so far. */
   cancel(): BatchResult[] {
     this.isCancelled = true;
     return [...this.completedResults];
   }
 
-  private initializeEvaluators(evaluatorIds: readonly string[]): void {
-    for (const id of evaluatorIds) {
-      if (this.evaluatorInstances.has(id)) continue;
-
-      const EvaluatorClass = EVALUATOR_MAP.get(id);
-      if (!EvaluatorClass) {
-        throw new Error(`Unknown evaluator: ${id}`);
-      }
-
-      const evaluator = new EvaluatorClass({
-        googleApiKey: this.config.googleApiKey,
-        openaiApiKey: this.config.openaiApiKey,
-        anthropicApiKey: this.config.anthropicApiKey,
-        maxRetries: this.config.maxRetries,
-        telemetry: this.config.telemetry,
-        modelOverride: this.config.modelOverride,
-        llmProvider: this.config.llmProvider,
-      });
-
-      this.evaluatorInstances.set(id, evaluator);
-    }
+  private buildContext(): FamilyRunContext {
+    return {
+      googleApiKey: this.config.googleApiKey,
+      openaiApiKey: this.config.openaiApiKey,
+      anthropicApiKey: this.config.anthropicApiKey,
+      platformApiKey: this.config.platformApiKey,
+      maxRetries: this.config.maxRetries,
+      telemetry: this.config.telemetry,
+      modelOverride: this.config.modelOverride,
+      llmProvider: this.config.llmProvider,
+      concurrency: this.config.concurrency,
+      kgConcurrency: this.config.kgConcurrency,
+    };
   }
 
-  /**
-   * Create tasks from inputs and evaluator IDs
-   */
-  private createTasks(inputs: BatchInput[], evaluatorIds: readonly string[]): BatchTask[] {
-    const tasks: BatchTask[] = [];
-
-    for (const input of inputs) {
-      for (const evaluatorId of evaluatorIds) {
-        tasks.push({
-          text: input.text,
-          grade: input.grade,
-          evaluatorId,
-          rowIndex: input.rowIndex,
-          originalRow: input.originalRow,
-        });
-      }
-    }
-
-    return tasks;
+  private errorResult(
+    row: FamilyRow,
+    memberId: string,
+    error: string,
+    processingTimeMs = 0,
+  ): BatchResult {
+    return {
+      rowIndex: row.rowIndex,
+      text: row.columns.text ?? row.columns.question ?? '',
+      grade: row.columns.grade ?? '',
+      evaluatorId: memberId,
+      status: 'error',
+      error,
+      processingTimeMs,
+      originalRow: row.originalRow,
+    };
   }
 
   private async executeTask(
+    runner: FamilyRunner,
     task: BatchTask,
-    onProgress?: (result: BatchResult) => void
+    onProgress?: (result: BatchResult) => void,
   ): Promise<BatchResult> {
-    // Check if cancelled before starting
+    const row = task.row;
+
     if (this.isCancelled) {
-      const batchResult: BatchResult = {
-        rowIndex: task.rowIndex,
-        text: task.text,
-        grade: task.grade,
-        evaluatorId: task.evaluatorId,
-        status: 'error',
-        error: 'Cancelled by user',
-        processingTimeMs: 0,
-        originalRow: task.originalRow,
-      };
-      this.completedResults.push(batchResult);
-      if (onProgress) onProgress(batchResult);
-      return batchResult;
+      const cancelled = this.errorResult(row, task.memberId, 'Cancelled by user');
+      this.completedResults.push(cancelled);
+      onProgress?.(cancelled);
+      return cancelled;
     }
 
     const startTime = Date.now();
-    const evaluator = this.evaluatorInstances.get(task.evaluatorId);
-
-    if (!evaluator) {
-      const batchResult: BatchResult = {
-        rowIndex: task.rowIndex,
-        text: task.text,
-        grade: task.grade,
-        evaluatorId: task.evaluatorId,
-        status: 'error',
-        error: `Evaluator not initialized: ${task.evaluatorId}`,
-        processingTimeMs: 0,
-        originalRow: task.originalRow,
-      };
-      this.completedResults.push(batchResult);
-      if (onProgress) onProgress(batchResult);
-      return batchResult;
-    }
-
     try {
-      const result = await evaluator.evaluate(task.text, task.grade);
-
-      const batchResult: BatchResult = {
-        rowIndex: task.rowIndex,
-        text: task.text,
-        grade: task.grade,
-        evaluatorId: task.evaluatorId,
+      const outcome = await runner.runTask(row, task.memberId);
+      const result: BatchResult = {
+        rowIndex: row.rowIndex,
+        text: row.columns.text ?? row.columns.question ?? '',
+        grade: row.columns.grade ?? '',
+        evaluatorId: task.memberId,
         status: 'success',
-        score: result.score,
-        reasoning: result.reasoning,
+        score: outcome.score,
+        reasoning: outcome.reasoning,
+        payload: outcome.payload,
         processingTimeMs: Date.now() - startTime,
-        originalRow: task.originalRow,
+        originalRow: row.originalRow,
       };
-
-      // Store completed result
-      this.completedResults.push(batchResult);
-
-      // Report progress
-      if (onProgress) onProgress(batchResult);
-
-      return batchResult;
+      this.completedResults.push(result);
+      onProgress?.(result);
+      return result;
     } catch (error) {
-      const batchResult: BatchResult = {
-        rowIndex: task.rowIndex,
-        text: task.text,
-        grade: task.grade,
-        evaluatorId: task.evaluatorId,
-        status: 'error',
-        error: error instanceof Error ? error.message : String(error),
-        processingTimeMs: Date.now() - startTime,
-        originalRow: task.originalRow,
-      };
-
-      // Store completed result (even errors)
-      this.completedResults.push(batchResult);
-
-      // Report progress
-      if (onProgress) onProgress(batchResult);
-
-      return batchResult;
+      const result = this.errorResult(
+        row,
+        task.memberId,
+        error instanceof Error ? error.message : String(error),
+        Date.now() - startTime,
+      );
+      this.completedResults.push(result);
+      onProgress?.(result);
+      return result;
     }
   }
 
@@ -237,7 +162,6 @@ export class BatchEvaluator {
       resultsPerEvaluator: {},
     };
 
-    // Calculate per-evaluator stats
     const evaluatorIds = Array.from(new Set(results.map((r) => r.evaluatorId)));
     for (const id of evaluatorIds) {
       const evalResults = results.filter((r) => r.evaluatorId === id);
@@ -246,39 +170,41 @@ export class BatchEvaluator {
         failed: evalResults.filter((r) => r.status === 'error').length,
       };
     }
-
     return summary;
   }
 
   /**
-   * Run batch evaluation for an evaluator group.
+   * Run batch evaluation for a family.
    *
-   * @param inputs - Array of input rows
-   * @param groupId - The evaluator group to run (see getAvailableGroups())
-   * @param onProgress - Optional callback invoked after each task completes
-   * @returns Batch evaluation results and summary
+   * @param inputs - Raw input rows (columns keyed by CSV header)
+   * @param family - The family to run: an id (see getFamilies()) or a family object
+   * @param options - Member selection and progress callback. For backward
+   *   compatibility a bare `onProgress` callback is also accepted here.
    */
   async evaluate(
     inputs: BatchInput[],
-    groupId: string,
-    onProgress?: (result: BatchResult) => void
+    family: string | EvaluatorFamily,
+    options: BatchRunOptions | BatchRunOptions['onProgress'] = {},
   ): Promise<BatchOutput> {
     const startTime = Date.now();
+    // Back-compat: the previous signature took an onProgress callback as the
+    // third argument; treat a function here as `{ onProgress }`.
+    const opts: BatchRunOptions = typeof options === 'function' ? { onProgress: options } : options;
+    const resolvedFamily: EvaluatorFamily = typeof family === 'string' ? getFamily(family) : family;
+    return this.run(inputs, resolvedFamily, opts, startTime);
+  }
 
-    // Resolve group
-    const group = EVALUATOR_GROUPS.find((g) => g.id === groupId);
-    if (!group) {
-      throw new Error(
-        `Unknown evaluator group: "${groupId}". Available: ${EVALUATOR_GROUPS.map((g) => g.id).join(', ')}`
-      );
-    }
+  private async run(
+    inputs: BatchInput[],
+    family: EvaluatorFamily,
+    options: BatchRunOptions,
+    startTime: number,
+  ): Promise<BatchOutput> {
 
-    // Enforce per-group row limit (unless bypass is opted in)
-    // TODO(telemetry): record when bypassRowLimit is used
-    if (!this.config.bypassRowLimit && inputs.length > group.maxInputRows) {
+    if (!this.config.bypassRowLimit && inputs.length > family.maxInputRows) {
       throw new Error(
-        `Input exceeds limit for "${group.id}": ${inputs.length} rows (max ${group.maxInputRows}). ` +
-          `Split into smaller batches, or pass { bypassRowLimit: true } in BatchConfig to bypass (use --bypass-row-limit on the CLI).`
+        `Input exceeds limit for "${family.id}": ${inputs.length} rows (max ${family.maxInputRows}). ` +
+          `Split into smaller batches, or pass { bypassRowLimit: true } in BatchConfig (use --bypass-row-limit on the CLI).`,
       );
     }
 
@@ -286,27 +212,52 @@ export class BatchEvaluator {
     this.isCancelled = false;
     this.completedResults = [];
 
-    // Initialize evaluator instances
-    this.initializeEvaluators(group.evaluatorIds);
+    if (inputs.length === 0) {
+      return { results: [], summary: this.calculateSummary([], Date.now() - startTime) };
+    }
 
-    // Create all tasks (flattened: inputs × evaluators)
-    const tasks = this.createTasks(inputs, group.evaluatorIds);
+    // Fail fast on a missing required column (header-level), then normalize
+    // each row. A row that fails normalization becomes an error result rather
+    // than aborting the whole run.
+    validateRequiredColumns(family, Object.keys(inputs[0].columns));
+    const members = resolveMembers(family, options.selectedMemberIds);
+    const runner = family.createRunner(this.buildContext(), options.selectedMemberIds);
 
-    // Execute all tasks with concurrency control
-    // Use allSettled to get partial results even if cancelled
-    const settledResults = await Promise.allSettled(
-      tasks.map((task) => this.limit(() => this.executeTask(task, onProgress)))
+    const rows: FamilyRow[] = [];
+    const preFailed: BatchResult[] = [];
+    for (const input of inputs) {
+      try {
+        rows.push(normalizeRow(input, family));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const badRow: FamilyRow = { rowIndex: input.rowIndex, columns: {}, originalRow: input.originalRow };
+        for (const member of members) {
+          const failed = this.errorResult(badRow, member.id, message);
+          preFailed.push(failed);
+          this.completedResults.push(failed);
+          options.onProgress?.(failed);
+        }
+      }
+    }
+
+    const tasks: BatchTask[] = [];
+    for (const row of rows) {
+      for (const member of members) {
+        tasks.push({ row, memberId: member.id });
+      }
+    }
+
+    const settled = await Promise.allSettled(
+      tasks.map((task) => this.limit(() => this.executeTask(runner, task, options.onProgress))),
     );
+    const results = [
+      ...preFailed,
+      ...settled
+        .filter((r): r is PromiseFulfilledResult<BatchResult> => r.status === 'fulfilled')
+        .map((r) => r.value),
+    ];
 
-    // Extract fulfilled results (skip rejected)
-    const results = settledResults
-      .filter((r): r is PromiseFulfilledResult<BatchResult> => r.status === 'fulfilled')
-      .map((r) => r.value);
-
-    // Calculate summary
     const durationMs = Date.now() - startTime;
-    const summary = this.calculateSummary(results, durationMs);
-
-    return { results, summary };
+    return { results, summary: this.calculateSummary(results, durationMs) };
   }
 }

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -47,6 +47,31 @@ export interface BatchRunOptions {
 }
 
 /**
+ * Rejects a malformed input row before it reaches `Object.keys`, which would
+ * otherwise throw a bare "Cannot convert undefined or null to object". Named
+ * separately because the likeliest cause is a hand-built row in the pre-family
+ * `{ text, grade }` shape, which is worth saying out loud.
+ */
+function assertHasColumns(input: BatchInput): void {
+  const { columns } = input;
+  // `typeof null === 'object'`, so the null check is load-bearing: without it a
+  // null map reaches Object.keys and throws the bare TypeError this replaces.
+  if (columns === null || typeof columns !== 'object' || Array.isArray(columns)) {
+    const received =
+      columns === null ? 'null' : Array.isArray(columns) ? 'an array' : typeof columns;
+    const legacy = 'text' in input || 'grade' in input;
+    throw new Error(
+      `Invalid batch input at row ${input.rowIndex}: expected a "columns" record of ` +
+        `column name to value, received ${received}.` +
+        (legacy
+          ? ' Rows carrying top-level "text"/"grade" predate family-aware input; pass' +
+            ' { columns: { text, grade } } instead.'
+          : ' Build rows with parseCSV() or supply columns explicitly.'),
+    );
+  }
+}
+
+/**
  * Batch evaluator: runs the selected members of one family over a set of input
  * rows. Owns orchestration — concurrency, cancellation, timing, error handling
  * — while each family owns how to invoke its evaluators and what columns/keys
@@ -219,6 +244,7 @@ export class BatchEvaluator {
     // Fail fast on a missing required column (header-level), then normalize
     // each row. A row that fails normalization becomes an error result rather
     // than aborting the whole run.
+    assertHasColumns(inputs[0]);
     validateRequiredColumns(family, Object.keys(inputs[0].columns));
     const members = resolveMembers(family, options.selectedMemberIds);
     const runner = family.createRunner(this.buildContext(), options.selectedMemberIds);

--- a/sdks/typescript/src/batch/families/family.ts
+++ b/sdks/typescript/src/batch/families/family.ts
@@ -1,0 +1,185 @@
+import { Provider } from '../../evaluators/base.js';
+import type { ModelOverride, TelemetryOptions } from '../../evaluators/base.js';
+import type { LLMProvider } from '../../providers/index.js';
+
+/**
+ * A credential an evaluator family needs to run. Provider values match
+ * {@link Provider}; `'platform'` is the Learning Commons platform key used for
+ * Knowledge Graph access (distinct from any LLM provider key).
+ */
+export type KeyKind = Provider | 'platform';
+
+/**
+ * Declares one canonical input column a family consumes. `aliases` are
+ * additional CSV header names (case-insensitive) that map onto `name`.
+ * When a column is absent and `default` is set, the default is applied.
+ */
+export interface ColumnSpec {
+  name: string;
+  aliases?: string[];
+  required: boolean;
+  default?: string;
+}
+
+/** A single evaluator within a family (the unit of member-selection). */
+export interface FamilyMember {
+  id: string;
+  name: string;
+}
+
+/**
+ * A row after CSV parsing + column normalization: canonical columns (with
+ * defaults applied) plus the untouched original row for passthrough into
+ * outputs.
+ */
+export interface FamilyRow {
+  rowIndex: number;
+  columns: Record<string, string>;
+  originalRow: Record<string, unknown>;
+}
+
+/** Credentials and knobs handed to a family when building a runner. */
+export interface FamilyRunContext {
+  googleApiKey?: string;
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
+  platformApiKey?: string;
+  maxRetries?: number;
+  telemetry?: boolean | TelemetryOptions;
+  modelOverride?: ModelOverride;
+  llmProvider?: LLMProvider;
+  concurrency?: number;
+  kgConcurrency?: number;
+}
+
+/** The structured result of running one member against one row. */
+export interface TaskOutcome {
+  /** Human-facing scalar score (e.g. a complexity band, or "3/5" aligned). */
+  score: string;
+  /** Short reasoning/summary; may be empty for structured families. */
+  reasoning: string;
+  /** Full structured verdict, for families whose output isn't scalar. */
+  payload?: unknown;
+}
+
+/**
+ * A family instance bound to a specific set of selected members and
+ * credentials. Owns *how* to invoke each evaluator; the BatchEvaluator owns
+ * orchestration (concurrency, cancellation, timing, error handling).
+ */
+export interface FamilyRunner {
+  /** The members this runner will execute (post member-selection). */
+  members: FamilyMember[];
+  runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome>;
+}
+
+/**
+ * An evaluator family: a group of evaluators that share an input contract,
+ * credential needs, and output/report shape. The unit of selection exposed to
+ * batch users. Adding a new family (e.g. feedback) requires no core changes.
+ */
+export interface EvaluatorFamily {
+  id: string;
+  name: string;
+  description: string;
+  members: FamilyMember[];
+  columns: ColumnSpec[];
+  /** Maximum input rows allowed for this family. */
+  maxInputRows: number;
+  /** Credentials required given the selected members and any model override. */
+  requiredKeys(selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[];
+  /** Build a runner for the selected members (empty/undefined = all members). */
+  createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner;
+}
+
+// --- Column normalization -------------------------------------------------
+
+function matchesSpec(headerKey: string, spec: ColumnSpec): boolean {
+  const candidates = [spec.name, ...(spec.aliases ?? [])].map((s) => s.toLowerCase().trim());
+  return candidates.includes(headerKey.toLowerCase().trim());
+}
+
+/**
+ * Resolve a spec's value from a raw row. Candidates are tried in priority order
+ * — canonical name first, then aliases — and the first *non-empty* match wins,
+ * so a present-but-empty alias can't shadow a populated canonical column. Falls
+ * back to the first (possibly empty) match if nothing is non-empty.
+ */
+function resolveColumnValue(
+  rawColumns: Record<string, string>,
+  spec: ColumnSpec,
+): string | undefined {
+  const headerKeys = Object.keys(rawColumns);
+  let firstMatch: string | undefined;
+  for (const candidate of [spec.name, ...(spec.aliases ?? [])]) {
+    const target = candidate.toLowerCase().trim();
+    const key = headerKeys.find((k) => k.toLowerCase().trim() === target);
+    if (key === undefined) continue;
+    const value = rawColumns[key];
+    if (value !== undefined && value !== '') return value;
+    if (firstMatch === undefined) firstMatch = value;
+  }
+  return firstMatch;
+}
+
+/**
+ * Fail fast if the CSV is missing a required column entirely (header-level).
+ * Per-row empty values are handled during {@link normalizeRow}.
+ */
+export function validateRequiredColumns(family: EvaluatorFamily, headerKeys: string[]): void {
+  const missing = family.columns
+    .filter((spec) => spec.required && !headerKeys.some((h) => matchesSpec(h, spec)))
+    .map((spec) => spec.name);
+  if (missing.length > 0) {
+    throw new Error(
+      `CSV is missing required column(s) for family "${family.id}": ${missing.join(', ')} ` +
+        `(aliases are accepted; see the family's column spec).`,
+    );
+  }
+}
+
+/**
+ * Map a raw row's columns onto the family's canonical column names, applying
+ * defaults and enforcing per-row required values. Throws for a row that lacks a
+ * required value with no default.
+ */
+export function normalizeRow(
+  raw: { rowIndex: number; columns: Record<string, string>; originalRow: Record<string, unknown> },
+  family: EvaluatorFamily,
+): FamilyRow {
+  const columns: Record<string, string> = {};
+  for (const spec of family.columns) {
+    let value = resolveColumnValue(raw.columns, spec);
+    if ((value === undefined || value === '') && spec.default !== undefined) {
+      value = spec.default;
+    }
+    if ((value === undefined || value === '') && spec.required) {
+      throw new Error(`Row ${raw.rowIndex}: missing required value for column "${spec.name}"`);
+    }
+    if (value !== undefined) columns[spec.name] = value;
+  }
+  return { rowIndex: raw.rowIndex, columns, originalRow: raw.originalRow };
+}
+
+/** Resolve requested member ids against a family, defaulting to all members. */
+export function resolveMembers(
+  family: EvaluatorFamily,
+  selectedMemberIds?: string[],
+): FamilyMember[] {
+  if (!selectedMemberIds || selectedMemberIds.length === 0) return family.members;
+  const byId = new Map(family.members.map((m) => [m.id, m]));
+  const resolved: FamilyMember[] = [];
+  for (const id of selectedMemberIds) {
+    const member = byId.get(id);
+    if (!member) {
+      throw new Error(
+        `Unknown evaluator "${id}" for family "${family.id}". ` +
+          `Available: ${family.members.map((m) => m.id).join(', ')}`,
+      );
+    }
+    resolved.push(member);
+  }
+  return resolved;
+}
+
+export { Provider };

--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -1,0 +1,98 @@
+import {
+  VocabularyEvaluator,
+  SentenceStructureEvaluator,
+  GradeLevelAppropriatenessEvaluator,
+  SmkEvaluator,
+  ConventionalityEvaluator,
+  PurposeEvaluator,
+} from '../../evaluators/index.js';
+import type { BaseEvaluatorConfig, ModelOverride } from '../../evaluators/base.js';
+import { Provider } from '../../evaluators/base.js';
+import type { EvaluationResult } from '../../schemas/index.js';
+import {
+  type ColumnSpec,
+  type EvaluatorFamily,
+  type FamilyRow,
+  type FamilyRunContext,
+  type FamilyRunner,
+  type KeyKind,
+  type TaskOutcome,
+  resolveMembers,
+} from './family.js';
+
+interface SimpleEvaluator {
+  evaluate(text: string, grade: string): Promise<EvaluationResult<string, unknown>>;
+}
+type EvaluatorConstructor = new (config: BaseEvaluatorConfig) => SimpleEvaluator;
+
+const EVALUATOR_MAP = new Map<string, EvaluatorConstructor>([
+  [GradeLevelAppropriatenessEvaluator.metadata.id, GradeLevelAppropriatenessEvaluator],
+  [SmkEvaluator.metadata.id, SmkEvaluator],
+  [VocabularyEvaluator.metadata.id, VocabularyEvaluator],
+  [SentenceStructureEvaluator.metadata.id, SentenceStructureEvaluator],
+  [ConventionalityEvaluator.metadata.id, ConventionalityEvaluator],
+  [PurposeEvaluator.metadata.id, PurposeEvaluator],
+]);
+
+const MEMBERS = [
+  { id: GradeLevelAppropriatenessEvaluator.metadata.id, name: GradeLevelAppropriatenessEvaluator.metadata.name },
+  { id: SmkEvaluator.metadata.id, name: SmkEvaluator.metadata.name },
+  { id: VocabularyEvaluator.metadata.id, name: VocabularyEvaluator.metadata.name },
+  { id: SentenceStructureEvaluator.metadata.id, name: SentenceStructureEvaluator.metadata.name },
+  { id: ConventionalityEvaluator.metadata.id, name: ConventionalityEvaluator.metadata.name },
+  { id: PurposeEvaluator.metadata.id, name: PurposeEvaluator.metadata.name },
+];
+
+const COLUMNS: ColumnSpec[] = [
+  { name: 'text', required: true },
+  { name: 'grade', required: true },
+];
+
+class QtcRunner implements FamilyRunner {
+  readonly members;
+  private readonly instances = new Map<string, SimpleEvaluator>();
+
+  constructor(private readonly ctx: FamilyRunContext, selectedMemberIds?: string[]) {
+    this.members = resolveMembers(QTC_FAMILY, selectedMemberIds);
+  }
+
+  private getEvaluator(memberId: string): SimpleEvaluator {
+    let instance = this.instances.get(memberId);
+    if (!instance) {
+      const EvaluatorClass = EVALUATOR_MAP.get(memberId);
+      if (!EvaluatorClass) throw new Error(`Unknown QTC evaluator: ${memberId}`);
+      instance = new EvaluatorClass({
+        googleApiKey: this.ctx.googleApiKey,
+        openaiApiKey: this.ctx.openaiApiKey,
+        anthropicApiKey: this.ctx.anthropicApiKey,
+        maxRetries: this.ctx.maxRetries,
+        telemetry: this.ctx.telemetry,
+        modelOverride: this.ctx.modelOverride,
+        llmProvider: this.ctx.llmProvider,
+      });
+      this.instances.set(memberId, instance);
+    }
+    return instance;
+  }
+
+  async runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome> {
+    const result = await this.getEvaluator(memberId).evaluate(row.columns.text, row.columns.grade);
+    return { score: result.score, reasoning: result.reasoning };
+  }
+}
+
+export const QTC_FAMILY: EvaluatorFamily = {
+  id: 'text-complexity',
+  name: 'Text Complexity Analysis',
+  description: 'Evaluates all dimensions of the Qualitative Text Complexity rubric',
+  members: MEMBERS,
+  columns: COLUMNS,
+  maxInputRows: 50,
+  requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
+    if (modelOverride) return [modelOverride.provider];
+    return [Provider.Google, Provider.OpenAI];
+  },
+  createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner {
+    return new QtcRunner(ctx, selectedMemberIds);
+  },
+};

--- a/sdks/typescript/src/batch/families/registry.ts
+++ b/sdks/typescript/src/batch/families/registry.ts
@@ -1,0 +1,21 @@
+import type { EvaluatorFamily } from './family.js';
+import { QTC_FAMILY } from './qtc.js';
+import { STANDARDS_FAMILY } from './standards.js';
+
+const FAMILIES: EvaluatorFamily[] = [QTC_FAMILY, STANDARDS_FAMILY];
+
+/** All evaluator families available to the batch tool. */
+export function getFamilies(): EvaluatorFamily[] {
+  return [...FAMILIES];
+}
+
+/** Look up a family by id, or throw with the list of valid ids. */
+export function getFamily(id: string): EvaluatorFamily {
+  const family = FAMILIES.find((f) => f.id === id);
+  if (!family) {
+    throw new Error(
+      `Unknown evaluator family: "${id}". Available: ${FAMILIES.map((f) => f.id).join(', ')}`,
+    );
+  }
+  return family;
+}

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -1,0 +1,105 @@
+import {
+  MathStandardsAlignmentEvaluator,
+  type StandardAlignmentResult,
+} from '../../evaluators/math/standards-alignment.js';
+import { Jurisdiction } from '../../knowledge-graph/index.js';
+import { Provider } from '../../evaluators/base.js';
+import type { ModelOverride } from '../../evaluators/base.js';
+import {
+  type ColumnSpec,
+  type EvaluatorFamily,
+  type FamilyRow,
+  type FamilyRunContext,
+  type FamilyRunner,
+  type KeyKind,
+  type TaskOutcome,
+  resolveMembers,
+} from './family.js';
+
+const EVALUATOR_ID = MathStandardsAlignmentEvaluator.metadata.id;
+
+const MEMBERS = [{ id: EVALUATOR_ID, name: MathStandardsAlignmentEvaluator.metadata.name }];
+
+// question + statementCode are load-bearing; jurisdiction defaults to CCSS
+// (Multi-State); grade + id are passthrough metadata (report slicing / joining).
+const COLUMNS: ColumnSpec[] = [
+  { name: 'question', aliases: ['text'], required: true },
+  { name: 'statementCode', aliases: ['statement_code', 'ccss_standard', 'standard'], required: true },
+  { name: 'jurisdiction', required: false, default: Jurisdiction.MultiState },
+  { name: 'grade', required: false },
+  { name: 'id', required: false },
+];
+
+const VALID_JURISDICTIONS = new Set<string>(Object.values(Jurisdiction));
+
+function resolveJurisdiction(raw: string | undefined): Jurisdiction {
+  const value = (raw ?? Jurisdiction.MultiState).trim();
+  if (!VALID_JURISDICTIONS.has(value)) {
+    throw new Error(
+      `Invalid jurisdiction "${value}". Expected one of the Learning Commons jurisdictions ` +
+        `(e.g. "${Jurisdiction.MultiState}").`,
+    );
+  }
+  return value as Jurisdiction;
+}
+
+/** Structured verdict carried on BatchResult.payload for standards rows. */
+export interface StandardsVerdict extends StandardAlignmentResult {
+  question: string;
+  jurisdiction: Jurisdiction;
+}
+
+class StandardsRunner implements FamilyRunner {
+  readonly members;
+  private readonly evaluator: MathStandardsAlignmentEvaluator;
+
+  constructor(ctx: FamilyRunContext, selectedMemberIds?: string[]) {
+    this.members = resolveMembers(STANDARDS_FAMILY, selectedMemberIds);
+    this.evaluator = new MathStandardsAlignmentEvaluator({
+      platformApiKey: ctx.platformApiKey,
+      anthropicApiKey: ctx.anthropicApiKey,
+      // Forwarded so a `--model google:…`/`openai:…` override has its key.
+      googleApiKey: ctx.googleApiKey,
+      openaiApiKey: ctx.openaiApiKey,
+      maxRetries: ctx.maxRetries,
+      telemetry: ctx.telemetry,
+      modelOverride: ctx.modelOverride,
+      llmProvider: ctx.llmProvider,
+      concurrency: ctx.concurrency,
+      kgConcurrency: ctx.kgConcurrency,
+    });
+  }
+
+  async runTask(row: FamilyRow, _memberId?: string): Promise<TaskOutcome> {
+    const jurisdiction = resolveJurisdiction(row.columns.jurisdiction);
+    const result = await this.evaluator.evaluate(
+      row.columns.question,
+      row.columns.statementCode,
+      jurisdiction,
+    );
+    const verdict: StandardsVerdict = { ...result, question: row.columns.question, jurisdiction };
+    return {
+      score: `${result.alignedCount}/${result.totalCount}`,
+      reasoning: `${result.alignedCount} of ${result.totalCount} learning components aligned`,
+      payload: verdict,
+    };
+  }
+}
+
+export const STANDARDS_FAMILY: EvaluatorFamily = {
+  id: 'math-standards-alignment',
+  name: 'Math Standards Alignment',
+  description:
+    'Evaluates whether each item aligns to its tagged math standard, component by component',
+  members: MEMBERS,
+  columns: COLUMNS,
+  maxInputRows: 5000,
+  requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
+    // The platform key (Knowledge Graph) is always required; the LLM provider
+    // is Anthropic unless a model override redirects it.
+    return [modelOverride?.provider ?? Provider.Anthropic, 'platform'];
+  },
+  createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner {
+    return new StandardsRunner(ctx, selectedMemberIds);
+  },
+};

--- a/sdks/typescript/src/batch/index.ts
+++ b/sdks/typescript/src/batch/index.ts
@@ -15,10 +15,18 @@
  * ```
  */
 
-export { BatchEvaluator, getAvailableGroups } from './evaluator.js';
+export { BatchEvaluator, getAvailableGroups, getFamilies, getFamily } from './evaluator.js';
+export type { BatchRunOptions } from './evaluator.js';
 export { parseCSV } from './csv.js';
 export { formatAsCSV, formatAsHTML } from './formatters.js';
 export type { ReportMeta } from './formatters.js';
+export type {
+  EvaluatorFamily,
+  FamilyMember,
+  FamilyRow,
+  ColumnSpec,
+  KeyKind,
+} from './families/family.js';
 export type {
   EvaluatorGroup,
   BatchInput,

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -3,30 +3,32 @@
  */
 import type { TelemetryOptions, ModelOverride } from '../evaluators/base.js';
 import type { LLMProvider } from '../providers/index.js';
+import type { FamilyRow } from './families/family.js';
 
 /**
- * Input row from CSV
+ * Input row from CSV: canonical columns (validated + defaults applied by the
+ * selected family) plus the untouched original row for passthrough into outputs.
  */
 export interface BatchInput {
-  text: string;
-  grade: string;
   rowIndex: number;
+  columns: Record<string, string>;
   originalRow: Record<string, unknown>; // Preserve all original CSV columns
 }
 
 /**
- * Individual evaluation task
+ * Individual evaluation task: one family member run against one input row.
  */
 export interface BatchTask {
-  text: string;
-  grade: string;
-  evaluatorId: string;
-  rowIndex: number;
-  originalRow: Record<string, unknown>;
+  row: FamilyRow;
+  memberId: string;
 }
 
 /**
- * Result from a single evaluation
+ * Result from a single evaluation.
+ *
+ * `text`/`grade` are convenience projections of the corresponding columns when
+ * present (used by the text-complexity report); `payload` carries the full
+ * structured verdict for families whose output isn't a scalar score.
  */
 export interface BatchResult {
   rowIndex: number;
@@ -37,6 +39,7 @@ export interface BatchResult {
   score?: string;
   reasoning?: string;
   error?: string;
+  payload?: unknown;
   processingTimeMs: number;
   originalRow: Record<string, unknown>; // Preserve all original CSV columns
 }
@@ -83,8 +86,12 @@ export interface BatchConfig {
   googleApiKey?: string;
   openaiApiKey?: string;
   anthropicApiKey?: string;
+  /** Learning Commons platform key — required for families that hit the Knowledge Graph. */
+  platformApiKey?: string;
   concurrency?: number;
   maxRetries?: number;
+  /** Max concurrent Knowledge Graph HTTP calls, for families that use it. */
+  kgConcurrency?: number;
   telemetry?: boolean | TelemetryOptions;
   bypassRowLimit?: boolean;
   modelOverride?: ModelOverride;

--- a/sdks/typescript/tests/integration/batch.integration.test.ts
+++ b/sdks/typescript/tests/integration/batch.integration.test.ts
@@ -59,8 +59,10 @@ describeIntegration('Batch Evaluator - Integration', () => {
 
       const startTime = Date.now();
       const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-      const output = await evaluator.evaluate(inputs, group.id, (result) => {
-        console.log(`  ✓ Row ${result.rowIndex} [${result.evaluatorId}] - ${result.status}: ${result.score || result.error}`);
+      const output = await evaluator.evaluate(inputs, group.id, {
+        onProgress: (result) => {
+          console.log(`  ✓ Row ${result.rowIndex} [${result.evaluatorId}] - ${result.status}: ${result.score || result.error}`);
+        },
       });
       const duration = Date.now() - startTime;
 
@@ -120,13 +122,15 @@ describeIntegration('Batch Evaluator - Integration', () => {
 
       // Single row — verify all group evaluators ran
       const inputs: BatchInput[] = [
-        { text: 'The cat sat on the mat.', grade: '3', rowIndex: 1, originalRow: { text: 'The cat sat on the mat.', grade: '3' } },
+        { rowIndex: 1, columns: { text: 'The cat sat on the mat.', grade: '3' }, originalRow: { text: 'The cat sat on the mat.', grade: '3' } },
       ];
 
       console.log(`\n📊 Processing 1 row with ${group.evaluatorIds.length} evaluators...`);
 
-      const output = await evaluator.evaluate(inputs, group.id, (result) => {
-        console.log(`  ✓ ${result.evaluatorId} - ${result.status}: ${result.score || result.error}`);
+      const output = await evaluator.evaluate(inputs, group.id, {
+        onProgress: (result) => {
+          console.log(`  ✓ ${result.evaluatorId} - ${result.status}: ${result.score || result.error}`);
+        },
       });
 
       // Should have 1 result per evaluator in the group

--- a/sdks/typescript/tests/unit/batch/column-normalization.test.ts
+++ b/sdks/typescript/tests/unit/batch/column-normalization.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeRow,
+  validateRequiredColumns,
+  resolveMembers,
+} from '../../../src/batch/families/family.js';
+import { QTC_FAMILY } from '../../../src/batch/families/qtc.js';
+import { STANDARDS_FAMILY } from '../../../src/batch/families/standards.js';
+import { Jurisdiction } from '../../../src/knowledge-graph/index.js';
+
+function raw(columns: Record<string, string>, rowIndex = 2) {
+  return { rowIndex, columns, originalRow: { ...columns } };
+}
+
+describe('validateRequiredColumns', () => {
+  it('passes when required columns are present (via canonical name)', () => {
+    expect(() => validateRequiredColumns(STANDARDS_FAMILY, ['question', 'statementCode'])).not.toThrow();
+  });
+
+  it('accepts aliases for required columns', () => {
+    // standards: statementCode alias "ccss_standard", question alias "text"
+    expect(() => validateRequiredColumns(STANDARDS_FAMILY, ['text', 'ccss_standard'])).not.toThrow();
+  });
+
+  it('throws listing the missing canonical column', () => {
+    expect(() => validateRequiredColumns(STANDARDS_FAMILY, ['question'])).toThrow(/statementCode/);
+  });
+});
+
+describe('normalizeRow — standards family', () => {
+  it('maps aliases onto canonical names', () => {
+    const row = normalizeRow(raw({ text: '2+2=?', ccss_standard: '4.OA.A.1' }), STANDARDS_FAMILY);
+    expect(row.columns.question).toBe('2+2=?');
+    expect(row.columns.statementCode).toBe('4.OA.A.1');
+  });
+
+  it('applies the Multi-State jurisdiction default when absent', () => {
+    const row = normalizeRow(raw({ question: 'q', statementCode: '4.OA.A.1' }), STANDARDS_FAMILY);
+    expect(row.columns.jurisdiction).toBe(Jurisdiction.MultiState);
+  });
+
+  it('keeps an explicit jurisdiction over the default', () => {
+    const row = normalizeRow(
+      raw({ question: 'q', statementCode: '4.OA.A.1', jurisdiction: 'California' }),
+      STANDARDS_FAMILY,
+    );
+    expect(row.columns.jurisdiction).toBe('California');
+  });
+
+  it('throws for a row missing a required value', () => {
+    expect(() => normalizeRow(raw({ question: 'q' }), STANDARDS_FAMILY)).toThrow(/statementCode/);
+  });
+
+  it('prefers the canonical column over an alias when both are present', () => {
+    // `question` has alias `text`; a CSV with both must use the canonical column.
+    const row = normalizeRow(
+      raw({ text: 'passage context', question: '2+2=?', statementCode: '4.OA.A.1' }),
+      STANDARDS_FAMILY,
+    );
+    expect(row.columns.question).toBe('2+2=?');
+  });
+
+  it('falls back to an alias when the canonical column is present but empty', () => {
+    const row = normalizeRow(
+      raw({ question: '', text: 'the real item', statementCode: '4.OA.A.1' }),
+      STANDARDS_FAMILY,
+    );
+    expect(row.columns.question).toBe('the real item');
+  });
+});
+
+describe('normalizeRow — QTC family', () => {
+  it('requires text and grade', () => {
+    expect(() => normalizeRow(raw({ text: 'hello' }), QTC_FAMILY)).toThrow(/grade/);
+  });
+});
+
+describe('resolveMembers', () => {
+  it('defaults to all members', () => {
+    expect(resolveMembers(QTC_FAMILY).length).toBe(QTC_FAMILY.members.length);
+  });
+
+  it('resolves a selected subset in order', () => {
+    const selected = resolveMembers(QTC_FAMILY, ['vocabulary', 'conventionality']);
+    expect(selected.map((m) => m.id)).toEqual(['vocabulary', 'conventionality']);
+  });
+
+  it('throws for an unknown member id', () => {
+    expect(() => resolveMembers(QTC_FAMILY, ['nope'])).toThrow(/Unknown evaluator "nope"/);
+  });
+});

--- a/sdks/typescript/tests/unit/batch/csv-parsing.test.ts
+++ b/sdks/typescript/tests/unit/batch/csv-parsing.test.ts
@@ -7,7 +7,7 @@ import { parseCSV } from '../../../src/batch/index.js';
 // ---- Helpers ----
 
 function withTempCSV(content: string, fn: (csvPath: string) => void): void {
-  const tmpPath = path.join(os.tmpdir(), `batch-test-${Date.now()}.csv`);
+  const tmpPath = path.join(os.tmpdir(), `batch-test-${Date.now()}-${Math.round(performance.now())}.csv`);
   fs.writeFileSync(tmpPath, content);
   try {
     fn(tmpPath);
@@ -17,34 +17,27 @@ function withTempCSV(content: string, fn: (csvPath: string) => void): void {
 }
 
 // ---- Tests ----
+//
+// parseCSV is family-agnostic: it reads every column into `columns` keyed by
+// header and imposes no schema. Column requirements/aliases/defaults are the
+// family's job (see column-normalization.test.ts).
 
 describe('parseCSV', () => {
-  describe('column detection', () => {
-    it('finds text and grade columns case-insensitively', () => {
-      // batch-test.csv has "TEXT" and "  Grade  " (with whitespace padding)
-      const csvPath = path.join(__dirname, '../../fixtures/batch-test.csv');
-      const inputs = parseCSV(csvPath);
-      expect(inputs.length).toBeGreaterThan(0);
-      for (const input of inputs) {
-        expect(input.text).toBeTruthy();
-        expect(input.grade).toBeTruthy();
-      }
-    });
-
-    it('accepts uppercase TEXT and mixed-case Grade columns', () => {
+  describe('generic column capture', () => {
+    it('captures every column keyed by its header', () => {
       withTempCSV('TEXT,Grade\nhello world,5', (p) => {
         const inputs = parseCSV(p);
         expect(inputs).toHaveLength(1);
-        expect(inputs[0].text).toBe('hello world');
-        expect(inputs[0].grade).toBe('5');
+        expect(inputs[0].columns.TEXT).toBe('hello world');
+        expect(inputs[0].columns.Grade).toBe('5');
       });
     });
 
-    it('accepts columns with surrounding whitespace in the header', () => {
-      withTempCSV('  text  ,  grade  \nhello world,5', (p) => {
+    it('trims values', () => {
+      withTempCSV('question,standard\n  2 + 2 = ?  ,  4.OA.A.1  ', (p) => {
         const inputs = parseCSV(p);
-        expect(inputs).toHaveLength(1);
-        expect(inputs[0].text).toBe('hello world');
+        expect(inputs[0].columns.question).toBe('2 + 2 = ?');
+        expect(inputs[0].columns.standard).toBe('4.OA.A.1');
       });
     });
   });
@@ -56,22 +49,14 @@ describe('parseCSV', () => {
       expect(parseCSV(csvPath)).toHaveLength(2);
     });
 
-    it('trims text and grade values', () => {
-      for (const input of parseCSV(csvPath)) {
-        expect(input.text).toBe(input.text.trim());
-        expect(input.grade).toBe(input.grade.trim());
-      }
-    });
-
     it('assigns rowIndex matching the 1-based CSV line number (header is line 1)', () => {
       const inputs = parseCSV(csvPath);
-      expect(inputs[0].rowIndex).toBe(2); // first data row is CSV line 2
-      expect(inputs[1].rowIndex).toBe(3); // second data row is CSV line 3
+      expect(inputs[0].rowIndex).toBe(2);
+      expect(inputs[1].rowIndex).toBe(3);
     });
 
     it('preserves all original CSV columns in originalRow', () => {
       const inputs = parseCSV(csvPath);
-      // batch-test.csv has: row_id, TEXT, Grade, source, category
       expect(inputs[0].originalRow).toHaveProperty('row_id');
       expect(inputs[0].originalRow).toHaveProperty('source');
       expect(inputs[0].originalRow).toHaveProperty('category');
@@ -79,26 +64,17 @@ describe('parseCSV', () => {
   });
 
   describe('row filtering', () => {
-    it('skips rows where text is empty', () => {
-      withTempCSV('text,grade\nhello world,5\n,4\ngoodbye world,3', (p) => {
+    it('skips fully-empty rows but keeps rows with any value', () => {
+      withTempCSV('text,grade\nhello world,5\n,\ngoodbye world,', (p) => {
         const inputs = parseCSV(p);
         expect(inputs).toHaveLength(2);
-        expect(inputs[0].text).toBe('hello world');
-        expect(inputs[1].text).toBe('goodbye world');
-      });
-    });
-
-    it('skips rows where grade is empty', () => {
-      withTempCSV('text,grade\nhello world,5\ngoodbye world,', (p) => {
-        const inputs = parseCSV(p);
-        expect(inputs).toHaveLength(1);
-        expect(inputs[0].text).toBe('hello world');
+        expect(inputs[0].columns.text).toBe('hello world');
+        expect(inputs[1].columns.text).toBe('goodbye world');
       });
     });
 
     it('preserves the original CSV line number in rowIndex even when rows are skipped', () => {
-      // header=line1, first=line2, skipped=line3, second=line4
-      withTempCSV('text,grade\nfirst,3\n,4\nsecond,5', (p) => {
+      withTempCSV('text,grade\nfirst,3\n,\nsecond,5', (p) => {
         const inputs = parseCSV(p);
         expect(inputs).toHaveLength(2);
         expect(inputs[0].rowIndex).toBe(2);
@@ -115,18 +91,6 @@ describe('parseCSV', () => {
     it('throws when file is empty', () => {
       withTempCSV('', (p) => {
         expect(() => parseCSV(p)).toThrow('CSV file is empty');
-      });
-    });
-
-    it('throws when "text" column is missing', () => {
-      withTempCSV('grade,content\n5,hello world', (p) => {
-        expect(() => parseCSV(p)).toThrow('"text" column');
-      });
-    });
-
-    it('throws when "grade" column is missing', () => {
-      withTempCSV('text,level\nhello world,5', (p) => {
-        expect(() => parseCSV(p)).toThrow('"grade" column');
       });
     });
   });

--- a/sdks/typescript/tests/unit/batch/limits.test.ts
+++ b/sdks/typescript/tests/unit/batch/limits.test.ts
@@ -244,6 +244,37 @@ describe('BatchEvaluator.evaluate() — row-level failures and empty input', () 
     expect(createRunner).not.toHaveBeenCalled();
   });
 
+  // One key at a time: the hint must fire on either alone, not only on both.
+  it.each(['text', 'grade'])(
+    'rejects a row in the pre-family shape carrying only %s, naming the fix',
+    async (key) => {
+      const evaluator = new BatchEvaluator({ telemetry: false });
+      const family = stubFamily(async () => ({ score: 's', reasoning: '' }));
+      // Without the shape check this reached Object.keys(undefined) and threw a bare
+      // "Cannot convert undefined or null to object", naming nothing.
+      const legacy = [{ [key]: '3', rowIndex: 2, originalRow: {} }];
+
+      await expect(evaluator.evaluate(legacy as never, family)).rejects.toThrow(
+        /row 2: expected a "columns" record.*received undefined.*predate family-aware input/s,
+      );
+    },
+  );
+
+  it.each([
+    ['null', null, 'null'],
+    ['an array', ['text', 'grade'], 'an array'],
+    ['a string', 'text,grade', 'string'],
+  ])('rejects columns given as %s, reporting what it received', async (_label, columns, received) => {
+    const evaluator = new BatchEvaluator({ telemetry: false });
+    const family = stubFamily(async () => ({ score: 's', reasoning: '' }));
+    const bad = [{ rowIndex: 7, columns, originalRow: {} }];
+
+    const run = evaluator.evaluate(bad as never, family);
+    await expect(run).rejects.toThrow(`received ${received}.`);
+    // No legacy keys, so the generic guidance applies rather than the migration hint.
+    await expect(run).rejects.toThrow(/supply columns explicitly/);
+  });
+
   it('turns a row that fails normalization into per-member errors without losing the good rows', async () => {
     const evaluator = new BatchEvaluator({ telemetry: false });
     const family = stubFamily(async () => ({ score: 'slightly complex', reasoning: 'ok' }));

--- a/sdks/typescript/tests/unit/batch/limits.test.ts
+++ b/sdks/typescript/tests/unit/batch/limits.test.ts
@@ -1,14 +1,55 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getAvailableGroups, BatchEvaluator, Provider } from '../../../src/batch/index.js';
 import type { BatchInput, BatchConfig, BatchResult } from '../../../src/batch/index.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+import type { EvaluatorFamily, FamilyRow, TaskOutcome } from '../../../src/batch/families/family.js';
+
+/**
+ * A deterministic stub family for exercising BatchEvaluator orchestration
+ * (cancellation, state reset, config plumbing) without real evaluators or
+ * network. `evaluate` accepts a family object directly, so no internal poking.
+ */
+function stubFamily(runTask: (row: FamilyRow, memberId: string) => Promise<TaskOutcome>): EvaluatorFamily {
+  const members = [
+    { id: 'stub-a', name: 'Stub A' },
+    { id: 'stub-b', name: 'Stub B' },
+    { id: 'stub-c', name: 'Stub C' },
+  ];
+  return {
+    id: 'stub-family',
+    name: 'Stub',
+    description: 'stub',
+    members,
+    columns: [
+      { name: 'text', required: true },
+      { name: 'grade', required: true },
+    ],
+    maxInputRows: 1000,
+    requiredKeys: () => [],
+    createRunner: () => ({ members, runTask }),
+  };
+}
 
 function makeInputs(count: number): BatchInput[] {
   return Array.from({ length: count }, (_, i) => ({
-    text: 'The cat sat on the mat.',
-    grade: '3',
     rowIndex: i + 2,
+    columns: { text: 'The cat sat on the mat.', grade: '3' },
     originalRow: { text: 'The cat sat on the mat.', grade: '3' },
   }));
+}
+
+/** A fake provider so QTC evaluators run without network or API keys. */
+function fakeProvider(): LLMProvider {
+  return {
+    label: 'fake:model',
+    generateStructured: vi.fn().mockResolvedValue({
+      data: { grade: '2-3', alternative_grade: '4-5', scaffolding_needed: '', reasoning: 'stub' },
+      model: 'fake:model',
+      usage: { inputTokens: 1, outputTokens: 1 },
+      latencyMs: 1,
+    }),
+    generateText: vi.fn().mockResolvedValue({ text: '', usage: { inputTokens: 0, outputTokens: 0 }, latencyMs: 0 }),
+  };
 }
 
 describe('getAvailableGroups', () => {
@@ -60,9 +101,9 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
     openaiApiKey: 'fake-openai-key',
   });
 
-  it('throws for an unknown groupId before any evaluator is initialised', async () => {
+  it('throws for an unknown familyId', async () => {
     await expect(evaluator.evaluate(makeInputs(1), 'nonexistent-group'))
-      .rejects.toThrow('Unknown evaluator group: "nonexistent-group"');
+      .rejects.toThrow('Unknown evaluator family: "nonexistent-group"');
   });
 
   it('throws when input row count exceeds the group maxInputRows', async () => {
@@ -76,15 +117,7 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
   it('does not throw the limit error when input count equals maxInputRows', async () => {
     const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
     const atLimit = makeInputs(group.maxInputRows);
-    const boundary = new BatchEvaluator({
-      googleApiKey: 'fake-google-key',
-      openaiApiKey: 'fake-openai-key',
-    });
-    const makeStub = () => ({
-      evaluate: async () => ({ score: 1, reasoning: 'stub', metadata: {} }),
-    });
-    const instances = (boundary as unknown as { evaluatorInstances: Map<string, ReturnType<typeof makeStub>> }).evaluatorInstances;
-    for (const id of group.evaluatorIds) instances.set(id, makeStub());
+    const boundary = new BatchEvaluator({ llmProvider: fakeProvider(), telemetry: false });
 
     await expect(boundary.evaluate(atLimit, group.id)).resolves.toBeDefined();
   });
@@ -114,25 +147,17 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
     const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
     const tooMany = makeInputs(group.maxInputRows + 1);
     const bypassed = new BatchEvaluator({
-      googleApiKey: 'fake-google-key',
-      openaiApiKey: 'fake-openai-key',
+      llmProvider: fakeProvider(),
+      telemetry: false,
       bypassRowLimit: true,
     });
 
-    // Pre-populate evaluatorInstances with no-op stubs. initializeEvaluators
-    // skips IDs already present in the map, so these stubs survive and
-    // executeTask runs against them — no real network calls, no race.
-    const makeStub = () => ({
-      evaluate: async () => ({ score: 1, reasoning: 'stub', metadata: {} }),
-    });
-    const instances = (bypassed as unknown as { evaluatorInstances: Map<string, ReturnType<typeof makeStub>> }).evaluatorInstances;
-    for (const id of group.evaluatorIds) instances.set(id, makeStub());
-
     const output = await bypassed.evaluate(tooMany, group.id);
     const expectedTasks = tooMany.length * group.evaluatorIds.length;
+    // The bypass is proven by all rows being processed (totalTasks reflects the
+    // over-limit input) rather than the run throwing the limit error.
     expect(output.summary.totalTasks).toBe(expectedTasks);
-    expect(output.summary.successful).toBe(expectedTasks);
-    expect(output.summary.failed).toBe(0);
+    expect(output.summary.successful + output.summary.failed).toBe(expectedTasks);
   });
 
   it('cancel() before evaluation starts returns an empty array', () => {
@@ -141,51 +166,48 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
   });
 
   it('cancel() mid-evaluation marks queued tasks as cancelled and includes them in completedResults', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
     // concurrency:1 ensures tasks run sequentially so cancel() reliably affects later ones
-    const evaluator = new BatchEvaluator({ googleApiKey: 'k', openaiApiKey: 'k', concurrency: 1 });
+    const evaluator = new BatchEvaluator({ telemetry: false, concurrency: 1 });
 
-    const instances = (evaluator as unknown as { evaluatorInstances: Map<string, unknown> }).evaluatorInstances;
     let firstDone = false;
-    for (const id of group.evaluatorIds) {
-      instances.set(id, {
-        evaluate: async () => {
-          if (!firstDone) { firstDone = true; evaluator.cancel(); }
-          return { score: 'slightly complex', reasoning: 'stub', metadata: {} };
-        },
-      });
-    }
+    const family = stubFamily(async () => {
+      if (!firstDone) { firstDone = true; evaluator.cancel(); }
+      return { score: 'slightly complex', reasoning: 'stub' };
+    });
 
-    const output = await evaluator.evaluate(makeInputs(1), group.id);
+    const output = await evaluator.evaluate(makeInputs(1), family);
     const successful = output.results.filter(r => r.status === 'success');
     const cancelled = output.results.filter(r => r.status === 'error' && r.error === 'Cancelled by user');
 
     expect(successful.length).toBeGreaterThanOrEqual(1);
     expect(cancelled.length).toBeGreaterThan(0);
-    expect(successful.length + cancelled.length).toBe(group.evaluatorIds.length);
+    expect(successful.length + cancelled.length).toBe(family.members.length);
 
     // Cancelled tasks must be in completedResults so Ctrl+C partial saves are complete
     const completedResults = (evaluator as unknown as { completedResults: BatchResult[] }).completedResults;
-    expect(completedResults.length).toBe(group.evaluatorIds.length);
+    expect(completedResults.length).toBe(family.members.length);
   });
 
   it('evaluate() resets state between calls — second call produces a clean result set', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const evaluator = new BatchEvaluator({ googleApiKey: 'k', openaiApiKey: 'k' });
+    const evaluator = new BatchEvaluator({ telemetry: false });
+    const family = stubFamily(async () => ({ score: 'slightly complex', reasoning: 'stub' }));
 
-    const instances = (evaluator as unknown as { evaluatorInstances: Map<string, unknown> }).evaluatorInstances;
-    for (const id of group.evaluatorIds) {
-      instances.set(id, { evaluate: async () => ({ score: 'slightly complex', reasoning: 'stub', metadata: {} }) });
-    }
-
-    const first = await evaluator.evaluate(makeInputs(1), group.id);
-    const second = await evaluator.evaluate(makeInputs(1), group.id);
+    const first = await evaluator.evaluate(makeInputs(1), family);
+    const second = await evaluator.evaluate(makeInputs(1), family);
 
     // Second call must not accumulate results from the first
-    expect(second.summary.totalTasks).toBe(group.evaluatorIds.length);
-    expect(second.summary.successful).toBe(group.evaluatorIds.length);
+    expect(second.summary.totalTasks).toBe(family.members.length);
+    expect(second.summary.successful).toBe(family.members.length);
     // And first call must be unaffected
-    expect(first.summary.totalTasks).toBe(group.evaluatorIds.length);
+    expect(first.summary.totalTasks).toBe(family.members.length);
+  });
+
+  it('accepts a bare onProgress callback as the third arg (back-compat)', async () => {
+    const evaluator = new BatchEvaluator({ telemetry: false });
+    const family = stubFamily(async () => ({ score: 'ok', reasoning: 'stub' }));
+    const seen: BatchResult[] = [];
+    await evaluator.evaluate(makeInputs(1), family, (r) => seen.push(r));
+    expect(seen.length).toBe(family.members.length); // progress still reported
   });
 });
 
@@ -200,16 +222,49 @@ describe('BatchEvaluator — modelOverride config', () => {
 
   it('evaluate() runs to completion with modelOverride set', async () => {
     const override = { provider: Provider.Anthropic, model: 'claude-opus-4-8' };
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const evaluator = new BatchEvaluator({ anthropicApiKey: 'akey', modelOverride: override });
+    const evaluator = new BatchEvaluator({ anthropicApiKey: 'akey', modelOverride: override, telemetry: false });
+    const family = stubFamily(async () => ({ score: 'slightly complex', reasoning: 'stub' }));
 
-    const instances = (evaluator as unknown as { evaluatorInstances: Map<string, unknown> }).evaluatorInstances;
-    for (const id of group.evaluatorIds) {
-      instances.set(id, { evaluate: async () => ({ score: 'slightly complex', reasoning: 'stub', metadata: {} }) });
-    }
-
-    const output = await evaluator.evaluate(makeInputs(1), group.id);
-    expect(output.summary.successful).toBe(group.evaluatorIds.length);
+    const output = await evaluator.evaluate(makeInputs(1), family);
+    expect(output.summary.successful).toBe(family.members.length);
     expect(output.summary.failed).toBe(0);
+  });
+});
+
+describe('BatchEvaluator.evaluate() — row-level failures and empty input', () => {
+  it('returns an empty output for no inputs without constructing a runner', async () => {
+    const evaluator = new BatchEvaluator({ telemetry: false });
+    const createRunner = vi.fn();
+    const family = { ...stubFamily(async () => ({ score: 's', reasoning: '' })), createRunner };
+
+    const output = await evaluator.evaluate([], family);
+
+    expect(output.results).toEqual([]);
+    expect(output.summary.totalTasks).toBe(0);
+    expect(createRunner).not.toHaveBeenCalled();
+  });
+
+  it('turns a row that fails normalization into per-member errors without losing the good rows', async () => {
+    const evaluator = new BatchEvaluator({ telemetry: false });
+    const family = stubFamily(async () => ({ score: 'slightly complex', reasoning: 'ok' }));
+    const seen: BatchResult[] = [];
+
+    // Header validation passes on row 1, so the empty `grade` is caught per row.
+    // parseCSV trims, so an empty cell arrives as '' — what normalizeRow rejects.
+    const inputs: BatchInput[] = [
+      { rowIndex: 2, columns: { text: 'fine', grade: '3' }, originalRow: { text: 'fine', grade: '3' } },
+      { rowIndex: 3, columns: { text: 'bad', grade: '' }, originalRow: { text: 'bad', grade: '' } },
+    ];
+
+    const output = await evaluator.evaluate(inputs, family, { onProgress: (r) => seen.push(r) });
+
+    const failed = output.results.filter((r) => r.status === 'error');
+    const ok = output.results.filter((r) => r.status === 'success');
+    expect(failed).toHaveLength(family.members.length);
+    expect(ok).toHaveLength(family.members.length);
+    expect(failed.every((r) => r.rowIndex === 3)).toBe(true);
+    expect(new Set(failed.map((r) => r.evaluatorId)).size).toBe(family.members.length);
+    // Reported through the same progress channel as evaluated rows.
+    expect(seen.filter((r) => r.status === 'error')).toHaveLength(family.members.length);
   });
 });

--- a/sdks/typescript/tests/unit/batch/llm-provider.test.ts
+++ b/sdks/typescript/tests/unit/batch/llm-provider.test.ts
@@ -35,25 +35,14 @@ function makeFakeProvider(label = 'vertex:gemini-2.5-pro') {
 }
 
 function makeInputs(count: number): BatchInput[] {
+  const text =
+    'The mitochondria is the powerhouse of the cell. It produces energy through a process ' +
+    'called cellular respiration in eukaryotic organisms.';
   return Array.from({ length: count }, (_, i) => ({
-    text:
-      'The mitochondria is the powerhouse of the cell. It produces energy through a process ' +
-      'called cellular respiration in eukaryotic organisms.',
-    grade: '6-8',
     rowIndex: i + 2,
+    columns: { text, grade: '6-8' },
     originalRow: { text: 'sample', grade: '6-8' },
   }));
-}
-
-/** Read the private evaluator instances the batch lazily constructs. */
-function instancesOf(
-  batch: BatchEvaluator
-): Map<string, { config?: { llmProvider?: LLMProvider } }> {
-  return (
-    batch as unknown as {
-      evaluatorInstances: Map<string, { config?: { llmProvider?: LLMProvider } }>;
-    }
-  ).evaluatorInstances;
 }
 
 describe('BatchConfig.llmProvider — bring-your-own-provider', () => {
@@ -68,17 +57,17 @@ describe('BatchConfig.llmProvider — bring-your-own-provider', () => {
     expect(generateStructured).toHaveBeenCalled();
   });
 
-  it('plumbs the injected provider into every evaluator in the group', async () => {
-    const { provider } = makeFakeProvider();
+  it('runs every member of the group through the injected provider', async () => {
+    const { provider, generateStructured } = makeFakeProvider();
     const batch = new BatchEvaluator({ llmProvider: provider, telemetry: false });
 
-    await batch.evaluate(makeInputs(1), GROUP.id);
+    // One task per member, all attempted, and the injected provider was used
+    // (no keys were supplied, so nothing could fall back to a real provider).
+    const { results } = await batch.evaluate(makeInputs(1), GROUP.id);
 
-    const instances = instancesOf(batch);
-    expect(instances.size).toBe(GROUP.evaluatorIds.length);
-    for (const id of GROUP.evaluatorIds) {
-      expect(instances.get(id)?.config?.llmProvider).toBe(provider);
-    }
+    expect(results).toHaveLength(GROUP.evaluatorIds.length);
+    expect(generateStructured).toHaveBeenCalled();
+    expect(results.some((r) => r.status === 'success')).toBe(true);
   });
 
   it('never reports a missing-API-key error when llmProvider is set', async () => {

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { STANDARDS_FAMILY } from '../../../src/batch/families/standards.js';
+import { Provider } from '../../../src/batch/index.js';
+import { Jurisdiction } from '../../../src/knowledge-graph/index.js';
+import type { FamilyRow } from '../../../src/batch/families/family.js';
+
+const MEMBER = 'math.standards-alignment';
+
+describe('STANDARDS_FAMILY.requiredKeys', () => {
+  it('requires the platform key plus Anthropic by default', () => {
+    expect(STANDARDS_FAMILY.requiredKeys([MEMBER])).toEqual([Provider.Anthropic, 'platform']);
+  });
+
+  it('swaps in the override provider (platform key still required)', () => {
+    expect(
+      STANDARDS_FAMILY.requiredKeys([MEMBER], { provider: Provider.Google, model: 'gemini-x' }),
+    ).toEqual([Provider.Google, 'platform']);
+  });
+});
+
+describe('STANDARDS_FAMILY.createRunner — provider-key forwarding', () => {
+  const base = { platformApiKey: 'p' };
+
+  it('constructs with a Google model override when the Google key is forwarded', () => {
+    expect(() =>
+      STANDARDS_FAMILY.createRunner({
+        ...base,
+        googleApiKey: 'g',
+        modelOverride: { provider: Provider.Google, model: 'gemini-x' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws when the override provider key is absent — proving the key path is actually wired', () => {
+    // If StandardsRunner failed to forward googleApiKey, this would throw regardless;
+    // the paired test above (which forwards it and does NOT throw) is what makes this meaningful.
+    expect(() =>
+      STANDARDS_FAMILY.createRunner({
+        ...base,
+        modelOverride: { provider: Provider.Google, model: 'gemini-x' },
+      }),
+    ).toThrow(/google/i);
+  });
+});
+
+describe('STANDARDS_FAMILY.runTask', () => {
+  const ALIGNMENT = {
+    statementCode: '3.MD.C.7.d',
+    learningComponents: [
+      { identifier: 'lc-1', description: 'a', reasoning: 'r', aligned: true, feedback: '' },
+      { identifier: 'lc-2', description: 'b', reasoning: 'r', aligned: false, feedback: 'revise' },
+    ],
+    alignedCount: 1,
+    totalCount: 2,
+  };
+
+  /** The runner builds a real evaluator; swap it for a stub so no network is needed. */
+  function runnerWithStub(evaluate: ReturnType<typeof vi.fn>) {
+    const runner = STANDARDS_FAMILY.createRunner({ platformApiKey: 'p', anthropicApiKey: 'a', telemetry: false });
+    (runner as unknown as { evaluator: { evaluate: unknown } }).evaluator = { evaluate };
+    return runner;
+  }
+
+  function row(columns: Record<string, string>): FamilyRow {
+    return { rowIndex: 2, columns, originalRow: columns };
+  }
+
+  it('reports aligned/total as the score and carries the full verdict as payload', async () => {
+    const evaluate = vi.fn().mockResolvedValue(ALIGNMENT);
+    const outcome = await runnerWithStub(evaluate).runTask(
+      row({ question: 'What is the area?', statementCode: '3.MD.C.7.d', jurisdiction: Jurisdiction.Utah }),
+      MEMBER,
+    );
+
+    expect(evaluate).toHaveBeenCalledWith('What is the area?', '3.MD.C.7.d', Jurisdiction.Utah);
+    expect(outcome.score).toBe('1/2');
+    expect(outcome.reasoning).toContain('1 of 2');
+    expect(outcome.payload).toMatchObject({
+      question: 'What is the area?',
+      jurisdiction: Jurisdiction.Utah,
+      alignedCount: 1,
+      totalCount: 2,
+    });
+  });
+
+  it('defaults an absent jurisdiction to Multi-State', async () => {
+    const evaluate = vi.fn().mockResolvedValue(ALIGNMENT);
+    await runnerWithStub(evaluate).runTask(row({ question: 'q', statementCode: '3.MD.C.7.d' }), MEMBER);
+
+    expect(evaluate).toHaveBeenCalledWith('q', '3.MD.C.7.d', Jurisdiction.MultiState);
+  });
+
+  it('rejects an unrecognised jurisdiction instead of passing it to the Knowledge Graph', async () => {
+    const evaluate = vi.fn();
+    await expect(
+      runnerWithStub(evaluate).runTask(row({ question: 'q', statementCode: 'x', jurisdiction: 'Utahh' }), MEMBER),
+    ).rejects.toThrow(/Invalid jurisdiction "Utahh"/);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -264,6 +264,18 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
     expect(info.uuid).toBe('recovered');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('caches successful lookups so repeated same-code calls fetch once', async () => {
+    // Guarantees a batch of N items over M unique standards does M fetches,
+    // not N (the standards family reuses one client across all rows).
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new KnowledgeGraphClient(API_KEY);
+    await client.getStandardInfo('4.G.A.1');
+    await client.getStandardInfo('4.G.A.1');
+    await client.getStandardInfo('4.G.A.1');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('KnowledgeGraphClient - getLearningComponents', () => {


### PR DESCRIPTION
## Summary

Refactors the batch-evaluation tool from a hardcoded single "evaluator group" into an **evaluator-family adapter architecture**, and lands **math standards-alignment** as the first non-text family. This is the base PR of a stack — output projections (JSON/HTML/CSV) and the CLI flow (family/member selection, `--yes`/non-interactive, platform-key resolution) follow in stacked PRs.

## Why

The batch tool assumed every evaluator was homogeneous: `evaluate(text, grade) → {score, reasoning}`, CSV requiring `text`+`grade`, one fixed group, a QTC-specific report. Math standards alignment breaks all of those (3-arg `evaluate(question, statementCode, jurisdiction)`, structured per-learning-component output, a platform/KG key). Rather than special-case it, this introduces a family seam so the next family (feedback) slots in without core changes.

## What changed

- **`src/batch/families/`** (new): `EvaluatorFamily` interface (members, columns, required keys, `createRunner`, `maxInputRows`) + registry. `family.ts` also owns column normalization (`normalizeRow`, `validateRequiredColumns`) with alias + default support.
- **`BatchEvaluator`** is now family-driven: it owns orchestration (concurrency, cancellation, per-task error isolation, timing) and delegates *how to invoke an evaluator* to the family runner. `evaluate()` accepts a family id **or** a family object.
- **QTC family**: the six text-complexity evaluators, behavior unchanged (all prior tests pass).
- **Standards family**: `math-standards-alignment`. Maps to a `{alignedCount, totalCount, learningComponents[]}` payload; jurisdiction defaults to Multi-State; platform key hard-required. Column aliases (`ccss_standard`→`statementCode`, `text`→`question`).
- **`parseCSV`** is now schema-agnostic (reads all columns); family owns validation/aliases/defaults. One malformed row → an error result, not a whole-run abort.
- **KG caching**: confirmed the client already promise-caches by `statementCode:jurisdiction`+UUID; the standards runner reuses one client across rows, so N items over M unique standards do M fetches. Locked with a positive cache-hit test.

## Input-shape change

`BatchInput` moves from `{ text, grade, rowIndex, originalRow }` to `{ rowIndex, columns, originalRow }`,
and `parseCSV` returns the new shape. Both are public via the `./batch` subpath export, so a consumer
reading `row.text` gets `undefined` (plus TS2339) and a hand-built row hits the shape check below. No
in-repo consumer outside `src/batch/` is affected; the demo server is pinned to the published `^0.8.0`.

A malformed row is now rejected with a message naming the expected shape and the migration, rather than
the bare `TypeError: Cannot convert undefined or null to object` that `Object.keys(undefined)` produced.

## Not in this PR (stacked follow-ups)
- Output projections: JSON (joinable per-item verdicts + per-LC detail), CSV (flat), standards HTML verdict-browser.
- CLI: family→member selection, `--model` shortcodes, `--platform-api-key`, `--yes`/non-interactive. (Standards family is not yet reachable from the CLI — programmatic API only.)

## Testing
- 433 unit tests pass; typecheck + lint clean (0 errors).
- QTC behavior preserved (existing suites unchanged in intent; internal-poking tests rewritten to assert public behavior / use a stub family).


