### PR TITLE
fix(deps): bump js-yaml override to 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -3076,9 +3076,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -113,7 +113,7 @@
   },
   "overrides": {
     "@redocly/openapi-core": {
-      "js-yaml": "4.3.0"
+      "js-yaml": "4.3.1"
     }
   },
   "engines": {


### PR DESCRIPTION
Resolves Dependabot alert [#37](https://github.com/learning-commons-org/evaluators/security/dependabot/37) — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), quadratic CPU consumption in js-yaml `!!omap` resolution (high).

Dependabot could not raise this PR itself: js-yaml is pinned by our own `overrides` block under `@redocly/openapi-core`, so the override wins over any upstream bump.

Bumps the pin `4.3.0` → `4.3.1` (dev scope only — reached solely by `npm run generate:kg-types`).

Lockfile edited by hand rather than via `npm install` to preserve the 10 `libc` arrays npm strips on macOS; `npm ci` then confirmed the lock is consistent and left it unmodified.

Verified: `js-yaml@4.3.1 overridden`, `npm audit` clear of this advisory, `generate:kg-types` succeeds, build + lint clean, 318 tests pass.

The override itself is still required — `openapi-typescript@7.13.0` depends on `@redocly/openapi-core@^1.34.6` (js-yaml 4.x). It can be dropped once that moves to redocly 2.x, which uses js-yaml `^5.2.2`.