### PR TITLE
feat(ts-sdk): batch outputs (JSON/HTML/CSV) + family-aware CLI with non-interactive mode

### DIFF
--- a/sdks/typescript/src/batch/README.md
+++ b/sdks/typescript/src/batch/README.md
@@ -1,6 +1,45 @@
 # Batch CSV Evaluator
 
-Evaluate multiple texts from a CSV file using a group of evaluators, with results output in CSV and HTML formats.
+Evaluate rows from a CSV file with an **evaluator family**, writing results as CSV, JSON, and HTML.
+
+## Evaluator families
+
+A *family* is a set of evaluators that share an input contract, credential needs, and report shape. Each run targets one family; you may run all of its members or a subset.
+
+| Family (`--family`) | Members | Required CSV columns | Keys |
+| --- | --- | --- | --- |
+| `text-complexity` | grade-level-appropriateness, subject-matter-knowledge, vocabulary, sentence-structure, conventionality, purpose | `text`, `grade` | Google + OpenAI |
+| `math-standards-alignment` | math.standards-alignment | `question`, `statementCode` (aliases: `ccss_standard`, `text`); optional `jurisdiction` (default `Multi-State`), `grade`, `id` | Anthropic + **platform** (Knowledge Graph) |
+
+Column matching is case-insensitive and alias-aware; the canonical column wins when both it and an alias are present.
+
+## Usage
+
+```bash
+# Interactive: prompts for family, members, model, keys, output dir
+evaluators-batch
+
+# Non-interactive (CI): every input supplied up front, never prompts
+evaluators-batch corpus.csv \
+  --family math-standards-alignment \
+  --platform-api-key "$PLATFORM_API_KEY" \
+  --anthropic-api-key "$ANTHROPIC_API_KEY" \
+  --output-dir ./out --yes
+
+# Run only some members of a family (avoids paying for evaluators you don't need)
+evaluators-batch texts.csv --family text-complexity --evaluator vocabulary,conventionality --yes
+
+# Model override: a shortcode (haiku, opus) or provider:model
+evaluators-batch texts.csv --family text-complexity --model anthropic:claude-opus-4-8 --yes
+```
+
+`-y`/`--yes` (or the absence of a TTY, e.g. CI) enables non-interactive mode: no prompts, and a clear error on any missing required input. Each run writes `results.csv`, `results.json`, and `results.html` to the output directory. The `math-standards-alignment` report is a verdict browser (per-item aligned/total with expandable per-component reasoning); the JSON carries full per-component detail plus each row's original columns so results join back to the source corpus.
+
+Run `evaluators-batch --help` for the full flag list.
+
+### Non-standard input formats
+
+The CLI consumes a generic CSV. If your source data is in another shape (JSON Lines, a bespoke schema, items whose question text must be assembled from multiple fields), convert it to the generic CSV first with a small one-off script — keep that converter outside this package.
 
 ## Installation
 

--- a/sdks/typescript/src/batch/cli-args.ts
+++ b/sdks/typescript/src/batch/cli-args.ts
@@ -4,6 +4,9 @@ import type { EvaluatorGroup } from './types.js';
 
 export interface CliArgs {
   csvPath?: string;
+  family?: string;
+  /** Selected member ids within the family (repeatable / comma-separated). */
+  evaluators?: string[];
   concurrency?: number;
   maxRetries?: number;
   noTelemetry?: boolean;
@@ -11,8 +14,14 @@ export interface CliArgs {
   googleApiKey?: string;
   openaiApiKey?: string;
   anthropicApiKey?: string;
+  platformApiKey?: string;
   outputDir?: string;
+  /** --model: a shortcode (e.g. "haiku") or "provider:model". */
+  model?: string;
+  /** @deprecated alias of --model, kept for back-compat. */
   modelOverride?: string;
+  /** Skip prompts: assume yes and error on missing required input. */
+  yes?: boolean;
   help?: boolean;
   version?: boolean;
 }
@@ -40,8 +49,19 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
       result.version = true;
     } else if (arg === '--no-telemetry') {
       result.noTelemetry = true;
+    } else if (arg === '--yes' || arg === '-y') {
+      result.yes = true;
     } else if (arg === '--bypass-row-limit') {
       result.bypassRowLimit = true;
+    } else if (arg === '--family' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      result.family = args[++i];
+    } else if (arg === '--evaluator' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      const values = args[++i].split(',').map((s) => s.trim()).filter(Boolean);
+      result.evaluators = [...(result.evaluators ?? []), ...values];
+    } else if (arg === '--platform-api-key' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      result.platformApiKey = args[++i];
+    } else if (arg === '--model' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      result.model = args[++i];
     } else if (arg === '--concurrency' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
       const v = parseInt(args[++i], 10);
       if (!isNaN(v) && v > 0) result.concurrency = v;
@@ -66,6 +86,34 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   return result;
 }
 
+
+/**
+ * Convenience shortcodes for common models. A CLI user rarely needs an
+ * arbitrary provider *instance* (that stays programmatic via `llmProvider`);
+ * the parameterizable case — provider + model — is what a flag can carry, and
+ * these aliases save typing. Extend as new models stabilize.
+ */
+export const MODEL_SHORTCODES: Record<string, string> = {
+  haiku: 'anthropic:claude-haiku-4-5-20251001',
+  opus: 'anthropic:claude-opus-4-8',
+};
+
+/**
+ * Resolve a `--model` value: a shortcode (see {@link MODEL_SHORTCODES}) or a
+ * literal `provider:model` string.
+ */
+export function resolveModel(raw: string): ModelOverride {
+  const trimmed = raw.trim();
+  const shortcut = MODEL_SHORTCODES[trimmed.toLowerCase()];
+  if (shortcut) return parseModelOverride(shortcut);
+  if (!trimmed.includes(':')) {
+    throw new Error(
+      `Unknown model "${raw}". Use a shortcode (${Object.keys(MODEL_SHORTCODES).join(', ')}) ` +
+        `or "provider:model" (e.g. anthropic:claude-opus-4-8).`,
+    );
+  }
+  return parseModelOverride(trimmed);
+}
 
 export function parseModelOverride(raw: string): ModelOverride {
   const colonIdx = raw.indexOf(':');

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -218,8 +218,9 @@ async function main() {
   if (cliArgs.help) { printHelp(); process.exit(0); }
   if (cliArgs.version) { console.log(getSDKVersion()); process.exit(0); }
 
-  // Non-interactive when --yes is passed or there is no attached terminal (CI).
-  const interactive = !cliArgs.yes && Boolean(process.stdout.isTTY);
+  // Non-interactive when --yes is passed or either stream lacks a terminal
+  // (CI, or stdout redirected to a file). Prompting needs a real stdin+stdout.
+  const interactive = !cliArgs.yes && Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
   console.log('\n📊 Batch CSV Evaluator\n');
 

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -4,23 +4,23 @@ import { randomUUID } from 'crypto';
 import prompts from 'prompts';
 import {
   BatchEvaluator,
-  getAvailableGroups,
+  getFamilies,
+  getFamily,
   parseCSV,
-  formatAsCSV,
-  formatAsHTML,
+  renderOutputs,
   Provider,
   type BatchInput,
   type ModelOverride,
   type ReportMeta,
+  type EvaluatorFamily,
 } from './index.js';
+import type { KeyKind } from './families/family.js';
+import { resolveMembers } from './families/family.js';
 import { ProgressTracker } from './progress.js';
 import { getSDKVersion } from '../telemetry/index.js';
-import { parseArgs, parseModelOverride, requiredProviders } from './cli-args.js';
+import { parseArgs, resolveModel, MODEL_SHORTCODES } from './cli-args.js';
 
 // ---- Output directory validation ----
-
-const KEY_FLAGS = new Set(['--google-api-key', '--openai-api-key', '--anthropic-api-key']);
-const KEY_FLAG_PREFIXES = ['--google-api-key=', '--openai-api-key=', '--anthropic-api-key='];
 
 function validateOutputDir(value: string): string | true {
   const trimmed = value.trim();
@@ -33,16 +33,13 @@ function validateOutputDir(value: string): string | true {
     } catch {
       return `Cannot access path: ${resolved}`;
     }
-    // Target dir exists — test writability there
   }
 
-  // Test writability of the target dir (if it exists) or its parent (if not yet created)
   const checkDir = fs.existsSync(resolved) ? resolved : path.dirname(resolved);
   if (!fs.existsSync(checkDir)) {
     return `Parent directory does not exist: ${path.dirname(resolved)}`;
   }
   try {
-    // Use a UUID to guarantee uniqueness across concurrent processes.
     const testFile = path.join(checkDir, `.write-test-${randomUUID()}`);
     fs.writeFileSync(testFile, '');
     fs.unlinkSync(testFile);
@@ -50,64 +47,85 @@ function validateOutputDir(value: string): string | true {
   } catch (error) {
     const code = (error as { code?: string }).code;
     if (code === 'EACCES') return `No write permission for directory: ${checkDir}`;
-    if (code === 'EROFS')  return `Directory is read-only: ${checkDir}`;
+    if (code === 'EROFS') return `Directory is read-only: ${checkDir}`;
     return `Cannot write to directory: ${error instanceof Error ? error.message : String(error)}`;
   }
 }
 
+// ---- Credentials ----
+
+const KEY_CONFIG: Record<KeyKind, { envVar: string; label: string; flag: string }> = {
+  [Provider.Google]: { envVar: 'GOOGLE_API_KEY', label: 'Google API Key', flag: '--google-api-key' },
+  [Provider.OpenAI]: { envVar: 'OPENAI_API_KEY', label: 'OpenAI API Key', flag: '--openai-api-key' },
+  [Provider.Anthropic]: { envVar: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key', flag: '--anthropic-api-key' },
+  platform: { envVar: 'PLATFORM_API_KEY', label: 'Learning Commons Platform Key', flag: '--platform-api-key' },
+};
+
 // ---- Help / version ----
 
 function printHelp(): void {
+  const families = getFamilies()
+    .map((f) => `    ${f.id}  (${f.members.map((m) => m.id).join(', ')})`)
+    .join('\n');
   console.log(`evaluators-batch v${getSDKVersion()}
 
 Usage: evaluators-batch [input.csv] [options]
 
-  input.csv              Path to the CSV file (requires "text" and "grade" columns)
+  input.csv              Path to the CSV file (columns depend on the family)
 
-API Keys (flag takes priority over env var; if neither is set, you will be prompted):
-  --google-api-key <key>     Google API key    (env: GOOGLE_API_KEY)
-  --openai-api-key <key>     OpenAI API key    (env: OPENAI_API_KEY)
-  --anthropic-api-key <key>  Anthropic API key (env: ANTHROPIC_API_KEY)
+Family & members:
+  --family <id>              Evaluator family to run. Available:
+${families}
+  --evaluator <id[,id...]>   Run only these members (repeatable). Default: all.
 
-Model Override:
-  --model-override <provider:model>   Use a specific model for all evaluators
-                                      Providers: openai, google, anthropic
-                                      Example: --model-override anthropic:claude-opus-4-8
-                                      When set, only that provider's key is required.
+Model:
+  --model <alias|provider:model>  Override the model for all members.
+                                  Shortcodes: ${Object.keys(MODEL_SHORTCODES).join(', ')}
+                                  Or "provider:model" (e.g. anthropic:claude-opus-4-8).
+
+API Keys (flag > env var; prompted when interactive, required otherwise):
+  --google-api-key <key>     (env: GOOGLE_API_KEY)
+  --openai-api-key <key>     (env: OPENAI_API_KEY)
+  --anthropic-api-key <key>  (env: ANTHROPIC_API_KEY)
+  --platform-api-key <key>   (env: PLATFORM_API_KEY) — required by math-standards-alignment
 
 Output:
   --output-dir <path>        Write results here (default: ./batch-results-<timestamp>)
+                             Produces results.csv, results.json, results.html
 
 Evaluation:
   --concurrency <n>          Max parallel evaluations (default: 3)
   --max-retries <n>          Retries per failed call (default: 2)
-  --bypass-row-limit         Skip the per-group row limit check
+  --bypass-row-limit         Skip the per-family row limit check
   --no-telemetry             Disable usage telemetry
 
+  -y, --yes                  Non-interactive: never prompt, error on missing input
   --version                  Print version and exit
   --help                     Show this help`);
 }
 
-// ---- API key resolution ----
+// ---- Interactive helpers ----
 
-const KEY_CONFIG: Record<Provider, { envVar: string; label: string }> = {
-  [Provider.Google]:    { envVar: 'GOOGLE_API_KEY',    label: 'Google API Key'    },
-  [Provider.OpenAI]:   { envVar: 'OPENAI_API_KEY',    label: 'OpenAI API Key'    },
-  [Provider.Anthropic]:{ envVar: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key' },
-};
-
-async function resolveApiKey(provider: Provider, fromFlag: string | undefined): Promise<string> {
-  const { envVar, label } = KEY_CONFIG[provider];
-  const fromEnv = process.env[envVar];
-
+async function resolveKey(
+  kind: KeyKind,
+  fromFlag: string | undefined,
+  interactive: boolean,
+): Promise<string> {
+  const { envVar, label, flag } = KEY_CONFIG[kind];
   if (fromFlag !== undefined) {
     if (!fromFlag) {
-      console.error(`❌ ${label} flag was provided but is empty`);
+      console.error(`❌ ${label} (${flag}) was provided but is empty`);
       process.exit(1);
     }
     return fromFlag;
   }
+  const fromEnv = process.env[envVar];
   if (fromEnv) return fromEnv;
+
+  if (!interactive) {
+    console.error(`❌ Missing ${label}. Provide ${flag} or set ${envVar} (running non-interactively).`);
+    process.exit(1);
+  }
 
   const result = await prompts({
     type: 'password',
@@ -115,13 +133,81 @@ async function resolveApiKey(provider: Provider, fromFlag: string | undefined): 
     message: `${label}:`,
     validate: (value) => (value ? true : `${label} is required`),
   });
-
   if (!result.key) {
     console.log('Cancelled.');
     process.exit(0);
   }
-
   return result.key as string;
+}
+
+async function selectFamily(cliFamily: string | undefined, interactive: boolean): Promise<EvaluatorFamily> {
+  if (cliFamily) return getFamily(cliFamily);
+  const families = getFamilies();
+  if (!interactive) {
+    console.error(`❌ Specify --family. Available: ${families.map((f) => f.id).join(', ')}`);
+    process.exit(1);
+  }
+  const { familyId } = await prompts({
+    type: 'select',
+    name: 'familyId',
+    message: 'Which evaluator family?',
+    choices: families.map((f) => ({ title: `${f.name} — ${f.description}`, value: f.id })),
+  });
+  if (!familyId) {
+    console.log('Cancelled.');
+    process.exit(0);
+  }
+  return getFamily(familyId as string);
+}
+
+async function selectMembers(
+  family: EvaluatorFamily,
+  cliEvaluators: string[] | undefined,
+  interactive: boolean,
+): Promise<string[] | undefined> {
+  if (cliEvaluators && cliEvaluators.length > 0) {
+    resolveMembers(family, cliEvaluators); // validates ids, throws on unknown
+    return cliEvaluators;
+  }
+  if (!interactive || family.members.length <= 1) return undefined; // all members
+  const { selected } = await prompts({
+    type: 'multiselect',
+    name: 'selected',
+    message: 'Which evaluators? (space to toggle, enter to confirm)',
+    choices: family.members.map((m) => ({ title: m.name, value: m.id, selected: true })),
+    instructions: false,
+    hint: '- all selected by default',
+  });
+  if (!selected || (selected as string[]).length === 0) return undefined; // treat none as all
+  return selected as string[];
+}
+
+async function selectModel(
+  cliArgs: ReturnType<typeof parseArgs>,
+  interactive: boolean,
+): Promise<ModelOverride | undefined> {
+  const raw = cliArgs.model ?? cliArgs.modelOverride;
+  if (raw !== undefined) return resolveModel(raw);
+  if (!interactive) return undefined;
+
+  const { useDefault } = await prompts({
+    type: 'confirm',
+    name: 'useDefault',
+    message: 'Use each evaluator’s default model?',
+    initial: true,
+  });
+  if (useDefault !== false) return undefined;
+
+  const { model } = await prompts({
+    type: 'text',
+    name: 'model',
+    message: `Model (shortcode [${Object.keys(MODEL_SHORTCODES).join(', ')}] or provider:model):`,
+    validate: (value) => {
+      try { resolveModel(value); return true; } catch (e) { return e instanceof Error ? e.message : 'Invalid model'; }
+    },
+  });
+  if (!model) return undefined;
+  return resolveModel(model as string);
 }
 
 // ---- Main ----
@@ -129,263 +215,163 @@ async function resolveApiKey(provider: Provider, fromFlag: string | undefined): 
 async function main() {
   const cliArgs = parseArgs();
 
-  if (cliArgs.help) {
-    printHelp();
-    process.exit(0);
-  }
+  if (cliArgs.help) { printHelp(); process.exit(0); }
+  if (cliArgs.version) { console.log(getSDKVersion()); process.exit(0); }
 
-  if (cliArgs.version) {
-    console.log(getSDKVersion());
-    process.exit(0);
-  }
-
-  // Parse model override early so errors surface before any prompts
-  let modelOverride: ModelOverride | undefined;
-  if (cliArgs.modelOverride !== undefined) {
-    try {
-      modelOverride = parseModelOverride(cliArgs.modelOverride);
-    } catch (error) {
-      console.error(`❌ ${error instanceof Error ? error.message : String(error)}`);
-      process.exit(1);
-    }
-  }
+  // Non-interactive when --yes is passed or there is no attached terminal (CI).
+  const interactive = !cliArgs.yes && Boolean(process.stdout.isTTY);
 
   console.log('\n📊 Batch CSV Evaluator\n');
-  console.log('This tool will evaluate multiple texts using one or more evaluators.\n');
 
   try {
-    // Step 1: CSV path — use positional arg or prompt
+    // 1. Family + members
+    const family = await selectFamily(cliArgs.family, interactive);
+    const selectedMemberIds = await selectMembers(family, cliArgs.evaluators, interactive);
+    const members = resolveMembers(family, selectedMemberIds);
+
+    // 2. Model choice (before keys, so key requirements reflect any override)
+    const modelOverride = await selectModel(cliArgs, interactive);
+
+    // 3. CSV
     let inputs: BatchInput[] = [];
     let csvPath: string;
-
     if (cliArgs.csvPath !== undefined) {
+      csvPath = cliArgs.csvPath;
       try {
-        inputs = parseCSV(cliArgs.csvPath);
-        csvPath = cliArgs.csvPath;
+        inputs = parseCSV(csvPath);
       } catch (error) {
         console.error(`❌ ${error instanceof Error ? error.message : 'Invalid CSV file'}`);
         process.exit(1);
       }
-    } else {
+    } else if (interactive) {
       const response = await prompts({
         type: 'text',
         name: 'csvPath',
         message: 'Where is your CSV file?',
         initial: './input.csv',
         validate: (value) => {
-          try {
-            inputs = parseCSV(value);
-            return true;
-          } catch (error) {
-            return error instanceof Error ? error.message : 'Invalid CSV file';
-          }
+          try { inputs = parseCSV(value); return true; } catch (e) { return e instanceof Error ? e.message : 'Invalid CSV file'; }
         },
       });
-
-      if (!response.csvPath) {
-        console.log('No file path provided. Run the command again to start over.');
-        process.exit(0);
-      }
-
+      if (!response.csvPath) { console.log('No file path provided.'); process.exit(0); }
       csvPath = response.csvPath as string;
+    } else {
+      console.error('❌ No CSV provided. Pass the CSV path as the first argument.');
+      process.exit(1);
     }
 
-    console.log(`\n✓ Found ${inputs.length} rows in CSV\n`);
+    console.log(`\n✓ ${inputs.length} rows · family: ${family.name} · evaluators: ${members.map((m) => m.id).join(', ')}`);
+    if (modelOverride) console.log(`  ⚡ Model override: ${modelOverride.provider}:${modelOverride.model}`);
 
-    // Step 2: Show the evaluator group that will run
-    const group = getAvailableGroups()[0];
-    console.log(`✓ Evaluator group: ${group.name}`);
-    console.log(`  ${group.description}`);
-    if (modelOverride) {
-      console.log(`  ⚡ Model override: ${modelOverride.provider}:${modelOverride.model}`);
-    }
-    console.log();
-
-    // Enforce row limit before prompting for API keys
-    if (inputs.length > group.maxInputRows) {
-      if (cliArgs.bypassRowLimit) {
-        console.warn(`⚠️  Row limit bypassed: ${inputs.length} rows (default max ${group.maxInputRows}).`);
-        console.warn(`   Expect longer runtime and possible provider throttling.\n`);
-      } else {
-        console.error(`❌ Too many rows: ${inputs.length} (max ${group.maxInputRows} for this group)\n`);
-        console.log('Options:');
-        console.log(`  • Trim the CSV to ${group.maxInputRows} rows`);
-        console.log('  • Split into multiple smaller batches');
-        console.log(`  • Re-run with --bypass-row-limit to skip this check:\n`);
-        const rawArgList = process.argv.slice(2).filter(a => a !== '--bypass-row-limit');
-        const safeArgs: string[] = [];
-        for (let j = 0; j < rawArgList.length; j++) {
-          const a = rawArgList[j];
-          if (KEY_FLAGS.has(a)) {
-            safeArgs.push(a, '<redacted>');
-            // Skip the value token if it looks like a value, not a flag (consistent with parseArgs behaviour)
-            if (j + 1 < rawArgList.length && !rawArgList[j + 1].startsWith('-')) j++;
-          } else if (KEY_FLAG_PREFIXES.some(p => a.startsWith(p))) {
-            safeArgs.push(`${a.slice(0, a.indexOf('='))}=<redacted>`);
-          } else {
-            safeArgs.push(a.includes(' ') ? `"${a.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : a);
-          }
-        }
-        console.log(`    evaluators-batch ${[...safeArgs, '--bypass-row-limit'].join(' ')}\n`);
-        process.exit(1);
-      }
+    // 4. Row limit (fail fast before prompting for keys)
+    if (inputs.length > family.maxInputRows && !cliArgs.bypassRowLimit) {
+      console.error(`\n❌ Too many rows: ${inputs.length} (max ${family.maxInputRows} for "${family.id}").`);
+      console.error('   Trim the CSV, split into batches, or re-run with --bypass-row-limit.');
+      process.exit(1);
     }
 
-    // Step 3: Resolve API keys — skip prompts for any key already provided
-    const needed = requiredProviders(group, modelOverride);
-    const keyFlagMap: Record<Provider, string | undefined> = {
-      [Provider.Google]:    cliArgs.googleApiKey,
-      [Provider.OpenAI]:   cliArgs.openaiApiKey,
-      [Provider.Anthropic]:cliArgs.anthropicApiKey,
+    // 5. Keys — exactly what this family + selection + override requires
+    const requiredKeys = family.requiredKeys(members.map((m) => m.id), modelOverride);
+    const flagFor: Record<KeyKind, string | undefined> = {
+      [Provider.Google]: cliArgs.googleApiKey,
+      [Provider.OpenAI]: cliArgs.openaiApiKey,
+      [Provider.Anthropic]: cliArgs.anthropicApiKey,
+      platform: cliArgs.platformApiKey,
     };
-
-    const resolvedKeys: Partial<Record<Provider, string>> = {};
-    for (const provider of needed) {
-      resolvedKeys[provider] = await resolveApiKey(provider, keyFlagMap[provider]);
+    const keys: Partial<Record<KeyKind, string>> = {};
+    for (const kind of requiredKeys) {
+      keys[kind] = await resolveKey(kind, flagFor[kind], interactive);
     }
 
-    // Step 4: Output directory — use flag or prompt
+    // 6. Output dir
     const now = new Date();
     const pad = (n: number) => String(n).padStart(2, '0');
     const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
     const defaultOutputDir = path.join(process.cwd(), `batch-results-${timestamp}`);
-
     let outputDir: string;
-
     if (cliArgs.outputDir !== undefined) {
       const validation = validateOutputDir(cliArgs.outputDir);
-      if (validation !== true) {
-        console.error(`❌ Invalid --output-dir: ${validation}`);
-        process.exit(1);
-      }
+      if (validation !== true) { console.error(`❌ Invalid --output-dir: ${validation}`); process.exit(1); }
       outputDir = path.resolve(cliArgs.outputDir.trim());
-    } else {
+    } else if (interactive) {
       const response = await prompts({
-        type: 'text',
-        name: 'outputDir',
-        message: 'Output directory:',
-        initial: defaultOutputDir,
-        validate: validateOutputDir,
+        type: 'text', name: 'outputDir', message: 'Output directory:', initial: defaultOutputDir, validate: validateOutputDir,
       });
-
-      if (!response.outputDir) {
-        console.log('No output directory provided. Run the command again to start over.');
-        process.exit(0);
-      }
-
+      if (!response.outputDir) { console.log('No output directory provided.'); process.exit(0); }
       outputDir = path.resolve((response.outputDir as string).trim());
+    } else {
+      outputDir = defaultOutputDir;
     }
-
     fs.mkdirSync(outputDir, { recursive: true });
 
-    // Build report metadata
     const csvBasename = path.basename(csvPath, path.extname(csvPath));
     const reportMeta: ReportMeta = {
       csvPath: path.resolve(csvPath),
-      groupId: group.id,
+      groupId: family.id,
       reportId: `${csvBasename.replace(/[^a-zA-Z0-9]/g, '_')}_${timestamp}`,
       generatedAt: now,
       totalInputRows: inputs.length,
     };
 
-    // Step 5: Confirm and run
-    const totalTasks = inputs.length * group.evaluatorIds.length;
-
-    console.log(`\n📝 Summary:`);
-    console.log(`  Input rows:  ${inputs.length}${cliArgs.bypassRowLimit ? ' (row limit bypassed)' : ''}`);
-    console.log(`  Evaluators:  ${group.evaluatorIds.length}`);
-    console.log(`  Total tasks: ${totalTasks}`);
-    console.log(`  Concurrency: ${cliArgs.concurrency ?? 3}`);
-    console.log(`  Max retries: ${cliArgs.maxRetries ?? 2}`);
-    if (modelOverride) {
-      console.log(`  Model:       ${modelOverride.provider}:${modelOverride.model}`);
-    }
-    console.log(`  Output:      ${outputDir}\n`);
-
-    const { confirm } = await prompts({
-      type: 'confirm',
-      name: 'confirm',
-      message: 'Start batch evaluation?',
-      initial: true,
-    });
-
-    if (!confirm) {
-      console.log('Cancelled.');
-      process.exit(0);
+    // 7. Confirm (interactive only)
+    const totalTasks = inputs.length * members.length;
+    console.log(`\n📝 ${totalTasks} tasks · concurrency ${cliArgs.concurrency ?? 3} · output ${outputDir}\n`);
+    if (interactive) {
+      const { confirm } = await prompts({ type: 'confirm', name: 'confirm', message: 'Start batch evaluation?', initial: true });
+      if (!confirm) { console.log('Cancelled.'); process.exit(0); }
     }
 
-    // Step 6: Run batch evaluation
-    console.log('\n' + '='.repeat(60));
+    // 8. Run
+    console.log('='.repeat(60));
     const tracker = new ProgressTracker(totalTasks);
     const evaluationStartTime = Date.now();
-
     const evaluator = new BatchEvaluator({
-      googleApiKey:    resolvedKeys[Provider.Google],
-      openaiApiKey:    resolvedKeys[Provider.OpenAI],
-      anthropicApiKey: resolvedKeys[Provider.Anthropic],
-      concurrency:     cliArgs.concurrency ?? 3,
-      maxRetries:      cliArgs.maxRetries ?? 2,
-      telemetry:       !cliArgs.noTelemetry,
-      bypassRowLimit:  cliArgs.bypassRowLimit ?? false,
+      googleApiKey: keys[Provider.Google],
+      openaiApiKey: keys[Provider.OpenAI],
+      anthropicApiKey: keys[Provider.Anthropic],
+      platformApiKey: keys.platform,
+      concurrency: cliArgs.concurrency ?? 3,
+      maxRetries: cliArgs.maxRetries ?? 2,
+      telemetry: !cliArgs.noTelemetry,
+      bypassRowLimit: cliArgs.bypassRowLimit ?? false,
       modelOverride,
     });
 
-    // Handle Ctrl+C gracefully
     let isShuttingDown = false;
     const handleShutdown = () => {
-      if (isShuttingDown) {
-        console.log('\n\n⚠️  Force quit detected. Exiting immediately...');
-        process.exit(1);
-      }
-
+      if (isShuttingDown) { console.log('\n\n⚠️  Force quit.'); process.exit(1); }
       isShuttingDown = true;
-      console.log('\n\n⚠️  Shutdown requested. Saving partial results...');
-      console.log('   (Press Ctrl+C again to force quit)\n');
-
-      const partialResults = evaluator.cancel();
-
-      if (partialResults.length > 0) {
-        const durationMs = Date.now() - evaluationStartTime;
-        const partialOutput = {
-          results: partialResults,
-          summary: {
-            totalTasks: partialResults.length,
-            successful: partialResults.filter((r) => r.status === 'success').length,
-            failed: partialResults.filter((r) => r.status === 'error').length,
-            durationMs,
-            resultsPerEvaluator: {},
-          },
-        };
-
+      console.log('\n\n⚠️  Shutdown requested. Saving partial results…\n');
+      const partial = evaluator.cancel();
+      if (partial.length > 0) {
         try {
-          fs.writeFileSync(path.join(outputDir, 'results-partial.csv'), formatAsCSV(partialOutput));
-          fs.writeFileSync(path.join(outputDir, 'results-partial.html'), formatAsHTML(partialOutput, reportMeta));
-
-          console.log(`✓ Saved ${partialResults.length} results to:`);
-          console.log(`  ${outputDir}/`);
-          console.log(`    ├── results-partial.csv`);
-          console.log(`    └── results-partial.html`);
-          console.log();
+          const bundle = renderOutputs(family.id, { results: partial, summary: {
+            totalTasks: partial.length,
+            successful: partial.filter((r) => r.status === 'success').length,
+            failed: partial.filter((r) => r.status === 'error').length,
+            durationMs: Date.now() - evaluationStartTime,
+            resultsPerEvaluator: {},
+          } }, reportMeta);
+          fs.writeFileSync(path.join(outputDir, 'results-partial.csv'), bundle.csv);
+          fs.writeFileSync(path.join(outputDir, 'results-partial.json'), bundle.json);
+          fs.writeFileSync(path.join(outputDir, 'results-partial.html'), bundle.html);
+          console.log(`✓ Saved ${partial.length} partial results to ${outputDir}/\n`);
         } catch (error) {
           console.error('❌ Error saving partial results:', error instanceof Error ? error.message : String(error));
         }
       } else {
         console.log('No results to save yet.\n');
       }
-
       process.exit(0);
     };
-
     process.on('SIGINT', handleShutdown);
     process.on('SIGTERM', handleShutdown);
 
     let output;
     try {
-      output = await evaluator.evaluate(inputs, group.id, {
-        onProgress: (result) => {
-          tracker.update(result);
-          tracker.display();
-        },
+      output = await evaluator.evaluate(inputs, family.id, {
+        selectedMemberIds,
+        onProgress: (result) => { tracker.update(result); tracker.display(); },
       });
     } finally {
       process.off('SIGINT', handleShutdown);
@@ -394,22 +380,21 @@ async function main() {
 
     tracker.displaySummary();
 
-    // Step 7: Write output files
+    // 9. Write outputs
     try {
-      fs.writeFileSync(path.join(outputDir, 'results.csv'), formatAsCSV(output));
-      fs.writeFileSync(path.join(outputDir, 'results.html'), formatAsHTML(output, reportMeta));
-
-      const htmlPath = path.join(outputDir, 'results.html');
-      console.log('📄 Output files generated:');
+      const bundle = renderOutputs(family.id, output, reportMeta);
+      fs.writeFileSync(path.join(outputDir, 'results.csv'), bundle.csv);
+      fs.writeFileSync(path.join(outputDir, 'results.json'), bundle.json);
+      fs.writeFileSync(path.join(outputDir, 'results.html'), bundle.html);
+      console.log('\n📄 Output files:');
       console.log(`  ${outputDir}/`);
-      console.log(`    ├── results.csv`);
-      console.log(`    └── results.html`);
-      console.log();
-      console.log(`Open the report: ${htmlPath}`);
+      console.log('    ├── results.csv');
+      console.log('    ├── results.json');
+      console.log('    └── results.html');
+      console.log(`\nOpen the report: ${path.join(outputDir, 'results.html')}`);
     } catch (error) {
       console.error('\n❌ Error writing output files:');
       if (error instanceof Error) console.error(`  ${error.message}`);
-      console.error('\n⚠️  Evaluation completed but outputs could not be saved.');
       process.exit(1);
     }
   } catch (error) {

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -129,6 +129,7 @@ export class BatchEvaluator {
       status: 'error',
       error,
       processingTimeMs,
+      columns: row.columns,
       originalRow: row.originalRow,
     };
   }
@@ -160,7 +161,8 @@ export class BatchEvaluator {
         reasoning: outcome.reasoning,
         payload: outcome.payload,
         processingTimeMs: Date.now() - startTime,
-        originalRow: row.originalRow,
+        columns: row.columns,
+      originalRow: row.originalRow,
       };
       this.completedResults.push(result);
       onProgress?.(result);

--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -48,6 +48,19 @@ const COLUMNS: ColumnSpec[] = [
   { name: 'grade', required: true },
 ];
 
+/**
+ * Per-member providers, so selecting a subset doesn't demand keys the run won't
+ * use. Only `vocabulary` and `sentence-structure` reach OpenAI.
+ */
+const PROVIDERS_BY_MEMBER = new Map<string, readonly Provider[]>([
+  [GradeLevelAppropriatenessEvaluator.metadata.id, GradeLevelAppropriatenessEvaluator.metadata.defaultProviders],
+  [SmkEvaluator.metadata.id, SmkEvaluator.metadata.defaultProviders],
+  [VocabularyEvaluator.metadata.id, VocabularyEvaluator.metadata.defaultProviders],
+  [SentenceStructureEvaluator.metadata.id, SentenceStructureEvaluator.metadata.defaultProviders],
+  [ConventionalityEvaluator.metadata.id, ConventionalityEvaluator.metadata.defaultProviders],
+  [PurposeEvaluator.metadata.id, PurposeEvaluator.metadata.defaultProviders],
+]);
+
 class QtcRunner implements FamilyRunner {
   readonly members;
   private readonly instances = new Map<string, SimpleEvaluator>();
@@ -88,9 +101,13 @@ export const QTC_FAMILY: EvaluatorFamily = {
   members: MEMBERS,
   columns: COLUMNS,
   maxInputRows: 50,
-  requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
+  requiredKeys(selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
     if (modelOverride) return [modelOverride.provider];
-    return [Provider.Google, Provider.OpenAI];
+    const keys = new Set<KeyKind>();
+    for (const member of resolveMembers(QTC_FAMILY, selectedMemberIds)) {
+      for (const provider of PROVIDERS_BY_MEMBER.get(member.id) ?? []) keys.add(provider);
+    }
+    return [...keys];
   },
   createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner {
     return new QtcRunner(ctx, selectedMemberIds);

--- a/sdks/typescript/src/batch/families/standards-output.ts
+++ b/sdks/typescript/src/batch/families/standards-output.ts
@@ -96,7 +96,7 @@ export function formatStandardsJSON(output: BatchOutput, meta: StandardsOutputMe
 // --- CSV -------------------------------------------------------------------
 
 function escapeCSV(field: string): string {
-  if (field.includes(',') || field.includes('"') || field.includes('\n')) {
+  if (/[",\n\r]/.test(field)) {
     return `"${field.replace(/"/g, '""')}"`;
   }
   return field;
@@ -105,14 +105,17 @@ function escapeCSV(field: string): string {
 /**
  * Flat, joinable CSV: passthrough of every original column, then the verdict
  * roll-ups. Per-component detail rides along as a JSON string so no data is
- * lost while the file stays spreadsheet-friendly.
+ * lost while the file stays spreadsheet-friendly. Verdict columns that would
+ * collide with an existing source column are `verdict_`-prefixed so joins stay
+ * unambiguous.
  */
 export function formatStandardsCSV(output: BatchOutput): string {
   const rows = collectRows(output);
   if (rows.length === 0) return '';
 
   const originalColumns = Object.keys(rows[0].originalRow);
-  const verdictColumns = [
+  const lowerOriginal = new Set(originalColumns.map((c) => c.toLowerCase()));
+  const verdictFields = [
     'statement_code',
     'jurisdiction',
     'aligned_count',
@@ -122,7 +125,10 @@ export function formatStandardsCSV(output: BatchOutput): string {
     'error',
     'learning_components_json',
   ];
-  const headers = [...originalColumns, ...verdictColumns];
+  const verdictColumns = verdictFields.map((name) =>
+    lowerOriginal.has(name.toLowerCase()) ? `verdict_${name}` : name,
+  );
+  const headers = [...originalColumns, ...verdictColumns].map(escapeCSV);
 
   const lines = rows.map((r) => {
     const originalValues = originalColumns.map((col) => escapeCSV(String(r.originalRow[col] ?? '')));

--- a/sdks/typescript/src/batch/families/standards-output.ts
+++ b/sdks/typescript/src/batch/families/standards-output.ts
@@ -39,7 +39,8 @@ function toRow(result: BatchResult): StandardsRow {
     id: String(idValue),
     grade: result.grade ?? '',
     statementCode: verdict?.statementCode ?? String(original.statementCode ?? original.ccss_standard ?? ''),
-    jurisdiction: verdict?.jurisdiction ?? '',
+    // Keep context on error rows (no payload) by falling back to the source row.
+    jurisdiction: verdict?.jurisdiction ?? String(original.jurisdiction ?? ''),
     question: verdict?.question ?? result.text ?? '',
     status: result.status,
     alignedCount: verdict ? verdict.alignedCount : null,
@@ -113,7 +114,18 @@ export function formatStandardsCSV(output: BatchOutput): string {
   const rows = collectRows(output);
   if (rows.length === 0) return '';
 
-  const originalColumns = Object.keys(rows[0].originalRow);
+  // Union of source columns across all rows (first-seen order) so a ragged /
+  // programmatically-built result set can't silently drop columns.
+  const originalColumns: string[] = [];
+  const seenOriginal = new Set<string>();
+  for (const r of rows) {
+    for (const col of Object.keys(r.originalRow)) {
+      if (!seenOriginal.has(col)) {
+        seenOriginal.add(col);
+        originalColumns.push(col);
+      }
+    }
+  }
   const lowerOriginal = new Set(originalColumns.map((c) => c.toLowerCase()));
   const verdictFields = [
     'statement_code',
@@ -181,10 +193,18 @@ export function formatStandardsHTML(output: BatchOutput, meta: StandardsOutputMe
   const safeJson = JSON.stringify(reportData)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026');
+    .replace(/&/g, '\\u0026')
+    // U+2028/U+2029 are valid JSON but break inline <script> parsing pre-ES2019.
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 
-  if (!standardsReportTemplate.includes(INJECTION_MARKER)) {
+  return injectReportData(standardsReportTemplate, safeJson);
+}
+
+/** Takes the template as a parameter so the corruption guard is reachable in tests. */
+export function injectReportData(template: string, payload: string): string {
+  if (!template.includes(INJECTION_MARKER)) {
     throw new Error('Standards report template injection marker not found — template may be corrupted');
   }
-  return standardsReportTemplate.replace(INJECTION_MARKER, `var REPORT_DATA = ${safeJson};`);
+  return template.replace(INJECTION_MARKER, `var REPORT_DATA = ${payload};`);
 }

--- a/sdks/typescript/src/batch/families/standards-output.ts
+++ b/sdks/typescript/src/batch/families/standards-output.ts
@@ -1,0 +1,184 @@
+import type { BatchOutput, BatchResult } from '../types.js';
+import type { StandardsVerdict } from './standards.js';
+import standardsReportTemplate from './standards-report.html';
+
+/** Metadata shared by every output projection. */
+export interface StandardsOutputMeta {
+  reportId: string;
+  generatedAt: Date;
+  sourcePath: string;
+  totalInputRows: number;
+}
+
+/**
+ * One flattened verdict per input row. `learningComponents` is preserved in
+ * full for the JSON/HTML views; the CSV flattens the roll-ups and carries the
+ * per-component detail as an embedded JSON string so it stays joinable.
+ */
+interface StandardsRow {
+  rowIndex: number;
+  id: string;
+  grade: string;
+  statementCode: string;
+  jurisdiction: string;
+  question: string;
+  status: 'success' | 'error';
+  alignedCount: number | null;
+  totalCount: number | null;
+  error: string | null;
+  learningComponents: StandardsVerdict['learningComponents'];
+  originalRow: Record<string, unknown>;
+}
+
+function toRow(result: BatchResult): StandardsRow {
+  const verdict = result.payload as StandardsVerdict | undefined;
+  const original = result.originalRow ?? {};
+  const idValue = original.id ?? original.item_id ?? '';
+  return {
+    rowIndex: result.rowIndex,
+    id: String(idValue),
+    grade: result.grade ?? '',
+    statementCode: verdict?.statementCode ?? String(original.statementCode ?? original.ccss_standard ?? ''),
+    jurisdiction: verdict?.jurisdiction ?? '',
+    question: verdict?.question ?? result.text ?? '',
+    status: result.status,
+    alignedCount: verdict ? verdict.alignedCount : null,
+    totalCount: verdict ? verdict.totalCount : null,
+    error: result.status === 'error' ? result.error ?? 'Unknown error' : null,
+    learningComponents: verdict?.learningComponents ?? [],
+    originalRow: original,
+  };
+}
+
+function collectRows(output: BatchOutput): StandardsRow[] {
+  return output.results.map(toRow).sort((a, b) => a.rowIndex - b.rowIndex);
+}
+
+// --- JSON ------------------------------------------------------------------
+
+/**
+ * Machine-readable verdicts for downstream analysis (flag-rate, coverage). Each
+ * item carries the full per-component detail plus the untouched `originalRow`,
+ * so results join back to the source corpus on any column.
+ */
+export function formatStandardsJSON(output: BatchOutput, meta: StandardsOutputMeta): string {
+  const rows = collectRows(output);
+  return JSON.stringify(
+    {
+      meta: {
+        reportId: meta.reportId,
+        family: 'math-standards-alignment',
+        generatedAt: meta.generatedAt.toISOString(),
+        sourcePath: meta.sourcePath,
+        totalInputRows: meta.totalInputRows,
+      },
+      summary: output.summary,
+      items: rows.map((r) => ({
+        rowIndex: r.rowIndex,
+        id: r.id,
+        grade: r.grade,
+        statementCode: r.statementCode,
+        jurisdiction: r.jurisdiction,
+        question: r.question,
+        status: r.status,
+        alignedCount: r.alignedCount,
+        totalCount: r.totalCount,
+        error: r.error,
+        learningComponents: r.learningComponents,
+        originalRow: r.originalRow,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+// --- CSV -------------------------------------------------------------------
+
+function escapeCSV(field: string): string {
+  if (field.includes(',') || field.includes('"') || field.includes('\n')) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+/**
+ * Flat, joinable CSV: passthrough of every original column, then the verdict
+ * roll-ups. Per-component detail rides along as a JSON string so no data is
+ * lost while the file stays spreadsheet-friendly.
+ */
+export function formatStandardsCSV(output: BatchOutput): string {
+  const rows = collectRows(output);
+  if (rows.length === 0) return '';
+
+  const originalColumns = Object.keys(rows[0].originalRow);
+  const verdictColumns = [
+    'statement_code',
+    'jurisdiction',
+    'aligned_count',
+    'total_count',
+    'aligned_ratio',
+    'status',
+    'error',
+    'learning_components_json',
+  ];
+  const headers = [...originalColumns, ...verdictColumns];
+
+  const lines = rows.map((r) => {
+    const originalValues = originalColumns.map((col) => escapeCSV(String(r.originalRow[col] ?? '')));
+    const ratio =
+      r.alignedCount !== null && r.totalCount !== null && r.totalCount > 0
+        ? (r.alignedCount / r.totalCount).toFixed(3)
+        : '';
+    const verdictValues = [
+      escapeCSV(r.statementCode),
+      escapeCSV(r.jurisdiction),
+      r.alignedCount ?? '',
+      r.totalCount ?? '',
+      ratio,
+      r.status,
+      escapeCSV(r.error ?? ''),
+      escapeCSV(JSON.stringify(r.learningComponents)),
+    ];
+    return [...originalValues, ...verdictValues].join(',');
+  });
+
+  return [headers.join(','), ...lines].join('\n');
+}
+
+// --- HTML ------------------------------------------------------------------
+
+const INJECTION_MARKER = 'var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__';
+
+/**
+ * Self-contained verdict browser: per-item aligned/total with expandable
+ * per-component reasoning/feedback, filterable by standard and grade. Reports
+ * verdicts only — no flag-rate/coverage aggregates (that is interpretation,
+ * done downstream from the JSON).
+ */
+export function formatStandardsHTML(output: BatchOutput, meta: StandardsOutputMeta): string {
+  const rows = collectRows(output);
+  const reportData = {
+    meta: {
+      reportId: meta.reportId,
+      generatedAt: meta.generatedAt.toLocaleString('en-US', {
+        month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true,
+      }),
+      sourcePath: meta.sourcePath,
+      totalInputRows: meta.totalInputRows,
+      successful: output.summary.successful,
+      failed: output.summary.failed,
+    },
+    items: rows,
+  };
+
+  const safeJson = JSON.stringify(reportData)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+
+  if (!standardsReportTemplate.includes(INJECTION_MARKER)) {
+    throw new Error('Standards report template injection marker not found — template may be corrupted');
+  }
+  return standardsReportTemplate.replace(INJECTION_MARKER, `var REPORT_DATA = ${safeJson};`);
+}

--- a/sdks/typescript/src/batch/families/standards-output.ts
+++ b/sdks/typescript/src/batch/families/standards-output.ts
@@ -1,5 +1,5 @@
 import type { BatchOutput, BatchResult } from '../types.js';
-import type { StandardsVerdict } from './standards.js';
+import { STANDARDS_COLUMNS, type StandardsVerdict } from './standards.js';
 import standardsReportTemplate from './standards-report.html';
 
 /** Metadata shared by every output projection. */
@@ -30,18 +30,38 @@ interface StandardsRow {
   originalRow: Record<string, unknown>;
 }
 
+/**
+ * Reads a canonical column, preferring the normalized value and falling back to
+ * the untouched source row. The fallback matches case-insensitively against the
+ * family's own aliases: a hand-rolled list here would drift from the spec and
+ * drop headers the CLI accepts on input (rows that fail normalization carry no
+ * canonical columns, so the source row is all that is left).
+ */
+function column(result: BatchResult, canonical: string): string {
+  const normalized = result.columns?.[canonical];
+  if (normalized !== undefined && normalized !== '') return normalized;
+
+  const spec = STANDARDS_COLUMNS.find((c) => c.name === canonical);
+  const names = [canonical, ...(spec?.aliases ?? [])].map((n) => n.toLowerCase());
+  for (const [key, value] of Object.entries(result.originalRow ?? {})) {
+    if (names.includes(key.toLowerCase().trim()) && value != null && value !== '') {
+      return String(value);
+    }
+  }
+  return '';
+}
+
 function toRow(result: BatchResult): StandardsRow {
   const verdict = result.payload as StandardsVerdict | undefined;
   const original = result.originalRow ?? {};
-  const idValue = original.id ?? original.item_id ?? '';
   return {
     rowIndex: result.rowIndex,
-    id: String(idValue),
-    grade: result.grade ?? '',
-    statementCode: verdict?.statementCode ?? String(original.statementCode ?? original.ccss_standard ?? ''),
-    // Keep context on error rows (no payload) by falling back to the source row.
-    jurisdiction: verdict?.jurisdiction ?? String(original.jurisdiction ?? ''),
-    question: verdict?.question ?? result.text ?? '',
+    id: column(result, 'id'),
+    grade: result.grade || column(result, 'grade'),
+    // Keep context on error rows, which carry no verdict to read from.
+    statementCode: verdict?.statementCode ?? column(result, 'statementCode'),
+    jurisdiction: verdict?.jurisdiction ?? column(result, 'jurisdiction'),
+    question: verdict?.question ?? result.text ?? column(result, 'question'),
     status: result.status,
     alignedCount: verdict ? verdict.alignedCount : null,
     totalCount: verdict ? verdict.totalCount : null,
@@ -206,5 +226,9 @@ export function injectReportData(template: string, payload: string): string {
   if (!template.includes(INJECTION_MARKER)) {
     throw new Error('Standards report template injection marker not found — template may be corrupted');
   }
-  return template.replace(INJECTION_MARKER, `var REPORT_DATA = ${payload};`);
+  // Replacer function, not a string: as a string, `$$`/`$&`/`` $` ``/`$'` in the
+  // payload are substitution patterns. `$$x^2$$` in a question would render as
+  // `$x^2$`, and `$'` splices the template tail — including `</script>` — into the
+  // inline script, defeating the escaping applied to the payload.
+  return template.replace(INJECTION_MARKER, () => `var REPORT_DATA = ${payload};`);
 }

--- a/sdks/typescript/src/batch/families/standards-report.html
+++ b/sdks/typescript/src/batch/families/standards-report.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Math Standards Alignment — Verdicts</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1a1a2e; --muted: #6b7280; --line: #e5e7eb;
+    --card: #f9fafb; --accent: #4338ca;
+    --ok-bg: #dcfce7; --ok-fg: #166534; --partial-bg: #fef9c3; --partial-fg: #854d0e;
+    --none-bg: #fee2e2; --none-fg: #991b1b; --err-bg: #f3f4f6; --err-fg: #6b7280;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f1117; --fg: #e5e7eb; --muted: #9ca3af; --line: #2a2f3a;
+      --card: #161a22; --accent: #a5b4fc;
+      --ok-bg: #14331f; --ok-fg: #86efac; --partial-bg: #3a2e0a; --partial-fg: #fde68a;
+      --none-bg: #3a1414; --none-fg: #fca5a5; --err-bg: #1f232b; --err-fg: #9ca3af;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+  header { padding: 24px 28px; border-bottom: 1px solid var(--line); }
+  h1 { margin: 0 0 4px; font-size: 20px; }
+  .meta { color: var(--muted); font-size: 13px; }
+  .meta b { color: var(--fg); font-weight: 600; }
+  .controls { display: flex; flex-wrap: wrap; gap: 12px; padding: 16px 28px; border-bottom: 1px solid var(--line);
+    position: sticky; top: 0; background: var(--bg); z-index: 5; }
+  select, input[type=search] { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px;
+    background: var(--card); color: var(--fg); font-size: 14px; }
+  input[type=search] { flex: 1; min-width: 200px; }
+  .count { color: var(--muted); font-size: 13px; align-self: center; margin-left: auto; }
+  main { padding: 16px 28px 60px; }
+  .item { border: 1px solid var(--line); border-radius: 12px; margin-bottom: 12px; background: var(--card); overflow: hidden; }
+  .item summary { list-style: none; cursor: pointer; padding: 14px 16px; display: flex; gap: 12px; align-items: flex-start; }
+  .item summary::-webkit-details-marker { display: none; }
+  .badge { flex: none; font-weight: 700; font-size: 13px; padding: 4px 9px; border-radius: 999px; white-space: nowrap; }
+  .b-ok { background: var(--ok-bg); color: var(--ok-fg); }
+  .b-partial { background: var(--partial-bg); color: var(--partial-fg); }
+  .b-none { background: var(--none-bg); color: var(--none-fg); }
+  .b-err { background: var(--err-bg); color: var(--err-fg); }
+  .stem { flex: 1; }
+  .stem .q { font-weight: 500; }
+  .tags { margin-top: 4px; color: var(--muted); font-size: 12.5px; display: flex; gap: 12px; flex-wrap: wrap; }
+  .tags code { color: var(--accent); font-weight: 600; }
+  .lcs { border-top: 1px solid var(--line); padding: 4px 16px 12px; }
+  .lc { padding: 10px 0; border-bottom: 1px dashed var(--line); }
+  .lc:last-child { border-bottom: none; }
+  .lc-head { display: flex; gap: 8px; align-items: baseline; }
+  .yn { font-weight: 700; font-size: 12px; padding: 1px 7px; border-radius: 6px; }
+  .yn-yes { background: var(--ok-bg); color: var(--ok-fg); }
+  .yn-no { background: var(--none-bg); color: var(--none-fg); }
+  .lc-desc { font-weight: 500; }
+  .lc-field { margin-top: 5px; font-size: 13.5px; }
+  .lc-field .k { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .03em; }
+  .err-msg { padding: 0 16px 14px; color: var(--none-fg); font-size: 13.5px; }
+  .empty { color: var(--muted); text-align: center; padding: 48px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Math Standards Alignment — Verdicts</h1>
+  <div class="meta" id="meta"></div>
+</header>
+<div class="controls">
+  <select id="f-standard"><option value="">All standards</option></select>
+  <select id="f-grade"><option value="">All grades</option></select>
+  <select id="f-status">
+    <option value="">All results</option>
+    <option value="none">No components aligned (0)</option>
+    <option value="partial">Partial</option>
+    <option value="full">All components aligned</option>
+    <option value="error">Errors</option>
+  </select>
+  <input type="search" id="f-search" placeholder="Search question or component text…" />
+  <span class="count" id="count"></span>
+</div>
+<main id="list"></main>
+
+<script>
+var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__
+
+(function () {
+  var data = REPORT_DATA || { meta: {}, items: [] };
+  var items = data.items || [];
+  var m = data.meta || {};
+
+  document.getElementById('meta').innerHTML =
+    '<b>' + (m.reportId || '') + '</b> · generated ' + (m.generatedAt || '') +
+    ' · <b>' + (m.totalInputRows || 0) + '</b> items · ' +
+    '<b>' + (m.successful || 0) + '</b> evaluated · <b>' + (m.failed || 0) + '</b> errored' +
+    (m.sourcePath ? ' · ' + escapeHtml(m.sourcePath) : '');
+
+  var standards = Array.from(new Set(items.map(function (i) { return i.statementCode; }).filter(Boolean))).sort();
+  var grades = Array.from(new Set(items.map(function (i) { return i.grade; }).filter(Boolean))).sort();
+  fill('f-standard', standards);
+  fill('f-grade', grades);
+
+  var controls = ['f-standard', 'f-grade', 'f-status', 'f-search'];
+  controls.forEach(function (id) {
+    document.getElementById(id).addEventListener('input', render);
+  });
+  render();
+
+  function fill(id, values) {
+    var sel = document.getElementById(id);
+    values.forEach(function (v) {
+      var o = document.createElement('option'); o.value = v; o.textContent = v; sel.appendChild(o);
+    });
+  }
+
+  function classify(it) {
+    if (it.status === 'error') return 'error';
+    if (it.totalCount === 0 || it.totalCount === null) return 'none';
+    if (it.alignedCount === 0) return 'none';
+    if (it.alignedCount === it.totalCount) return 'full';
+    return 'partial';
+  }
+
+  function render() {
+    var fS = val('f-standard'), fG = val('f-grade'), fSt = val('f-status'), q = val('f-search').toLowerCase();
+    var list = document.getElementById('list');
+    list.innerHTML = '';
+    var shown = 0;
+
+    items.forEach(function (it) {
+      if (fS && it.statementCode !== fS) return;
+      if (fG && it.grade !== fG) return;
+      var cls = classify(it);
+      if (fSt) {
+        if (fSt === 'error' && cls !== 'error') return;
+        if (fSt === 'none' && cls !== 'none') return;
+        if (fSt === 'partial' && cls !== 'partial') return;
+        if (fSt === 'full' && cls !== 'full') return;
+      }
+      if (q) {
+        var hay = (it.question || '') + ' ' + (it.learningComponents || []).map(function (lc) {
+          return (lc.description || '') + ' ' + (lc.reasoning || '') + ' ' + (lc.feedback || '');
+        }).join(' ');
+        if (hay.toLowerCase().indexOf(q) === -1) return;
+      }
+      list.appendChild(renderItem(it, cls));
+      shown++;
+    });
+
+    if (shown === 0) list.innerHTML = '<div class="empty">No items match the current filters.</div>';
+    document.getElementById('count').textContent = shown + ' of ' + items.length + ' shown';
+  }
+
+  function renderItem(it, cls) {
+    var el = document.createElement('details');
+    el.className = 'item';
+    var badgeText, badgeClass;
+    if (cls === 'error') { badgeText = 'error'; badgeClass = 'b-err'; }
+    else {
+      badgeText = (it.alignedCount === null ? '?' : it.alignedCount) + '/' + (it.totalCount === null ? '?' : it.totalCount);
+      badgeClass = cls === 'full' ? 'b-ok' : (cls === 'none' ? 'b-none' : 'b-partial');
+    }
+
+    var summary = document.createElement('summary');
+    summary.innerHTML =
+      '<span class="badge ' + badgeClass + '">' + badgeText + '</span>' +
+      '<span class="stem"><span class="q">' + escapeHtml(it.question || '(no question text)') + '</span>' +
+      '<span class="tags"><code>' + escapeHtml(it.statementCode || '') + '</code>' +
+      (it.grade ? '<span>grade ' + escapeHtml(it.grade) + '</span>' : '') +
+      (it.id ? '<span>id ' + escapeHtml(it.id) + '</span>' : '') + '</span></span>';
+    el.appendChild(summary);
+
+    if (it.status === 'error') {
+      var e = document.createElement('div'); e.className = 'err-msg';
+      e.textContent = 'Evaluation error: ' + (it.error || 'unknown');
+      el.appendChild(e);
+      return el;
+    }
+
+    var lcs = document.createElement('div'); lcs.className = 'lcs';
+    (it.learningComponents || []).forEach(function (lc) {
+      var d = document.createElement('div'); d.className = 'lc';
+      var yn = lc.aligned ? '<span class="yn yn-yes">YES</span>' : '<span class="yn yn-no">NO</span>';
+      var html = '<div class="lc-head">' + yn + '<span class="lc-desc">' + escapeHtml(lc.description || '') + '</span></div>';
+      if (lc.reasoning) html += '<div class="lc-field"><span class="k">Reasoning</span><br>' + escapeHtml(lc.reasoning) + '</div>';
+      if (lc.feedback) html += '<div class="lc-field"><span class="k">Feedback</span><br>' + escapeHtml(lc.feedback) + '</div>';
+      d.innerHTML = html;
+      lcs.appendChild(d);
+    });
+    el.appendChild(lcs);
+    return el;
+  }
+
+  function val(id) { return document.getElementById(id).value; }
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/sdks/typescript/src/batch/families/standards-report.html
+++ b/sdks/typescript/src/batch/families/standards-report.html
@@ -88,7 +88,7 @@ var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__
   var m = data.meta || {};
 
   document.getElementById('meta').innerHTML =
-    '<b>' + (m.reportId || '') + '</b> · generated ' + (m.generatedAt || '') +
+    '<b>' + escapeHtml(m.reportId || '') + '</b> · generated ' + escapeHtml(m.generatedAt || '') +
     ' · <b>' + (m.totalInputRows || 0) + '</b> items · ' +
     '<b>' + (m.successful || 0) + '</b> evaluated · <b>' + (m.failed || 0) + '</b> errored' +
     (m.sourcePath ? ' · ' + escapeHtml(m.sourcePath) : '');

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -22,12 +22,12 @@ const MEMBERS = [{ id: EVALUATOR_ID, name: MathStandardsAlignmentEvaluator.metad
 
 // question + statementCode are load-bearing; jurisdiction defaults to CCSS
 // (Multi-State); grade + id are passthrough metadata (report slicing / joining).
-const COLUMNS: ColumnSpec[] = [
+export const STANDARDS_COLUMNS: ColumnSpec[] = [
   { name: 'question', aliases: ['text'], required: true },
   { name: 'statementCode', aliases: ['statement_code', 'ccss_standard', 'standard'], required: true },
   { name: 'jurisdiction', required: false, default: Jurisdiction.MultiState },
   { name: 'grade', required: false },
-  { name: 'id', required: false },
+  { name: 'id', aliases: ['item_id'], required: false },
 ];
 
 const VALID_JURISDICTIONS = new Set<string>(Object.values(Jurisdiction));
@@ -92,7 +92,7 @@ export const STANDARDS_FAMILY: EvaluatorFamily = {
   description:
     'Evaluates whether each item aligns to its tagged math standard, component by component',
   members: MEMBERS,
-  columns: COLUMNS,
+  columns: STANDARDS_COLUMNS,
   maxInputRows: 5000,
   requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
     // The platform key (Knowledge Graph) is always required; the LLM provider

--- a/sdks/typescript/src/batch/formatters.ts
+++ b/sdks/typescript/src/batch/formatters.ts
@@ -149,7 +149,7 @@ export function formatAsCSV(output: BatchOutput): string {
   return [headers, ...rows].map(row => row.join(',')).join('\n');
 }
 
-// ---- HTML Formatter ----
+// ---- JSON Formatter ----
 
 export interface ReportMeta {
   csvPath: string;
@@ -158,6 +158,41 @@ export interface ReportMeta {
   generatedAt: Date;
   totalInputRows: number;
 }
+
+/**
+ * Generic machine-readable output for the text-complexity family: one entry per
+ * (row, evaluator) with score/reasoning plus the untouched original row.
+ */
+export function formatAsJSON(output: BatchOutput, meta: ReportMeta): string {
+  return JSON.stringify(
+    {
+      meta: {
+        reportId: meta.reportId,
+        family: meta.groupId,
+        generatedAt: meta.generatedAt.toISOString(),
+        sourcePath: meta.csvPath,
+        totalInputRows: meta.totalInputRows,
+      },
+      summary: output.summary,
+      results: output.results
+        .slice()
+        .sort((a, b) => a.rowIndex - b.rowIndex || a.evaluatorId.localeCompare(b.evaluatorId))
+        .map((r) => ({
+          rowIndex: r.rowIndex,
+          evaluatorId: r.evaluatorId,
+          status: r.status,
+          score: r.score ?? null,
+          reasoning: r.reasoning ?? null,
+          error: r.error ?? null,
+          originalRow: r.originalRow,
+        })),
+    },
+    null,
+    2,
+  );
+}
+
+// ---- HTML Formatter ----
 
 export function formatAsHTML(output: BatchOutput, meta: ReportMeta): string {
   const { results } = output;

--- a/sdks/typescript/src/batch/index.ts
+++ b/sdks/typescript/src/batch/index.ts
@@ -18,8 +18,10 @@
 export { BatchEvaluator, getAvailableGroups, getFamilies, getFamily } from './evaluator.js';
 export type { BatchRunOptions } from './evaluator.js';
 export { parseCSV } from './csv.js';
-export { formatAsCSV, formatAsHTML } from './formatters.js';
+export { formatAsCSV, formatAsHTML, formatAsJSON } from './formatters.js';
 export type { ReportMeta } from './formatters.js';
+export { renderOutputs } from './output.js';
+export type { OutputBundle } from './output.js';
 export type {
   EvaluatorFamily,
   FamilyMember,

--- a/sdks/typescript/src/batch/output.ts
+++ b/sdks/typescript/src/batch/output.ts
@@ -1,0 +1,40 @@
+import type { BatchOutput } from './types.js';
+import { formatAsCSV, formatAsHTML, formatAsJSON, type ReportMeta } from './formatters.js';
+import { STANDARDS_FAMILY } from './families/standards.js';
+import {
+  formatStandardsCSV,
+  formatStandardsHTML,
+  formatStandardsJSON,
+} from './families/standards-output.js';
+
+export interface OutputBundle {
+  csv: string;
+  json: string;
+  html: string;
+}
+
+/**
+ * Render CSV + JSON + HTML for a completed batch, choosing the family's
+ * projections. The standards family emits a verdict browser and joinable JSON;
+ * every other family uses the text-complexity report shape.
+ */
+export function renderOutputs(familyId: string, output: BatchOutput, meta: ReportMeta): OutputBundle {
+  if (familyId === STANDARDS_FAMILY.id) {
+    const sMeta = {
+      reportId: meta.reportId,
+      generatedAt: meta.generatedAt,
+      sourcePath: meta.csvPath,
+      totalInputRows: meta.totalInputRows,
+    };
+    return {
+      csv: formatStandardsCSV(output),
+      json: formatStandardsJSON(output, sMeta),
+      html: formatStandardsHTML(output, sMeta),
+    };
+  }
+  return {
+    csv: formatAsCSV(output),
+    json: formatAsJSON(output, meta),
+    html: formatAsHTML(output, meta),
+  };
+}

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -41,6 +41,9 @@ export interface BatchResult {
   error?: string;
   payload?: unknown;
   processingTimeMs: number;
+  /** Canonical columns after family normalization (aliases + defaults applied).
+   * Absent on a hand-built result; empty for a row that failed normalization. */
+  columns?: Record<string, string>;
   originalRow: Record<string, unknown>; // Preserve all original CSV columns
 }
 

--- a/sdks/typescript/tests/unit/batch/cli-args.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseArgs, parseModelOverride, requiredProviders } from '../../../src/batch/cli-args.js';
+import { parseArgs, parseModelOverride, requiredProviders, resolveModel } from '../../../src/batch/cli-args.js';
 import { Provider } from '../../../src/batch/index.js';
 import type { EvaluatorGroup } from '../../../src/batch/index.js';
 
@@ -213,6 +213,53 @@ describe('parseArgs', () => {
       concurrency: 5,
       noTelemetry: true,
     });
+  });
+});
+
+// ---- new family/member/model/key/yes flags ----
+
+describe('parseArgs — family selection flags', () => {
+  it('parses --family', () => {
+    expect(parseArgs(['--family', 'math-standards-alignment'])).toMatchObject({ family: 'math-standards-alignment' });
+  });
+
+  it('parses --evaluator as a comma-separated list', () => {
+    expect(parseArgs(['--evaluator', 'vocabulary,conventionality']).evaluators).toEqual(['vocabulary', 'conventionality']);
+  });
+
+  it('accumulates repeated --evaluator flags', () => {
+    expect(parseArgs(['--evaluator', 'vocabulary', '--evaluator', 'purpose']).evaluators).toEqual(['vocabulary', 'purpose']);
+  });
+
+  it('parses --platform-api-key (space and = form)', () => {
+    expect(parseArgs(['--platform-api-key', 'pk']).platformApiKey).toBe('pk');
+    expect(parseArgs(['--platform-api-key=pk']).platformApiKey).toBe('pk');
+  });
+
+  it('parses --model and --yes/-y', () => {
+    expect(parseArgs(['--model', 'haiku']).model).toBe('haiku');
+    expect(parseArgs(['--yes']).yes).toBe(true);
+    expect(parseArgs(['-y']).yes).toBe(true);
+  });
+});
+
+// ---- resolveModel ----
+
+describe('resolveModel', () => {
+  it('resolves the haiku shortcode', () => {
+    expect(resolveModel('haiku')).toEqual({ provider: Provider.Anthropic, model: 'claude-haiku-4-5-20251001' });
+  });
+
+  it('resolves the opus shortcode case-insensitively', () => {
+    expect(resolveModel('OPUS')).toEqual({ provider: Provider.Anthropic, model: 'claude-opus-4-8' });
+  });
+
+  it('passes through a literal provider:model', () => {
+    expect(resolveModel('openai:gpt-5')).toEqual({ provider: Provider.OpenAI, model: 'gpt-5' });
+  });
+
+  it('throws for an unknown bare word (no colon, not a shortcode)', () => {
+    expect(() => resolveModel('gpt5')).toThrow(/shortcode/);
   });
 });
 

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -73,6 +73,18 @@ describe('renderOutputs — standards family', () => {
     expect(row).toContain('4.OA.A.1');
   });
 
+  it('prefixes verdict columns that collide with source columns (joinable, no dupes)', () => {
+    const r = standardsResult({ originalRow: { id: 'x', jurisdiction: 'California', statement_code: '4.OA.A.1' } });
+    const [header] = renderOutputs('math-standards-alignment', output([r]), meta).csv.split('\n');
+    const cols = header.split(',');
+    // Source columns kept as-is; colliding verdict columns are namespaced.
+    expect(cols.filter((c) => c === 'jurisdiction')).toHaveLength(1);
+    expect(cols).toContain('verdict_jurisdiction');
+    expect(cols).toContain('verdict_statement_code');
+    // Non-colliding verdict columns keep clean names.
+    expect(cols).toContain('aligned_ratio');
+  });
+
   it('HTML injects report data and leaves no placeholder marker', () => {
     const bundle = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
     expect(bundle.html).not.toContain('__REPLACED_BY_FORMATTER__');

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderOutputs } from '../../../src/batch/output.js';
+import { injectReportData } from '../../../src/batch/families/standards-output.js';
 import type { BatchOutput, BatchResult, ReportMeta } from '../../../src/batch/index.js';
 
 const meta: ReportMeta = {
@@ -92,12 +93,27 @@ describe('renderOutputs — standards family', () => {
     expect(bundle.html).toContain('4.OA.A.1');
   });
 
-  it('surfaces an errored row without a payload', () => {
-    const errored = standardsResult({ status: 'error', error: 'Standard not found', payload: undefined, score: undefined });
+  it('surfaces an errored row without a payload, keeping source context', () => {
+    const errored = standardsResult({
+      status: 'error', error: 'Standard not found', payload: undefined, score: undefined,
+      originalRow: { id: 'e1', ccss_standard: '4.OA.A.1', jurisdiction: 'Texas' },
+    });
     const parsed = JSON.parse(renderOutputs('math-standards-alignment', output([errored]), meta).json);
     expect(parsed.items[0].status).toBe('error');
     expect(parsed.items[0].error).toBe('Standard not found');
     expect(parsed.items[0].alignedCount).toBeNull();
+    // Error rows still carry jurisdiction/statementCode from the source row.
+    expect(parsed.items[0].jurisdiction).toBe('Texas');
+    expect(parsed.items[0].statementCode).toBe('4.OA.A.1');
+  });
+
+  it('CSV header is the union of source columns across all rows', () => {
+    const r1 = standardsResult({ originalRow: { id: 'a', ccss_standard: 'x' } });
+    const r2 = standardsResult({ rowIndex: 3, originalRow: { id: 'b', extra: 'y' } });
+    const [header] = renderOutputs('math-standards-alignment', output([r1, r2]), meta).csv.split('\n');
+    const cols = header.split(',');
+    expect(cols).toContain('extra'); // present only in the second row
+    expect(cols).toContain('ccss_standard'); // present only in the first row
   });
 });
 
@@ -112,5 +128,177 @@ describe('renderOutputs — text-complexity family (generic JSON)', () => {
     const parsed = JSON.parse(bundle.json);
     expect(parsed.results[0].evaluatorId).toBe('vocabulary');
     expect(parsed.results[0].score).toBe('slightly complex');
+  });
+
+  it('orders results by row, then by evaluator id within a row', () => {
+    const qtc = (rowIndex: number, evaluatorId: string): BatchResult => ({
+      rowIndex, text: 't', grade: '3', evaluatorId, status: 'success',
+      score: 'slightly complex', reasoning: '', processingTimeMs: 1,
+      originalRow: { text: 't', grade: '3' },
+    });
+    // Deliberately unsorted, with a same-row pair so the tiebreak is exercised.
+    const bundle = renderOutputs(
+      'text-complexity',
+      output([qtc(3, 'vocabulary'), qtc(2, 'vocabulary'), qtc(2, 'conventionality')]),
+      { ...meta, groupId: 'text-complexity' },
+    );
+
+    const parsed = JSON.parse(bundle.json);
+    expect(parsed.results.map((r: { rowIndex: number; evaluatorId: string }) => `${r.rowIndex}:${r.evaluatorId}`))
+      .toEqual(['2:conventionality', '2:vocabulary', '3:vocabulary']);
+  });
+});
+
+describe('renderOutputs — empty result sets', () => {
+  it('produces an empty standards CSV rather than a bare header', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([]), meta);
+    expect(bundle.csv).toBe('');
+  });
+
+  it('still produces parseable JSON and HTML when nothing ran', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([]), meta);
+    expect(() => JSON.parse(bundle.json)).not.toThrow();
+    expect(bundle.html).not.toContain('__REPLACED_BY_FORMATTER__');
+  });
+});
+
+describe('injectReportData', () => {
+  it('replaces the marker with the payload assignment', () => {
+    const out = injectReportData('before var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__ after', '{"a":1}');
+    expect(out).toContain('var REPORT_DATA = {"a":1};');
+    expect(out).not.toContain('__REPLACED_BY_FORMATTER__');
+  });
+
+  it('throws rather than emitting a report with no data when the marker is missing', () => {
+    expect(() => injectReportData('<html>no marker here</html>', '{}')).toThrow(/marker not found/);
+  });
+});
+
+describe('standards CSV — escaping, header contract, and blank handling', () => {
+  it('emits the exact header row so downstream joins have a stable contract', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
+    expect(bundle.csv.split('\n')[0]).toBe(
+      'id,ccss_standard,question,statement_code,jurisdiction,aligned_count,total_count,aligned_ratio,status,error,learning_components_json',
+    );
+  });
+
+  it('quotes and doubles-up fields containing a comma, quote or newline', () => {
+    const nasty = 'He said "hi", then\nleft';
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({ originalRow: { id: 'itm-1', ccss_standard: '4.OA.A.1', question: nasty } })]),
+      meta,
+    );
+    // The whole field is quoted and its inner quotes doubled, so the row still parses.
+    expect(bundle.csv).toContain('"He said ""hi"", then\nleft"');
+  });
+
+  it('leaves the ratio blank rather than dividing by zero', () => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({ payload: { statementCode: '4.OA.A.1', question: 'q', jurisdiction: 'Multi-State', alignedCount: 0, totalCount: 0, learningComponents: [] } })]),
+      meta,
+    );
+    const row = bundle.csv.split('\n')[1].split(',');
+    // aligned_count, total_count, aligned_ratio, status, error, learning_components_json
+    expect(row.slice(-6)).toEqual(['0', '0', '', 'success', '', '[]']);
+  });
+
+  it('writes an empty error cell on success and the message on failure', () => {
+    const ok = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
+    expect(JSON.parse(ok.json).items[0].error).toBeNull();
+
+    const bad = renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({ status: 'error', error: 'KG timeout', score: undefined, payload: undefined })]),
+      meta,
+    );
+    expect(bad.csv).toContain('KG timeout');
+    expect(JSON.parse(bad.json).items[0].error).toBe('KG timeout');
+
+    // Counts blank rather than "null", and no components, so the row still parses.
+    const cells = bad.csv.split('\n')[1].split(',');
+    expect(cells.slice(-6)).toEqual(['', '', '', 'error', 'KG timeout', '[]']);
+    expect(JSON.parse(bad.json).items[0].learningComponents).toEqual([]);
+  });
+
+  it('orders rows by source row index regardless of completion order', () => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([
+        standardsResult({ rowIndex: 4, originalRow: { id: 'c' } }),
+        standardsResult({ rowIndex: 2, originalRow: { id: 'a' } }),
+        standardsResult({ rowIndex: 3, originalRow: { id: 'b' } }),
+      ]),
+      meta,
+    );
+    expect(JSON.parse(bundle.json).items.map((i: { id: string }) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('falls back to the result text for question, and blanks a missing grade', () => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({
+        status: 'error', error: 'boom', payload: undefined, grade: undefined,
+        text: 'question from the row', originalRow: { id: 'itm-9' },
+      })]),
+      meta,
+    );
+    const row = JSON.parse(bundle.json).items[0];
+    expect(row.question).toBe('question from the row');
+    expect(row.grade).toBe('');
+  });
+
+  it('lists a column shared by several rows only once', () => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([
+        standardsResult({ rowIndex: 2, originalRow: { id: 'a', question: 'q1' } }),
+        standardsResult({ rowIndex: 3, originalRow: { id: 'b', question: 'q2' } }),
+      ]),
+      meta,
+    );
+    const header = bundle.csv.split('\n')[0].split(',');
+    expect(header.filter((h) => h === 'id')).toHaveLength(1);
+    expect(header.filter((h) => h === 'question')).toHaveLength(1);
+  });
+
+  it('blanks a column absent from a ragged row rather than writing undefined', () => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([
+        standardsResult({ rowIndex: 2, originalRow: { id: 'a', extra: 'present' } }),
+        standardsResult({ rowIndex: 3, originalRow: { id: 'b' } }),
+      ]),
+      meta,
+    );
+    const lines = bundle.csv.split('\n');
+    expect(lines[0].split(',').slice(0, 2)).toEqual(['id', 'extra']);
+    expect(lines[2].startsWith('b,,')).toBe(true);
+  });
+});
+
+describe('standards HTML — payload escaping', () => {
+  function htmlFor(question: string): string {
+    return renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({ payload: { statementCode: '4.OA.A.1', question, jurisdiction: 'Multi-State', alignedCount: 1, totalCount: 2, learningComponents: [] } })]),
+      meta,
+    ).html;
+  }
+
+  it('escapes angle brackets and ampersands so the payload cannot close the script tag', () => {
+    const html = htmlFor('</script><img src=x onerror=alert(1)>&');
+    expect(html).not.toContain('</script><img');
+    expect(html).toContain('\\u003c');
+    expect(html).toContain('\\u003e');
+    expect(html).toContain('\\u0026');
+  });
+
+  it('escapes U+2028 and U+2029, which are valid JSON but break inline script parsing', () => {
+    const html = htmlFor('line\u2028break\u2029here');
+    expect(html).toContain('\\u2028');
+    expect(html).toContain('\\u2029');
+    expect(html).not.toMatch(/[\u2028\u2029]/);
   });
 });

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { renderOutputs } from '../../../src/batch/output.js';
+import type { BatchOutput, BatchResult, ReportMeta } from '../../../src/batch/index.js';
+
+const meta: ReportMeta = {
+  csvPath: '/tmp/corpus.csv',
+  groupId: 'math-standards-alignment',
+  reportId: 'corpus_2026',
+  generatedAt: new Date('2026-08-08T00:00:00Z'),
+  totalInputRows: 2,
+};
+
+function standardsResult(over: Partial<BatchResult> = {}): BatchResult {
+  return {
+    rowIndex: 2,
+    text: '2+2=?',
+    grade: '4',
+    evaluatorId: 'math.standards-alignment',
+    status: 'success',
+    score: '1/2',
+    reasoning: '1 of 2 learning components aligned',
+    processingTimeMs: 10,
+    originalRow: { id: 'itm-1', ccss_standard: '4.OA.A.1', question: '2+2=?' },
+    payload: {
+      statementCode: '4.OA.A.1',
+      question: '2+2=?',
+      jurisdiction: 'Multi-State',
+      alignedCount: 1,
+      totalCount: 2,
+      learningComponents: [
+        { identifier: 'lc1', description: 'Add within 100', aligned: true, reasoning: 'r1', feedback: '' },
+        { identifier: 'lc2', description: 'Multiply', aligned: false, reasoning: 'r2', feedback: 'make it multiply' },
+      ],
+    },
+    ...over,
+  };
+}
+
+function output(results: BatchResult[]): BatchOutput {
+  return {
+    results,
+    summary: {
+      totalTasks: results.length,
+      successful: results.filter((r) => r.status === 'success').length,
+      failed: results.filter((r) => r.status === 'error').length,
+      durationMs: 100,
+      resultsPerEvaluator: {},
+    },
+  };
+}
+
+describe('renderOutputs — standards family', () => {
+  it('JSON carries per-component detail and the original row for joining', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
+    const parsed = JSON.parse(bundle.json);
+    expect(parsed.meta.family).toBe('math-standards-alignment');
+    expect(parsed.items).toHaveLength(1);
+    const item = parsed.items[0];
+    expect(item.id).toBe('itm-1');
+    expect(item.alignedCount).toBe(1);
+    expect(item.totalCount).toBe(2);
+    expect(item.learningComponents).toHaveLength(2);
+    expect(item.originalRow.ccss_standard).toBe('4.OA.A.1'); // joinable back to source
+  });
+
+  it('CSV flattens roll-ups, computes ratio, and preserves original columns', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
+    const [header, row] = bundle.csv.split('\n');
+    expect(header).toContain('aligned_count');
+    expect(header).toContain('aligned_ratio');
+    expect(header).toContain('id'); // passthrough original column
+    expect(row).toContain('0.500'); // 1/2
+    expect(row).toContain('4.OA.A.1');
+  });
+
+  it('HTML injects report data and leaves no placeholder marker', () => {
+    const bundle = renderOutputs('math-standards-alignment', output([standardsResult()]), meta);
+    expect(bundle.html).not.toContain('__REPLACED_BY_FORMATTER__');
+    expect(bundle.html).toContain('var REPORT_DATA = {');
+    expect(bundle.html).toContain('4.OA.A.1');
+  });
+
+  it('surfaces an errored row without a payload', () => {
+    const errored = standardsResult({ status: 'error', error: 'Standard not found', payload: undefined, score: undefined });
+    const parsed = JSON.parse(renderOutputs('math-standards-alignment', output([errored]), meta).json);
+    expect(parsed.items[0].status).toBe('error');
+    expect(parsed.items[0].error).toBe('Standard not found');
+    expect(parsed.items[0].alignedCount).toBeNull();
+  });
+});
+
+describe('renderOutputs — text-complexity family (generic JSON)', () => {
+  it('emits one result per (row, evaluator) with score/reasoning', () => {
+    const qtcResult: BatchResult = {
+      rowIndex: 2, text: 'hello', grade: '3', evaluatorId: 'vocabulary', status: 'success',
+      score: 'slightly complex', reasoning: 'simple words', processingTimeMs: 5,
+      originalRow: { text: 'hello', grade: '3' },
+    };
+    const bundle = renderOutputs('text-complexity', output([qtcResult]), { ...meta, groupId: 'text-complexity' });
+    const parsed = JSON.parse(bundle.json);
+    expect(parsed.results[0].evaluatorId).toBe('vocabulary');
+    expect(parsed.results[0].score).toBe('slightly complex');
+  });
+});

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -172,6 +172,23 @@ describe('injectReportData', () => {
   it('throws rather than emitting a report with no data when the marker is missing', () => {
     expect(() => injectReportData('<html>no marker here</html>', '{}')).toThrow(/marker not found/);
   });
+
+  // As a replacement *string*, `$$`/`$&`/`$'` are substitution patterns: `$$x^2$$`
+  // would collapse to `$x^2$` and `$'` would splice the template tail — including
+  // the closing </script> — into the inline script.
+  it.each([
+    ['$$ (LaTeX)', '{"q":"Evaluate $$x^2$$"}'],
+    ["$' (tail splice)", `{"q":"see $' here"}`],
+    ['$& (whole match)', '{"q":"a $& b"}'],
+    ['$` (prefix)', '{"q":"a $` b"}'],
+  ])('inserts %s verbatim instead of expanding it', (_label, payload) => {
+    const template = `<script>\nvar REPORT_DATA = null; // __REPLACED_BY_FORMATTER__\n</script>\n<div>TAIL</div>`;
+    const out = injectReportData(template, payload);
+
+    expect(out).toContain(`var REPORT_DATA = ${payload};`);
+    // Exactly one closing script tag: the tail was not spliced into the script.
+    expect(out.match(/<\/script>/g)).toHaveLength(1);
+  });
 });
 
 describe('standards CSV — escaping, header contract, and blank handling', () => {
@@ -220,6 +237,38 @@ describe('standards CSV — escaping, header contract, and blank handling', () =
     const cells = bad.csv.split('\n')[1].split(',');
     expect(cells.slice(-6)).toEqual(['', '', '', 'error', 'KG timeout', '[]']);
     expect(JSON.parse(bad.json).items[0].learningComponents).toEqual([]);
+  });
+
+  // normalizeRow matches headers case-insensitively and via the family's aliases,
+  // so anything accepted on input must survive into the outputs.
+  it.each([
+    ['canonical, normalized', { columns: { id: 'itm-9', statementCode: '5.NF.B.3', jurisdiction: 'Utah' } }],
+    ['aliased + capitalized source headers', {
+      columns: undefined,
+      originalRow: { Item_ID: 'itm-9', CCSS_Standard: '5.NF.B.3', Jurisdiction: 'Utah' },
+    }],
+    // Blank/null/padded keys must all fall through to a populated alias rather
+    // than resolving to '' or the string "null".
+    ['blank, null and padded keys, falling through to a populated alias', {
+      columns: { id: '', statementCode: '', jurisdiction: '' },
+      originalRow: {
+        statementCode: '',
+        statement_code: null,
+        Item_ID: 'itm-9',
+        CCSS_Standard: '5.NF.B.3',
+        '  Jurisdiction  ': 'Utah',
+      },
+    }],
+  ])('carries id/statementCode/jurisdiction from %s onto an error row', (_label, over) => {
+    const bundle = renderOutputs(
+      'math-standards-alignment',
+      output([standardsResult({ status: 'error', error: 'KG 401', score: undefined, payload: undefined, ...over })]),
+      meta,
+    );
+    const [item] = JSON.parse(bundle.json).items;
+    expect(item.id).toBe('itm-9');
+    expect(item.statementCode).toBe('5.NF.B.3');
+    expect(item.jurisdiction).toBe('Utah');
   });
 
   it('orders rows by source row index regardless of completion order', () => {

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { STANDARDS_FAMILY } from '../../../src/batch/families/standards.js';
+import { QTC_FAMILY } from '../../../src/batch/families/qtc.js';
 import { Provider } from '../../../src/batch/index.js';
 import { Jurisdiction } from '../../../src/knowledge-graph/index.js';
 import type { FamilyRow } from '../../../src/batch/families/family.js';
@@ -15,6 +16,33 @@ describe('STANDARDS_FAMILY.requiredKeys', () => {
     expect(
       STANDARDS_FAMILY.requiredKeys([MEMBER], { provider: Provider.Google, model: 'gemini-x' }),
     ).toEqual([Provider.Google, 'platform']);
+  });
+});
+
+describe('QTC_FAMILY.requiredKeys — member selection', () => {
+  it('demands both keys when every member runs', () => {
+    expect(new Set(QTC_FAMILY.requiredKeys([]))).toEqual(new Set([Provider.Google, Provider.OpenAI]));
+  });
+
+  // Demanding a key the run never uses blocks an otherwise valid non-interactive run.
+  it.each([
+    ['grade-level-appropriateness', [Provider.Google]],
+    ['sentence-structure', [Provider.OpenAI]],
+    ['vocabulary', [Provider.Google, Provider.OpenAI]],
+  ])('asks only for the keys %s actually uses', (memberId, expected) => {
+    expect(new Set(QTC_FAMILY.requiredKeys([memberId]))).toEqual(new Set(expected));
+  });
+
+  it('unions the keys across a mixed selection', () => {
+    expect(new Set(QTC_FAMILY.requiredKeys(['grade-level-appropriateness', 'sentence-structure']))).toEqual(
+      new Set([Provider.Google, Provider.OpenAI]),
+    );
+  });
+
+  it('still collapses to the override provider alone', () => {
+    expect(
+      QTC_FAMILY.requiredKeys(['vocabulary'], { provider: Provider.Anthropic, model: 'claude-x' }),
+    ).toEqual([Provider.Anthropic]);
   });
 });
 


### PR DESCRIPTION
## Summary

Stacked on #152. Adds the **output projections** and the **CLI flow** for the family-adapter batch tool, making the `math-standards-alignment` family reachable end-to-end.

## What changed

**Outputs (WS4)**
- `renderOutputs(familyId, output, meta)` dispatches per family → `{ csv, json, html }`.
- Standards family: joinable **JSON** (per-item verdicts with full per-component detail + each row's original columns), flat **CSV** (roll-ups + `aligned_ratio`, per-component detail as embedded JSON), and a self-contained **HTML verdict browser** (per-item aligned/total, expandable per-component reasoning/feedback, filter by standard/grade/status/text). Verdicts only — aggregate flag-rate/coverage is downstream interpretation.
- Generic `formatAsJSON` for the text-complexity family.

**CLI (WS5)**
- Family → member selection (`--family`, `--evaluator id[,id...]`, repeatable; interactive multiselect otherwise).
- `--model <shortcode|provider:model>` (shortcodes: `haiku`, `opus`) — also fixes the missing `--model` alias.
- Credential resolution driven by the family's `requiredKeys`, including the always-required **platform key** for standards (`--platform-api-key` / `PLATFORM_API_KEY`).
- `-y`/`--yes` (and auto when no TTY) → non-interactive: never prompts, errors on missing input. Writes `results.csv` + `results.json` + `results.html`.

## Validation
- 477 unit tests pass; typecheck + lint clean; `tsup` build bundles the HTML template.
- Mutation tested with Stryker: `standards-output.ts` at **93% on covered code** (11 survivors), `output.ts` at 100%. Line coverage was 100% before this pass and hid real gaps — CSV quote/comma/newline escaping and every HTML `<`/`>`/`&`/U+2028 escape were executed but unasserted, so a mutant removing them survived. `injectReportData` is extracted so the template-corruption guard is reachable without corrupting the real template. The remaining survivors are equivalent mutants (redundant `!== null` guards already covered by `totalCount > 0`) and `toLocaleString` date-format options, where asserting an exact locale string would be brittle.
- **End-to-end on the real Grade 4–5 corpus (2,738 items)** via a throwaway JSONL→CSV converter (kept out of the package): CLI parsed the real CSV, mapped aliases (`ccss_standard`→`statementCode`), resolved family/member, passed the row limit; on a 3-row slice with dummy keys it drove the full path to a **real Knowledge Graph 401**, proving request construction + **per-row error isolation** (3/3 errored, no whole-run abort) + all three outputs written with joinable `originalRow`. Successful-verdict path needs live keys.

## Review fixes

- **Report payload no longer acts as a `String.replace` pattern.** It was passed as the replacement
  string, so `$$`/`$&`/`` $` ``/`$'` in row data were substitution patterns: `$$x^2$$` in a question
  rendered as `$x^2$`, and `$'` spliced the template tail — including the closing `</script>` — into the
  inline script, defeating the escaping applied to the payload immediately above. Now a replacer function.
- **`--evaluator` selection drives credential requirements.** `requiredKeys` ignored the selected members,
  so running only `grade-level-appropriateness` (Google) still demanded an OpenAI key and blocked an
  otherwise valid non-interactive run. QTC now unions each selected member's `defaultProviders`.
- **Outputs read canonical columns instead of re-deriving them.** `toRow` used a hand-rolled, case-sensitive
  alias list that disagreed with the family's `ColumnSpec` (missing `statement_code`/`standard`, inventing
  `item_id`), so headers the CLI accepts on input were dropped from the reports. `BatchResult` now carries
  the normalized `columns`, `item_id` is a declared alias, and the source-row fallback matches
  case-insensitively against the spec's own aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




