### PR TITLE
chore(ts-sdk): regenerate Knowledge Graph API types from upstream spec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # (diff collapsed by default, expandable; omitted from language stats).
 #   _generated_*.py  →  make generate-settings
 #   contracts.toml   →  notebook/contract capture + make sync-settings (bundled copy)
+#   kg-api.d.ts      →  npm run generate:kg-types (sdks/typescript)
 sdks/python/src/learning_commons_evaluators/settings/_generated_*.py linguist-generated=true
 sdks/python/src/learning_commons_evaluators/settings/**/contracts.toml linguist-generated=true
 sdks/settings/**/contracts.toml linguist-generated=true
+sdks/typescript/src/knowledge-graph/kg-api.d.ts linguist-generated=true

--- a/sdks/typescript/eslint.config.js
+++ b/sdks/typescript/eslint.config.js
@@ -5,6 +5,9 @@ import globals from 'globals';
 
 export default [
   js.configs.recommended,
+  // Generated from the upstream OpenAPI spec; its doc comments carry whatever
+  // characters the spec authors used, so linting it fails on their text.
+  { ignores: ['src/knowledge-graph/kg-api.d.ts'] },
   {
     files: ['src/**/*.ts', 'tests/**/*.ts'],
     languageOptions: {

--- a/sdks/typescript/src/knowledge-graph/kg-api.d.ts
+++ b/sdks/typescript/src/knowledge-graph/kg-api.d.ts
@@ -4,6 +4,548 @@
  */
 
 export interface paths {
+    "/standards-frameworks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Standards frameworks
+         * @description Fetches a list of StandardsFramework objects representing complete academic standards documents. Each standards framework represents a complete standards document published by an official body like a state department of education.
+         *     This endpoint allows you to discover available standards frameworks and retrieve metadata about standards documents from different jurisdictions, subjects, and adoption statuses.
+         *
+         *     Use this endpoint when you need to:
+         *     - Discover available standards frameworks to query academic standards from
+         *     - Find standards framework UUIDs needed for the GET /academic-standards endpoint
+         *     - Browse standards frameworks by subject, jurisdiction, or adoption status
+         *     - Get standards framework metadata (title, adoption status, modification dates)
+         *
+         *     **Related topics:**
+         *     - [Understanding StandardsFramework vs StandardsFrameworkItem](/knowledge-graph/graph-reference/academic-standards)
+         *     - [Framework adoption statuses](/knowledge-graph/graph-reference/value-and-format-standards#adoptionstatusenum)
+         */
+        get: operations["listFrameworks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Standard by ID
+         * @description Fetches a single `StandardsFrameworkItem` by its CASE Network UUID.
+         *
+         *     A `StandardsFrameworkItem` represents an individual statement or structural element within a standards framework. These items can be normative statements that specify what students should know or be able to do (e.g., "Describe the impact of a transformation matrix on a graphical object"), or organizational groupings that structure the framework (e.g., domains, strands, clusters).
+         *
+         *     Use this endpoint when you need to:
+         *     - Display the full details of a specific academic standard in your application
+         *     - Retrieve the exact statement text, grade levels, and classification for a known academic standard
+         *     - Trace an academic standard back to its source in the CASE Network via the CASE identifiers
+         *
+         *     The response includes the statement text, grade level(s), subject area, jurisdiction, and all source attribution required by the CC BY 4.0 license.
+         *
+         *     **Related topics:**
+         *     - [Understanding StandardsFrameworkItem vs StandardsFramework](/knowledge-graph/graph-reference/academic-standards)
+         *     - [Standard classification types](/knowledge-graph/graph-reference/value-and-format-standards#normalizedstatementtypeenum)
+         */
+        get: operations["getAcademicStandardByCaseIdentifierUUID"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Standards in a framework
+         * @description Fetches a list of StandardsFrameworkItems for a specific standards framework.
+         *
+         *     This endpoint retrieves academic standards from a single standards framework identified by its CASE Network UUID. You can further filter the results by grade level or classification type. This is useful when you need to work with academic standards from a specific state or jurisdiction.
+         *
+         *     Use this endpoint when you need to:
+         *     - Get all academic standards within a specific standards framework
+         *     - Find academic standards for a particular grade level within a standards framework
+         *     - Filter academic standards by subject area (e.g., only Mathematics academic standards)
+         *     - Filter academic standards by their normalized classification (e.g., only instructional academic standards, not organizational groupings)
+         *     - Retrieve a subset of a standards framework's academic standards for display or processing
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned and navigate through large result sets.
+         *
+         *     **Related topics:**
+         *     - [Understanding StandardsFrameworkItem classifications](/knowledge-graph/graph-reference/value-and-format-standards#normalizedstatementtypeenum)
+         */
+        get: operations["listAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search standards
+         * @description Searches for StandardsFrameworkItems using either semantic search or exact statement code match across all standards frameworks.
+         *
+         *     This endpoint supports two mutually exclusive search modes:
+         *
+         *     - **Semantic search** (`query`): Full-text semantic search against the standard's description. Results are ranked by relevance and include a `score` reflecting vector similarity.
+         *     - **Code search** (`statementCode`): Exact statement code match (e.g., "3.NF.A.1"). Case-insensitive, no partial matching. All results carry a `score` of 1.0.
+         *
+         *     **Exactly one of `query` or `statementCode` must be provided.** Providing both or neither returns a 400 error.
+         *
+         *     Results can be narrowed further using the optional filters and support cursor-based pagination.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find academic standards relevant to a concept or learning goal (semantic search)
+         *     - Look up an academic standard by its exact statement code
+         *     - Find all standards frameworks that include a specific statement code
+         *     - Filter search results by grade level, subject, or statement type
+         *
+         *     **Note:** Not all academic standards have statement codes - some organizational groupings may have null codes and won't appear in code search results.
+         *
+         *     **Related topics:**
+         *     - [Understanding statement codes](/knowledge-graph/graph-reference/academic-standards#standardsframeworkitem)
+         */
+        get: operations["searchAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/children": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Children of a standard
+         * @description Fetches StandardsFrameworkItems that are direct children of the specified academic standard through the "hasChild" relationship.
+         *
+         *     This endpoint retrieves academic standards that are hierarchically organized under the given academic standard. This allows you to navigate down the standards framework hierarchy from domains to clusters to individual academic standards, or from any parent grouping to its children.
+         *
+         *     Use this endpoint when you need to:
+         *     - Navigate down the standards framework hierarchy (e.g., from domain to academic standards)
+         *     - Get all academic standards within a specific grouping or cluster
+         *     - Build tree visualizations of standards framework structures
+         *     - Explore the organizational structure of a standards document
+         *
+         *     **Note:** This returns direct children only, not all descendants. To get all descendants, you'll need to traverse multiple levels.
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Understanding the hasChild relationship](/knowledge-graph/graph-reference/academic-standards#haschild)
+         */
+        get: operations["listChildAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/prerequisites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Prerequisites for a standard
+         * @description Fetches the prerequisite StandardsFrameworkItems for the specified academic standard - the foundational standards it builds **from** via the "buildsTowards" relationship.
+         *
+         *     These are the foundational skills or concepts that contribute to mastery of the given academic standard (each prerequisite `buildsTowards` the given standard). The relationship is directional but does not require strict prerequisite order - students don't need to fully master prerequisites before engaging with the given academic standard.
+         *
+         *     Use this endpoint when you need to:
+         *     - Identify foundational academic standards students should be familiar with before tackling a target academic standard
+         *     - Trace backward through a learning progression to understand dependencies
+         *     - Design remediation or review activities based on prerequisite skills
+         *     - Map out a coherent learning pathway for students
+         *
+         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards (CCSS) for Mathematics. Coverage for other subjects and frameworks may be limited.
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Understanding the buildsTowards relationship](/knowledge-graph/graph-reference/learning-progressions#buildstowards)
+         */
+        get: operations["listPrerequisiteAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/builds-towards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Standards a standard builds towards
+         * @description Fetches the StandardsFrameworkItems that the specified academic standard builds **towards** via the "buildsTowards" relationship - the standards it is a prerequisite of.
+         *
+         *     These are the next logical learning steps or more advanced concepts that students can progress to after working with the given academic standard (the given standard `buildsTowards` each of them). Proficiency in the given academic standard supports the likelihood of success in these standards.
+         *
+         *     Use this endpoint when you need to:
+         *     - Identify next steps in a learning progression after students master an academic standard
+         *     - Design curriculum sequences that build on foundational skills
+         *     - Map forward through learning pathways to understand where academic standards lead
+         *     - Plan long-term instructional trajectories for students
+         *
+         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards (CCSS) for Mathematics. Coverage for other subjects and frameworks may be limited.
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Understanding the buildsTowards relationship](/knowledge-graph/graph-reference/learning-progressions#buildstowards)
+         */
+        get: operations["listBuildsTowardsAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/related-standards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Related standards for a standard
+         * @description Fetches StandardsFrameworkItems that are related to the specified academic standard through the "relatesTo" relationship.
+         *
+         *     This endpoint retrieves academic standards that share meaningful conceptual or skill-based links with the given academic standard, without implying a specific sequence or prerequisite order. These lateral connections highlight associations that can inform instructional design, identify reinforcing concepts, or reveal thematic links across academic standards.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find academic standards with related content or skills for integrated instruction
+         *     - Identify opportunities for reinforcing concepts across different academic standards
+         *     - Design cross-curricular or thematic units that connect related academic standards
+         *     - Discover alternative pathways or parallel concepts in curriculum planning
+         *
+         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards (CCSS) for Mathematics. Coverage for other subjects and frameworks may be limited.
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Understanding the relatesTo relationship](/knowledge-graph/graph-reference/learning-progressions#relatesto)
+         */
+        get: operations["listRelatedAcademicStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/learning-components": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Learning components for a standard
+         * @description Fetches a list of LearningComponents that support a specific StandardsFrameworkItem.
+         *
+         *     This endpoint retrieves all learning components that are aligned to a given academic standard through the "supports" relationship. Learning components break down broad academic standards into granular, teachable skills, making them actionable for lesson planning and assessment design.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find the specific skills that compose a given academic standard
+         *     - Identify granular learning targets for instruction aligned to an academic standard
+         *     - Map learning components to your curriculum or assessment items
+         *     - Understand how a broad academic standard breaks down into teachable units
+         *
+         *     **Note:** Learning component alignments are currently available primarily for Mathematics academic standards. Academic standards in other subjects or certain special categories (e.g., Standards for Mathematical Practice, Pre-K, advanced math) may not have LC alignments.
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Understanding the supports relationship](/knowledge-graph/graph-reference/learning-components#supports)
+         *     - [LC alignment methodology](/knowledge-graph/graph-reference/learning-components#creation-of-lcs)
+         *     - [Available LC coverage by state](/knowledge-graph/graph-reference/learning-components#current-lc-mappings)
+         */
+        get: operations["listLearningComponentsByAcademicStandard"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/crosswalks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Crosswalks for a standard
+         * @description Fetches a list of standards that align to a specific standard through shared Learning Components.
+         *
+         *     This endpoint retrieves crosswalk relationships bidirectionally:
+         *     - **State standard → CCSS**: Pass in a state standard to get matching Common Core State Standards (CCSS)
+         *     - **CCSS → State standards**: Pass in a Common Core State Standards (CCSS) standard to get matching state standards across jurisdictions
+         *
+         *     Each crosswalk includes similarity metrics based on measurable overlap of Learning Components to help understand the strength and nature of the alignment.
+         *
+         *     Crosswalks provide a scalable way to extend mappings between CCSS and state-specific frameworks without independent matching logic. By leveraging the LC superset, crosswalks show where standards converge in content coverage.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find Common Core State Standards (CCSS) standards that align to a state standard for content adaptation
+         *     - Find state standards that align to a Common Core State Standards (CCSS) standard across multiple jurisdictions
+         *     - Understand the similarity between standards
+         *     - Map content between Common Core and state frameworks
+         *     - Analyze the degree of overlap between standards
+         *
+         *     **Note:** Crosswalks are currently available only for Mathematics standards in states where LC alignment exists. Crosswalks are evidence-based (require at least one shared LC).
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
+         *
+         *     **Related topics:**
+         *     - [Standards crosswalks methodology](/knowledge-graph/graph-reference/standards-crosswalks)
+         */
+        get: operations["listCrosswalkedStandards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning-components/{identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Learning component by ID
+         * @description Fetches a single LearningComponent by its unique identifier.
+         *
+         *     A LearningComponent represents a single, well-defined skill or concept that students are expected to learn. Learning components are granular units of learning that break down broad state standards into teachable and measurable parts at the level of a lesson, activity, or assessment question.
+         *
+         *     Use this endpoint when you need to:
+         *     - Display the full details of a specific learning component
+         *     - Retrieve the skill description and metadata for a known learning component
+         *     - Access attribution information for learning components used in your application
+         *
+         *     Learning components(LCs) are developed through expert-driven processes with input from experienced educators. Currently, LCs are available for mathematics standards across multiple states, with more subjects and states being added over time.
+         *
+         *     **Related topics:**
+         *     - [Understanding Learning Components](/knowledge-graph/graph-reference/learning-components)
+         *     - [LC creation and alignment process](/knowledge-graph/graph-reference/learning-components#creation-of-lcs)
+         *     - [Available LC mappings by state](/knowledge-graph/graph-reference/learning-components#current-lc-mappings)
+         */
+        get: operations["getLearningComponentByIdentifier"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/lessons": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lessons for a standard
+         * @description Fetches summary information for all lessons that address a specific academic standard.
+         *
+         *     Returns lesson summaries (identifier, name, position) that are aligned to this standard, indicating which lessons in the curriculum help students achieve this learning expectation.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find all lessons that teach a specific standard
+         *     - Build standards-based lesson sequences
+         *     - Track where standards are addressed across the curriculum
+         *     - Generate standards coverage reports
+         */
+        get: operations["getStandardLessons"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/activities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Activities for a standard
+         * @description Fetches summary information for all activities that address a specific academic standard.
+         *
+         *     Returns activity summaries (identifier, name, position) that are aligned to this standard, indicating which specific instructional tasks help students achieve this learning expectation.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find all activities that teach a specific standard
+         *     - Build standards-based activity sets
+         *     - Track standards coverage at the activity level
+         *     - Generate detailed standards alignment reports
+         */
+        get: operations["getStandardActivities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/academic-standards/{caseIdentifierUUID}/assessments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Assessments for a standard
+         * @description Fetches summary information for all assessments that evaluate a specific academic standard.
+         *
+         *     Returns assessment summaries (identifier, name) that are aligned to this standard, indicating which assessments measure student achievement of this learning expectation.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find all assessments that evaluate a specific standard
+         *     - Build standards-based assessment systems
+         *     - Track which standards are assessed
+         *     - Generate assessment coverage reports
+         */
+        get: operations["getStandardAssessments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning-components": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Learning components by subject
+         * @description Fetches a list of LearningComponents filtered by academic subject.
+         *
+         *     This endpoint retrieves learning components for a specific subject area. Learning components are granular skills that break down broad standards into teachable units. Learning components are available for Mathematics and English Language Arts, with additional subjects being developed.
+         *
+         *     Use this endpoint when you need to:
+         *     - Get all learning components available for a specific subject
+         *     - Browse the complete set of skills/concepts for curriculum planning
+         *     - Retrieve LCs for mapping to your own content or assessments
+         *     - Export learning component data for analysis or integration
+         *
+         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned and navigate through large result sets.
+         *
+         *     **Related topics:**
+         *     - [Understanding Learning Components](/knowledge-graph/graph-reference/learning-components)
+         *     - [Available LC coverage by subject and state](/knowledge-graph/graph-reference/learning-components#current-lc-mappings)
+         */
+        get: operations["listLearningComponents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning-components/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search learning components
+         * @description <Warning>This endpoint is for free-text semantic search across learning component descriptions. To retrieve learning components for a specific standard, use [Components for a standard](/api-reference/learning-components/learning-components-for-a-standard) instead.</Warning>
+         *
+         *     Searches for LearningComponents using semantic search against learning component descriptions.
+         *
+         *     Results are ranked by relevance to the query text and include a `score` reflecting vector similarity. Use the optional `academicSubject` filter to narrow results to a specific subject area.
+         *
+         *     Use this endpoint when you need to:
+         *     - Find learning components relevant to a specific skill or concept
+         *     - Discover granular instructional targets related to a teaching goal
+         *     - Search for LCs to map to your own content or assessments
+         *
+         *     **Related topics:**
+         *     - [Understanding Learning Components](/knowledge-graph/graph-reference/learning-components)
+         *     - [Available LC coverage by subject and state](/knowledge-graph/graph-reference/learning-components#current-lc-mappings)
+         */
+        get: operations["searchLearningComponents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/courses": {
         parameters: {
             query?: never;
@@ -77,7 +619,7 @@ export interface paths {
          * Lesson grouping by ID
          * @description Fetches detailed information about a specific lesson grouping.
          *
-         *     A lesson grouping organizes a set of related lessons within a curriculum. The naming and organizational level of lesson groupings vary across curricula - they may be called units, modules, chapters, sections, themes, etc. The `groupName` property indicates the specific type used by the curriculum.
+         *     Set of related lessons within a curriculum; naming and organizational level may vary across curricula (e.g., unit, module, chapter, section, theme). The `groupName` property indicates the specific type used by the curriculum.
          *
          *     Lesson groupings can be nested (e.g., units containing sections, chapters containing modules) as indicated by the `groupLevel` property, where 0 represents the top level.
          *
@@ -297,640 +839,96 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/standards-frameworks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Standards frameworks
-         * @description Fetches a list of StandardsFramework objects representing complete academic standards documents. Each standards framework represents a complete standards document published by an official body like a state department of education.
-         *     This endpoint allows you to discover available standards frameworks and retrieve metadata about standards documents from different jurisdictions, subjects, and adoption statuses.
-         *
-         *     Use this endpoint when you need to:
-         *     - Discover available standards frameworks to query academic standards from
-         *     - Find standards framework UUIDs needed for the GET /academic-standards endpoint
-         *     - Browse standards frameworks by subject, jurisdiction, or adoption status
-         *     - Get standards framework metadata (title, adoption status, modification dates)
-         *
-         *     **Related topics:**
-         *     - [Understanding StandardsFramework vs StandardsFrameworkItem](/knowledge-graph/entity-and-relationship-reference/academic-standards)
-         *     - [Framework adoption statuses](/knowledge-graph/entity-and-relationship-reference/value-and-format-standards#adoptionstatusenum)
-         */
-        get: operations["listFrameworks"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Academic standard by ID
-         * @description Fetches a single StandardsFrameworkItem by its CASE UUID identifier.
-         *
-         *     A StandardsFrameworkItem represents an individual statement or structural element within a standards framework. These items can be normative statements that specify what students should know or be able to do (e.g., "Describe the impact of a transformation matrix on a graphical object"), or organizational groupings that structure the framework (e.g., domains, strands, clusters).
-         *
-         *     Use this endpoint when you need to:
-         *     - Display the full details of a specific academic standard in your application
-         *     - Retrieve the exact statement text, grade levels, and classification for a known academic standard
-         *     - Trace an academic standard back to its source in the CASE Network via the CASE identifiers
-         *
-         *     The response includes the statement text, grade level(s), subject area, jurisdiction, and all source attribution required by the CC BY 4.0 license.
-         *
-         *     **Related topics:**
-         *     - [Understanding StandardsFrameworkItem vs StandardsFramework](/knowledge-graph/entity-and-relationship-reference/academic-standards)
-         *     - [Standard classification types](/knowledge-graph/entity-and-relationship-reference/value-and-format-standards#normalizedstatementtypeenum)
-         */
-        get: operations["getAcademicStandardByCaseIdentifierUUID"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Academic standards in a framework
-         * @description Fetches a list of StandardsFrameworkItems for a specific standards framework.
-         *
-         *     This endpoint retrieves academic standards from a single standards framework identified by its CASE UUID. You can further filter the results by grade level or classification type. This is useful when you need to work with academic standards from a specific state or jurisdiction.
-         *
-         *     Use this endpoint when you need to:
-         *     - Get all academic standards within a specific standards framework
-         *     - Find academic standards for a particular grade level within a standards framework
-         *     - Filter academic standards by subject area (e.g., only Mathematics academic standards)
-         *     - Filter academic standards by their normalized classification (e.g., only instructional academic standards, not organizational groupings)
-         *     - Retrieve a subset of a standards framework's academic standards for display or processing
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned and navigate through large result sets.
-         *
-         *     **Related topics:**
-         *     - [Understanding StandardsFrameworkItem classifications](/knowledge-graph/entity-and-relationship-reference/value-and-format-standards#normalizedstatementtypeenum)
-         */
-        get: operations["listAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/search": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search academic standards
-         * @description Searches for StandardsFrameworkItems using either semantic search or exact statement code match across all standards frameworks.
-         *
-         *     This endpoint supports two mutually exclusive search modes:
-         *
-         *     - **Semantic search** (`query`): Full-text semantic search against the standard's description. Results are ranked by relevance and include a `score` reflecting vector similarity.
-         *     - **Code search** (`statementCode`): Exact statement code match (e.g., "3.NF.A.1"). Case-insensitive, no partial matching. All results carry a `score` of 1.0.
-         *
-         *     **Exactly one of `query` or `statementCode` must be provided.** Providing both or neither returns a 400 error.
-         *
-         *     Results can be narrowed further using the optional filters and support cursor-based pagination.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find academic standards relevant to a concept or learning goal (semantic search)
-         *     - Look up an academic standard by its exact statement code
-         *     - Find all standards frameworks that include a specific statement code
-         *     - Filter search results by grade level, subject, or statement type
-         *
-         *     **Note:** Not all academic standards have statement codes - some organizational groupings may have null codes and won't appear in code search results.
-         *
-         *     **Related topics:**
-         *     - [Understanding statement codes](/knowledge-graph/entity-and-relationship-reference/academic-standards#standardsframeworkitem)
-         */
-        get: operations["searchAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/children": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Children of a standard
-         * @description Fetches StandardsFrameworkItems that are direct children of the specified academic standard through the "hasChild" relationship.
-         *
-         *     This endpoint retrieves academic standards that are hierarchically organized under the given academic standard. This allows you to navigate down the standards framework hierarchy from domains to clusters to individual academic standards, or from any parent grouping to its children.
-         *
-         *     Use this endpoint when you need to:
-         *     - Navigate down the standards framework hierarchy (e.g., from domain to academic standards)
-         *     - Get all academic standards within a specific grouping or cluster
-         *     - Build tree visualizations of standards framework structures
-         *     - Explore the organizational structure of a standards document
-         *
-         *     **Note:** This returns direct children only, not all descendants. To get all descendants, you'll need to traverse multiple levels.
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Understanding the hasChild relationship](/knowledge-graph/entity-and-relationship-reference/academic-standards#haschild)
-         */
-        get: operations["listChildAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/prerequisites": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Prerequisites for a standard
-         * @description Fetches StandardsFrameworkItems that build towards the specified academic standard through the "buildsTowards" relationship.
-         *
-         *     This endpoint retrieves academic standards where proficiency supports the likelihood of success in the target academic standard. These are the foundational skills or concepts that contribute to mastery of the given academic standard. The relationship is directional but does not require strict prerequisite order - students don't need to fully master prerequisites before engaging with the target academic standard.
-         *
-         *     Use this endpoint when you need to:
-         *     - Identify foundational academic standards students should be familiar with before tackling a target academic standard
-         *     - Trace backward through a learning progression to understand dependencies
-         *     - Design remediation or review activities based on prerequisite skills
-         *     - Map out a coherent learning pathway for students
-         *
-         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards for Mathematics. Coverage for other subjects and frameworks may be limited.
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Understanding the buildsTowards relationship](/knowledge-graph/entity-and-relationship-reference/learning-progressions#buildstowards)
-         */
-        get: operations["listPrerequisiteAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/builds-towards": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Standards that build towards a standard
-         * @description Fetches StandardsFrameworkItems that the specified academic standard builds towards through the "buildsTowards" relationship.
-         *
-         *     This endpoint retrieves academic standards where proficiency in the given academic standard supports the likelihood of success. These are the next logical learning steps or more advanced concepts that students can progress to after working with the current academic standard.
-         *
-         *     Use this endpoint when you need to:
-         *     - Identify next steps in a learning progression after students master an academic standard
-         *     - Design curriculum sequences that build on foundational skills
-         *     - Map forward through learning pathways to understand where academic standards lead
-         *     - Plan long-term instructional trajectories for students
-         *
-         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards for Mathematics. Coverage for other subjects and frameworks may be limited.
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Understanding the buildsTowards relationship](/knowledge-graph/entity-and-relationship-reference/learning-progressions#buildstowards)
-         */
-        get: operations["listBuildsTowardsAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/related-standards": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Related standards for a standard
-         * @description Fetches StandardsFrameworkItems that are related to the specified academic standard through the "relatesTo" relationship.
-         *
-         *     This endpoint retrieves academic standards that share meaningful conceptual or skill-based links with the given academic standard, without implying a specific sequence or prerequisite order. These lateral connections highlight associations that can inform instructional design, identify reinforcing concepts, or reveal thematic links across academic standards.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find academic standards with related content or skills for integrated instruction
-         *     - Identify opportunities for reinforcing concepts across different academic standards
-         *     - Design cross-curricular or thematic units that connect related academic standards
-         *     - Discover alternative pathways or parallel concepts in curriculum planning
-         *
-         *     **Note:** Learning progression data is currently based on Student Achievement Partners' Coherence Map for Common Core State Standards for Mathematics. Coverage for other subjects and frameworks may be limited.
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Understanding the relatesTo relationship](/knowledge-graph/entity-and-relationship-reference/learning-progressions#relatesto)
-         */
-        get: operations["listRelatedAcademicStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/learning-components": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Learning components for a standard
-         * @description Fetches a list of LearningComponents that support a specific StandardsFrameworkItem.
-         *
-         *     This endpoint retrieves all learning components that are aligned to a given academic standard through the "supports" relationship. Learning components break down broad academic standards into granular, teachable skills, making them actionable for lesson planning and assessment design.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find the specific skills that compose a given academic standard
-         *     - Identify granular learning targets for instruction aligned to an academic standard
-         *     - Map learning components to your curriculum or assessment items
-         *     - Understand how a broad academic standard breaks down into teachable units
-         *
-         *     **Note:** Learning component alignments are currently available primarily for Mathematics academic standards. Academic standards in other subjects or certain special categories (e.g., Standards for Mathematical Practice, Pre-K, advanced math) may not have LC alignments.
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Understanding the supports relationship](/knowledge-graph/entity-and-relationship-reference/learning-components#supports)
-         *     - [LC alignment methodology](/knowledge-graph/entity-and-relationship-reference/learning-components#creation-of-lcs)
-         *     - [Available LC coverage by state](/knowledge-graph/entity-and-relationship-reference/learning-components#current-lc-mappings)
-         */
-        get: operations["listLearningComponentsByAcademicStandard"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/crosswalks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Crosswalks for a standard
-         * @description Fetches a list of standards that align to a specific standard through shared Learning Components.
-         *
-         *     This endpoint retrieves crosswalk relationships bidirectionally:
-         *     - **State standard → CCSS**: Pass in a state standard to get matching Common Core State Standards
-         *     - **CCSS → State standards**: Pass in a CCSS standard to get matching state standards across jurisdictions
-         *
-         *     Each crosswalk includes similarity metrics based on measurable overlap of Learning Components to help understand the strength and nature of the alignment.
-         *
-         *     Crosswalks provide a scalable way to extend mappings between CCSS and state-specific frameworks without independent matching logic. By leveraging the LC superset, crosswalks show where standards converge in content coverage.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find CCSS standards that align to a state standard for content adaptation
-         *     - Find state standards that align to a CCSS standard across multiple jurisdictions
-         *     - Understand the similarity between standards
-         *     - Map content between Common Core and state frameworks
-         *     - Analyze the degree of overlap between standards
-         *
-         *     **Note:** Crosswalks are currently available only for Mathematics standards in states where LC alignment exists. Crosswalks are evidence-based (require at least one shared LC).
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned.
-         *
-         *     **Related topics:**
-         *     - [Standards crosswalks methodology](/knowledge-graph/entity-and-relationship-reference/standards-crosswalks)
-         */
-        get: operations["listCrosswalkedStandards"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/learning-components/{identifier}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Learning component by ID
-         * @description Fetches a single LearningComponent by its unique identifier.
-         *
-         *     A LearningComponent represents a single, well-defined skill or concept that students are expected to learn. Learning components are granular units of learning that break down broad state standards into teachable and measurable parts at the level of a lesson, activity, or assessment question.
-         *
-         *     Use this endpoint when you need to:
-         *     - Display the full details of a specific learning component
-         *     - Retrieve the skill description and metadata for a known learning component
-         *     - Access attribution information for learning components used in your application
-         *
-         *     Learning components(LCs) are developed through expert-driven processes with input from experienced educators. Currently, LCs are available for mathematics standards across multiple states, with more subjects and states being added over time.
-         *
-         *     **Related topics:**
-         *     - [Understanding Learning Components](/knowledge-graph/entity-and-relationship-reference/learning-components)
-         *     - [LC creation and alignment process](/knowledge-graph/entity-and-relationship-reference/learning-components#creation-of-lcs)
-         *     - [Available LC mappings by state](/knowledge-graph/entity-and-relationship-reference/learning-components#current-lc-mappings)
-         */
-        get: operations["getLearningComponentByIdentifier"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/lessons": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Lessons for a standard
-         * @description Fetches summary information for all lessons that address a specific academic standard.
-         *
-         *     Returns lesson summaries (identifier, name, position) that are aligned to this standard, indicating which lessons in the curriculum help students achieve this learning expectation.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find all lessons that teach a specific standard
-         *     - Build standards-based lesson sequences
-         *     - Track where standards are addressed across the curriculum
-         *     - Generate standards coverage reports
-         */
-        get: operations["getStandardLessons"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/activities": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Activities for a standard
-         * @description Fetches summary information for all activities that address a specific academic standard.
-         *
-         *     Returns activity summaries (identifier, name, position) that are aligned to this standard, indicating which specific instructional tasks help students achieve this learning expectation.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find all activities that teach a specific standard
-         *     - Build standards-based activity sets
-         *     - Track standards coverage at the activity level
-         *     - Generate detailed standards alignment reports
-         */
-        get: operations["getStandardActivities"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/academic-standards/{caseIdentifierUUID}/assessments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Assessments for a standard
-         * @description Fetches summary information for all assessments that evaluate a specific academic standard.
-         *
-         *     Returns assessment summaries (identifier, name) that are aligned to this standard, indicating which assessments measure student achievement of this learning expectation.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find all assessments that evaluate a specific standard
-         *     - Build standards-based assessment systems
-         *     - Track which standards are assessed
-         *     - Generate assessment coverage reports
-         */
-        get: operations["getStandardAssessments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/learning-components": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Learning components by subject
-         * @description Fetches a list of LearningComponents filtered by academic subject.
-         *
-         *     This endpoint retrieves learning components for a specific subject area. Learning components are granular skills that break down broad standards into teachable units. Learning components are available for Mathematics and English Language Arts, with additional subjects being developed.
-         *
-         *     Use this endpoint when you need to:
-         *     - Get all learning components available for a specific subject
-         *     - Browse the complete set of skills/concepts for curriculum planning
-         *     - Retrieve LCs for mapping to your own content or assessments
-         *     - Export learning component data for analysis or integration
-         *
-         *     The endpoint returns paginated results. Use the `limit` and `cursor` parameters to control the number of results returned and navigate through large result sets.
-         *
-         *     **Related topics:**
-         *     - [Understanding Learning Components](/knowledge-graph/entity-and-relationship-reference/learning-components)
-         *     - [Available LC coverage by subject and state](/knowledge-graph/entity-and-relationship-reference/learning-components#current-lc-mappings)
-         */
-        get: operations["listLearningComponents"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/learning-components/search": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search learning components
-         * @description <Warning>This endpoint is for free-text semantic search across learning component descriptions. To retrieve learning components for a specific standard, use [Learning components for a standard](/api-reference/learning-components/learning-components-for-a-standard) instead.</Warning>
-         *
-         *     Searches for LearningComponents using semantic search against learning component descriptions.
-         *
-         *     Results are ranked by relevance to the query text and include a `score` reflecting vector similarity. Use the optional `academicSubject` filter to narrow results to a specific subject area.
-         *
-         *     Use this endpoint when you need to:
-         *     - Find learning components relevant to a specific skill or concept
-         *     - Discover granular instructional targets related to a teaching goal
-         *     - Search for LCs to map to your own content or assessments
-         *
-         *     **Related topics:**
-         *     - [Understanding Learning Components](/knowledge-graph/entity-and-relationship-reference/learning-components)
-         *     - [Available LC coverage by subject and state](/knowledge-graph/entity-and-relationship-reference/learning-components#current-lc-mappings)
-         */
-        get: operations["searchLearningComponents"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /** @description An activity represents a discrete instructional task or exercise within a lesson, designed for students, teachers, or both. */
         Activity: {
-            /** @description The unique identifier of the activity */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the activity */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Activity 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Activity 1") */
             ordinalName?: string;
-            /** @description The position of this activity within its parent lesson */
+            /** @description Position of the resource within its parent */
             position?: number;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the activity is intended */
-            gradeLevel?: string[];
-            /** @description The author of the activity */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the activity */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the activity */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description A curriculum-specific categorization of the resource (e.g., "Warm-up", "Cool-down", "Practice") */
+            /** @description Curriculum-specific categorization of the resource (e.g., "Warm-up", "Cool-down", "Practice") */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this activity */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the activity is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description Approximate or typical time it usually takes to work with or through the activity (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string;
-            /** @description Describes intended grouping structure for student participation (e.g., "individual", "pair", "small_group", "whole_class") */
+            /** @description Grouping structure for student participation (e.g., "individual", "pair", "small_group", "whole_class") */
             studentGroupingType?: string;
             /**
              * Format: date
-             * @description The date on which the activity was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this activity */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
         };
         Course: {
-            /** @description The unique identifier of the course */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the course */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description A detailed description of the course */
+            /** @description Description */
             description?: string;
-            /** @description The identifier for the course used by the course provider (e.g., CS101 or 6.001) */
+            /** @description Unique identifier for the resource used by the course provider (e.g., "CS101" or "6.001") */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
             academicSubject?: components["schemas"]["AcademicSubjectENUM"];
-            /** @description Specifies the educational grades for which the course is intended */
             gradeLevel?: components["schemas"]["GradeLevelENUM"][];
-            /** @description The author of the course */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the course */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the course */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this course */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Approximate or typical time it usually takes to work with or through the course (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string | null;
             /**
              * Format: date
-             * @description The date on which the course was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this course */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
         };
         /**
-         * @description Curriculum identifier
+         * @description Unique identifier for the resource in Knowledge Graph
          * @enum {string}
          */
         CurriculumIdENUM: "im360";
@@ -945,7 +943,7 @@ export interface components {
          */
         AcademicSubjectENUM: "English Language Arts" | "Mathematics" | "Science" | "Social Studies" | "Other";
         /**
-         * @description Educational grade level
+         * @description Educational grade level that the resource is intended for
          * @enum {string}
          */
         GradeLevelENUM: "PK" | "K" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
@@ -955,349 +953,335 @@ export interface components {
          */
         AdoptionStatusENUM: "Draft" | "Proposed" | "Adopted" | "Implemented" | "Retired";
         /**
-         * @description Language code in BCP 47 format
+         * @description Language used in the resource (BCP 47 format)
          * @enum {string}
          */
         LanguageENUM: "en-US" | "es-US";
         /**
-         * @description Normalized classification of a standards framework item
+         * @description Classification label that has been standardized across standards frameworks for cross-state queries and categorization
          * @enum {string}
          */
         NormalizedStatementTypeENUM: "Standard" | "Standard Grouping" | "Other";
         /** @description Cursor-based pagination metadata */
         Pagination: {
-            /** @description Maximum number of results returned per page */
+            /** @description Maximum number of results to return per page */
             limit: number;
-            /** @description Cursor for fetching the next page. Null if no more results available. Pass this value as the 'cursor' parameter in the next request. */
+            /** @description Cursor for fetching the next page of results in your next request (`null` if there are no more results) */
             nextCursor?: string | null;
-            /** @description Indicates whether there are more results available after this page */
+            /** @description Whether there are more results after this page */
             hasMore: boolean;
         };
-        /** @description Generic cursor-based paginated response wrapper */
+        /** @description Cursor-based paginated response */
         PaginatedResponse: {
             /** @description Array of result items */
             data: Record<string, never>[];
             pagination: components["schemas"]["Pagination"];
         };
         ScopeAndSequence: components["schemas"]["ScopeAndSequenceSummary"] | components["schemas"]["ScopeAndSequenceFull"];
-        /** @description Hierarchical structure of a course showing lesson groupings and lessons (summary view with minimal fields) */
+        /** @description Hierarchical structure of a course showing lesson groupings and lessons (`summary` view) */
         ScopeAndSequenceSummary: {
-            /** @description The unique identifier of the course */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             courseId: string;
-            /** @description The name of the course */
+            /** @description Name or title of the resource */
             courseName: string;
             /**
-             * @description The level of detail included in the response (enum property replaced by openapi-typescript)
+             * @description Level of detail included in the response (enum property replaced by openapi-typescript)
              * @enum {string}
              */
             view: "summary";
-            /** @description Top-level lesson groupings (e.g., units, modules, chapters) in the course */
+            /** @description Top-level lesson groupings (e.g., units, modules, chapters) */
             lessonGroupings: components["schemas"]["LessonGroupingNode"][];
         };
-        /** @description Hierarchical structure of a course showing lesson groupings and lessons (full view with all metadata) */
+        /** @description Hierarchical structure of a course showing lesson groupings and lessons (`full` view) */
         ScopeAndSequenceFull: {
-            /** @description The unique identifier of the course */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             courseId: string;
-            /** @description The name of the course */
+            /** @description Name or title of the resource */
             courseName: string;
             /**
-             * @description The level of detail included in the response (enum property replaced by openapi-typescript)
+             * @description Level of detail included in the response (enum property replaced by openapi-typescript)
              * @enum {string}
              */
             view: "full";
-            /** @description Top-level lesson groupings (e.g., units, modules, chapters) in the course */
+            /** @description Top-level lesson groupings (e.g., units, modules, chapters) */
             lessonGroupings: components["schemas"]["LessonGroupingNodeFull"][];
         };
-        /** @description A lesson grouping node in the course hierarchy for summary view (minimal fields) */
+        /** @description Lesson grouping node in the course hierarchy for summary view (minimal fields) */
         LessonGroupingNode: {
-            /** @description The unique identifier of the lesson grouping */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson grouping */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Unit 1", "Chapter 2") */
+            /** @description Label with sequence number and descriptive text (e.g., "Unit 1", "Chapter 2") */
             ordinalName?: string;
-            /** @description The type of grouping (e.g., "unit", "section", "module", "chapter") */
+            /** @description Type of grouping (e.g., "unit", "section", "module", "chapter") */
             groupName: string;
-            /** @description The nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
+            /** @description Nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
             groupLevel: number;
-            /** @description The position of this grouping within its parent */
+            /** @description Position of the resource within its parent */
             position: number;
             /** @description Nested lesson groupings within this grouping */
             children?: components["schemas"]["LessonGroupingNode"][];
             /** @description Lessons within this grouping */
             lessons?: components["schemas"]["LessonNode"][];
         };
-        /** @description A lesson grouping node in the course hierarchy for full view (all metadata fields) */
+        /** @description Lesson grouping node in the course hierarchy for full view (all metadata fields) */
         LessonGroupingNodeFull: {
-            /** @description The unique identifier of the lesson grouping */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson grouping */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Unit 1", "Chapter 2") */
+            /** @description Label with sequence number and descriptive text (e.g., "Unit 1", "Chapter 2") */
             ordinalName?: string;
-            /** @description The type of grouping (e.g., "unit", "section", "module", "chapter") */
+            /** @description Type of grouping (e.g., "unit", "section", "module", "chapter") */
             groupName: string;
-            /** @description The nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
+            /** @description Nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
             groupLevel: number;
-            /** @description The position of this grouping within its parent */
+            /** @description Position of the resource within its parent */
             position: number;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the grouping is intended */
-            gradeLevel?: string[];
-            /** @description The author of the lesson grouping */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author?: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider?: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the grouping */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the lesson grouping */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license?: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this lesson grouping */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the lesson grouping is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
-            /** @description Approximate or typical time it usually takes to work with or through the lesson grouping (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string;
             /**
              * Format: date
-             * @description The date on which the lesson grouping was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this lesson grouping */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
             /** @description Nested lesson groupings within this grouping */
             children?: components["schemas"]["LessonGroupingNodeFull"][];
             /** @description Lessons within this grouping */
             lessons?: components["schemas"]["LessonNodeFull"][];
         };
-        /** @description A lesson node in the course hierarchy for summary view (minimal fields) */
+        /** @description Lesson node in the course hierarchy for summary view (minimal fields) */
         LessonNode: {
-            /** @description The unique identifier of the lesson */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Lesson 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Lesson 1") */
             ordinalName?: string;
-            /** @description The position of this lesson within its parent grouping */
+            /** @description Position of the resource within its parent */
             position: number;
         };
-        /** @description A lesson node in the course hierarchy for full view (all metadata fields) */
+        /** @description Lesson node in the course hierarchy for full view (all metadata fields) */
         LessonNodeFull: {
-            /** @description The unique identifier of the lesson */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Lesson 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Lesson 1") */
             ordinalName?: string;
-            /** @description The position of this lesson within its parent grouping */
+            /** @description Position within the resource's parent grouping */
             position: number;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the lesson is intended */
-            gradeLevel?: string[];
-            /** @description The author of the lesson */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author?: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider?: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the lesson */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the lesson */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license?: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this lesson */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the lesson is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
-            /** @description Approximate or typical time it usually takes to work with or through the content (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string;
             /**
              * Format: date
-             * @description The date on which the lesson was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this lesson */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
         };
-        /** @description A lesson grouping organizes a set of related lessons within a curriculum. The naming and organizational level may vary across curricula (e.g., unit, module, chapter, section, theme). */
+        /** @description Set of related lessons within a curriculum; naming and organizational level may vary across curricula (e.g., unit, module, chapter, section, theme) */
         LessonGrouping: {
-            /** @description The unique identifier of the lesson grouping */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson grouping */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Unit 1", "Chapter 2") */
+            /** @description Label with sequence number and descriptive text (e.g., "Unit 1", "Chapter 2") */
             ordinalName?: string;
-            /** @description The type of grouping (e.g., "unit", "section", "module", "chapter") */
+            /** @description Type of grouping (e.g., "unit", "section", "module", "chapter") */
             groupName: string;
-            /** @description The nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
+            /** @description Nesting level of this grouping (0 = top level, 1 = nested once, etc.) */
             groupLevel: number;
-            /** @description The position of this grouping within its parent */
+            /** @description Position of the resource within its parent */
             position?: number;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the grouping is intended */
-            gradeLevel?: string[];
-            /** @description The author of the lesson grouping */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the grouping */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the lesson grouping */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this lesson grouping */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the lesson grouping is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
-            /** @description Approximate or typical time it usually takes to work with or through the lesson grouping (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string | null;
             /**
              * Format: date
-             * @description The date on which the lesson grouping was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this lesson grouping */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
-            /** @description The lessons contained in this lesson grouping */
+            /** @description Lessons contained in this resource */
             lessons?: components["schemas"]["Lesson"][];
         };
-        /** @description A lesson represents a focused instructional session within a larger curriculum structure, such as a lesson grouping or course, designed to achieve specific learning objectives. */
+        /** @description Focused instructional session within a curriculum structure (e.g., lesson grouping or course) designed to achieve specific learning objectives */
         Lesson: {
-            /** @description The unique identifier of the lesson */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Lesson 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Lesson 1") */
             ordinalName?: string;
-            /** @description The position of this lesson within its parent grouping */
+            /** @description Position of the resource within its parent */
             position?: number;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the lesson is intended */
-            gradeLevel?: string[];
-            /** @description The author of the lesson */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the lesson */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the lesson */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this lesson */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the lesson is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
-            /** @description Approximate or typical time it usually takes to work with or through the content (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string;
             /**
              * Format: date
-             * @description The date on which the lesson was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this lesson */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
         };
-        /**
-         * @description Represents an individual statement or structural element within a standards framework.
-         *
-         *     StandardsFrameworkItems are the building blocks of academic standards documents. They can be:
-         *     - **Learning expectations**: Normative statements that define what students should know or be able to do (e.g., standards, competencies, performance indicators)
-         *     - **Organizational elements**: Structural groupings that organize learning expectations into coherent units (e.g., domains, strands, clusters, conceptual categories)
-         *
-         *     Each item preserves the original statement text and metadata from state frameworks while including normalized properties that enable cross-framework queries and comparisons. Items maintain full traceability to their source in the CASE Network through CASE identifiers.
-         */
+        /** @description Individual element within a standards framework (e.g., standards, organizational groupings) */
         StandardsFrameworkItem: {
-            /** @description The unique identifier for this item in the Knowledge Graph system. This is a system-generated UUID that remains stable across data updates and can be used to reference this item in queries and relationships. */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
             /**
              * Format: uri
-             * @description A URI referencing the equivalent item in the CASE Network published by 1EdTech. This identifier can be used to trace the corresponding standard in the CASE dataset.
+             * @description URI referencing the CASE Network equivalent
              */
             caseIdentifierURI?: string;
             /**
              * Format: uuid
-             * @description A UUID referencing the equivalent item in the CASE Network published by 1EdTech. Use this identifier to trace the standard back to its authoritative source, establish equivalence with other systems using CASE data, or cross-reference with official state documentation that includes CASE identifiers.
+             * @description CASE Network UUID for the resource
              */
             caseIdentifierUUID: string;
-            /** @description A short, human-readable code that uniquely identifies this standard within its standards framework context. Typically alphanumeric (e.g., "3.NF.A.1", "A.1B", "MP1") and reflects the standards framework's internal coding scheme. This is the code educators use to reference standards in curriculum materials, lesson plans, and assessment systems. May be null for organizational groupings that don't have assigned codes. */
+            /** @description Code that identifies a standard within its standards framework (e.g., "3.NF.A.1", "A.1B", "MP1"); `null` for organizational groupings without assigned codes */
             statementCode?: string | null;
-            /** @description The full text of the standard or organizational element, describing what students should know or be able to do */
+            /** @description Full text of the standard describing what students should know or be able to do */
             description?: string | null;
-            /** @description The original classification label used by the source standards framework to categorize this item (e.g., "Domain", "Cluster", "Strand", "Benchmark", "Practice Standard"). Unlike normalizedStatementType which standardizes across standards frameworks, this field preserves the exact terminology used in the state's official standards document, which can be helpful for maintaining consistency with state-specific materials and educator expectations. */
+            /** @description Original classification label that preserves the terminology in the state's official standards document (e.g., "Domain", "Cluster", "Strand", "Benchmark", "Practice Standard") */
             statementType?: string | null;
-            /** @description A normalized classification that describes the broad functional role of this item, standardized across all standards frameworks regardless of how individual states label their standards. This enables cross-state queries like "find all actual standards" vs "find all organizational groupings". Use this field when you need consistent categorization across multiple jurisdictions. */
             normalizedStatementType?: components["schemas"]["NormalizedStatementTypeENUM"];
-            /** @description The state, territory, country, or governing education agency responsible for publishing and adopting this standard. For U.S. state standards, this is the state name (e.g., "Iowa", "California"). This field is essential for filtering standards by location and understanding which standards apply to specific student populations or geographic regions. */
             jurisdiction?: components["schemas"]["JurisdictionENUM"];
-            /** @description The academic subject area for this standard */
             academicSubject?: components["schemas"]["AcademicSubjectENUM"];
-            /** @description The educational grade level(s) for which this standard is intended. Values are strings to accommodate grade bands and special designations (e.g., "K", "PK", "9-12"). A standard may specify multiple individual grades or grade ranges. Use this field to filter standards appropriate for specific student grade levels. */
             gradeLevel?: components["schemas"]["GradeLevelENUM"][] | null;
-            /** @description The language of the content, in BCP 47 format */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: components["schemas"]["LanguageENUM"];
             /**
              * Format: date
-             * @description The date on which this element was most recently modified in the source system (CASE Network). Use this field to track when standards were last updated and identify the most current version of standards data.
+             * @description Date last modified
              */
             dateModified?: string | null;
-            /** @description Optional field containing additional context, commentary, clarifications, or usage guidance about this standard. May include information about prerequisite knowledge, connections to other standards, or implementation notes from the source framework. */
+            /** @description (Optional) Additional context, commentary, clarifications, or usage guidance */
             notes?: string | null;
-            /** @description The author or creator of this content, typically the organization that published the standards framework */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this standard, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
+            /** @description Whether this item has 1+ direct child standards */
+            hasChildren: boolean;
         };
-        /** @description A StandardsFrameworkItemSummary enriched with a relevance score from the search. */
+        /** @description StandardsFrameworkItemSummary enriched with a relevance score from the search. */
         AcademicStandardSearchResult: components["schemas"]["StandardsFrameworkItemSummary"] & {
             /**
              * Format: float
-             * @description Relevance score between 0 and 1. Higher values indicate stronger alignment with the search criteria. For semantic search, this reflects vector similarity. For exact code match, the score is always 1.0.
+             * @description Relevance score between 0 and 1 (reflects vector similarity for semantic search; 1.0 for exact code match)
              */
             score: number;
         };
@@ -1307,180 +1291,176 @@ export interface components {
          *     StandardsFramework serves as the root entity that organizes and contextualizes all standards within a given standards framework. Each standards framework represents a complete standards document with its own jurisdiction, subject area, and adoption status.
          */
         StandardsFramework: {
-            /** @description The unique identifier for this standards framework in the Knowledge Graph system. This is a system-generated identifier that remains stable across data updates. */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
             /**
              * Format: uri
-             * @description A URI referencing the equivalent standards framework in the CASE Network published by 1EdTech. This identifier can be used to trace the corresponding standards framework in the CASE dataset.
+             * @description URI referencing the CASE Network equivalent
              */
             caseIdentifierURI?: string;
             /**
              * Format: uuid
-             * @description A UUID referencing the equivalent standards framework in the CASE Network published by 1EdTech. Use this identifier to query standards within this standards framework.
+             * @description CASE Network UUID for the resource
              */
             caseIdentifierUUID: string;
-            /** @description The name or title of the standards framework (e.g., "Louisiana Student Standards for English Language Arts", "Iowa Core Mathematics Standards") */
+            /** @description Name or title of the resource */
             name?: string | null;
-            /** @description A description of the standards framework providing additional context or information about the standards document */
+            /** @description Description with additional context */
             description?: string | null;
-            /** @description The state, territory, country, or governing education agency responsible for publishing and adopting this standards framework */
             jurisdiction?: components["schemas"]["JurisdictionENUM"];
-            /** @description The academic subject area covered by this standards framework */
+            /** @description Academic subject area */
             academicSubject?: components["schemas"]["AcademicSubjectENUM"];
-            /** @description The language of the standards framework content, in BCP 47 format */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: components["schemas"]["LanguageENUM"];
-            /** @description The adoption status of the standards framework within the jurisdiction. Indicates whether the standards framework has been formally adopted, is in development, or has been deprecated. */
             adoptionStatus?: components["schemas"]["AdoptionStatusENUM"];
             /**
              * Format: date
-             * @description The date on which this standards framework was most recently modified. Use this field to track when standards frameworks were last updated.
+             * @description Date last modified
              */
             dateModified?: string | null;
-            /** @description Optional field containing additional context, commentary, clarifications, or usage guidance about this standards framework */
+            /** @description (Optional) Additional context, commentary, clarifications, or usage guidance */
             notes?: string | null;
-            /** @description The author or creator of this standards framework, typically the organization that published the standards document */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this standards framework, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
         };
         /**
-         * @description A lightweight representation of a StandardsFrameworkItem containing only essential identifying information.
+         * @description Lightweight representation of a StandardsFrameworkItem containing only essential identifying information.
          *
-         *     This summary format is used in relationship endpoints (learning progressions, related standards) to keep responses fast and enable efficient graph traversal. To retrieve full details for a standard, use the GET /standards/{caseIdentifierUUID} endpoint.
+         *     Used in relationship endpoints (learning progressions, related standards) to keep responses fast and enable efficient graph traversal. To retrieve full details for a standard, use the GET /standards/{caseIdentifierUUID} endpoint.
          */
         StandardsFrameworkItemSummary: {
             /**
              * Format: uuid
-             * @description A UUID referencing the item in the CASE Network published by 1EdTech. Use this identifier to retrieve the full standard details via GET /standards/{caseIdentifierUUID}.
+             * @description CASE Network UUID for the resource
              */
             caseIdentifierUUID: string;
-            /** @description A short, human-readable code that uniquely identifies this standard within its framework context (e.g., "3.NF.A.1", "5.NF.A.1"). May be null for organizational groupings. */
+            /** @description Code that identifies a standard within its standards framework (e.g., "3.NF.A.1", "A.1B", "MP1"); `null` for organizational groupings without assigned codes */
             statementCode?: string | null;
-            /** @description The full text of the standard describing what students should know or be able to do */
+            /** @description Full text of the standard describing what students should know or be able to do */
             description?: string | null;
-            /** @description The state, territory, or jurisdiction responsible for this standard (e.g., "Iowa", "California", "Multi-State") */
             jurisdiction?: components["schemas"]["JurisdictionENUM"];
-            /** @description The author or creator of this content, typically the organization that published the standards framework */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this standard, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
         };
         /** @description A StandardsFrameworkItemSummary augmented with the educational alignment type from the source resource (lesson, activity, or assessment) to this standard. */
         StandardsFrameworkItemAlignmentSummary: components["schemas"]["StandardsFrameworkItemSummary"] & {
-            /** @description Educational alignment types describing how the source resource (lesson, activity, or assessment) relates to this standard. Common values: `addressing` (directly teaches the standard), `building_toward` (scaffolds toward it), `building_on` (builds on prior learning of it), `practicing` (provides practice on it). A single source-standard pair may carry multiple alignment types, in which case all are returned. */
+            /** @description Description of how the resource relates to its standard (e.g., `addressing`, `building_toward`, `building_on`, `practicing`) */
             curriculumAlignmentType?: string[];
         };
         /** @description A lightweight representation of an Activity containing only essential identifying information for alignment endpoints. */
         ActivitySummary: {
-            /** @description The unique identifier of the activity */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the activity */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Activity 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Activity 1") */
             ordinalName?: string;
-            /** @description The author of the activity */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description A license document that applies to this content */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description Attribution statement required for license compliance */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
-            /** @description Educational alignment types describing how this activity relates to the standard it was queried under. Common values: `addressing` (directly teaches the standard), `building_toward` (scaffolds toward it), `building_on` (builds on prior learning of it), `practicing` (provides practice on it). A single activity-standard pair may carry multiple alignment types, in which case all are returned. */
+            /** @description Description of how the resource relates to its standard (e.g., `addressing`, `building_toward`, `building_on`, `practicing`) */
             curriculumAlignmentType?: string[];
         };
         /** @description An assessment evaluates a student's understanding or mastery of knowledge, skills, or competencies through structured tasks or questions. */
         Assessment: {
-            /** @description The unique identifier of the assessment */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the assessment */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description The academic subject */
+            /** @description Academic subject */
             academicSubject?: string;
-            /** @description Specifies the educational grades for which the assessment is intended */
-            gradeLevel?: string[];
-            /** @description The author of the assessment */
+            gradeLevel?: components["schemas"]["GradeLevelENUM"][];
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or service operator */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description The language of the content */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: string;
-            /** @description The educational use of the assessment */
+            /** @description Educational use of the resource */
             educationalUse?: string;
-            /** @description Specifies the intended audience for the assessment */
+            /** @description Intended audience of the resource */
             audience?: string[];
-            /** @description A license document that applies to this content, typically indicated by URL */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description A curriculum-specific categorization of the resource */
+            /** @description Curriculum-specific categorization of the resource */
             curriculumLabel?: string;
-            /** @description LMS loading guidance for this assessment */
+            /** @description LMS loading guidance for the resource */
             lmsLoadingGuidance?: string;
-            /** @description Whether the assessment is optional to complete */
+            /** @description Whether the resource is optional to complete */
             isOptional?: boolean;
-            /** @description The identifier for the course used by the course provider */
+            /** @description Unique identifier for the resource used by the course provider */
             courseCode?: string;
-            /** @description The identifier assigned to this resource by its publisher */
+            /** @description Unique identifier for the resource used by the publisher */
             publisherIdentifier?: string | null;
             /** @description Describes intended grouping structure for student participation (e.g., "individual", "pair", "small_group") */
             studentGroupingType?: string;
-            /** @description Approximate or typical time it usually takes to work with or through the assessment (ISO 8601 duration format) */
+            /** @description Approximate amount of time required to work through the resource (ISO 8601 duration format) */
             timeRequired?: string | null;
             /**
              * Format: date
-             * @description The date on which the assessment was created
+             * @description Date created
              */
             dateCreated?: string;
-            /** @description A human-readable attribution statement for this assessment */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement?: string;
         };
         /** @description A lightweight representation of an Assessment containing only essential identifying information for alignment endpoints. */
         AssessmentSummary: {
-            /** @description The unique identifier of the assessment */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the assessment */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description The author of the assessment */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description A license document that applies to this content */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description Attribution statement required for license compliance */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
-            /** @description Educational alignment types describing how this assessment relates to the standard it was queried under. Common values: `addressing` (directly teaches the standard), `building_toward` (scaffolds toward it), `building_on` (builds on prior learning of it), `practicing` (provides practice on it). A single assessment-standard pair may carry multiple alignment types, in which case all are returned. */
+            /** @description Description of how the resource relates to its standard (e.g., `addressing`, `building_toward`, `building_on`, `practicing`) */
             curriculumAlignmentType?: string[];
         };
         /** @description A lightweight representation of a Lesson containing only essential identifying information for alignment endpoints. */
         LessonSummary: {
-            /** @description The unique identifier of the lesson */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the lesson */
+            /** @description Name or title of the resource */
             name: string;
-            /** @description A label combining sequence number with descriptive text (e.g., "Lesson 1") */
+            /** @description Label with sequence number and descriptive text (e.g., "Lesson 1") */
             ordinalName?: string;
-            /** @description The author of the lesson */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider */
+            /** @description Source data provider for the resource */
             provider: string;
-            /** @description A license document that applies to this content */
+            /** @description URL to the resource's license document */
             license: string;
-            /** @description Attribution statement required for license compliance */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
-            /** @description Educational alignment types describing how this lesson relates to the standard it was queried under. Common values: `addressing` (directly teaches the standard), `building_toward` (scaffolds toward it), `building_on` (builds on prior learning of it), `practicing` (provides practice on it). A single lesson-standard pair may carry multiple alignment types, in which case all are returned. */
+            /** @description Description of how the resource relates to its standard (e.g., `addressing`, `building_toward`, `building_on`, `practicing`) */
             curriculumAlignmentType?: string[];
         };
         /**
@@ -1497,36 +1477,35 @@ export interface components {
         StandardCrosswalk: {
             /**
              * Format: uuid
-             * @description The CASE UUID of the aligned standard. Use this identifier to retrieve the full standard details via GET /academic-standards/{caseIdentifierUUID}.
+             * @description CASE Network UUID for the resource
              */
             caseIdentifierUUID: string;
-            /** @description The statement code of the aligned standard (e.g., "3.NF.A.1" for CCSS, "MA.3.NF.1" for Massachusetts). May be null for organizational groupings. */
+            /** @description Code that identifies a standard within its standards framework (e.g., "3.NF.A.1", "A.1B", "MP1"); `null` for organizational groupings without assigned codes */
             statementCode?: string | null;
-            /** @description The full text of the aligned standard describing what students should know or be able to do */
+            /** @description Full text of the standard describing what students should know or be able to do */
             description?: string | null;
-            /** @description The jurisdiction of the aligned standard. For CCSS standards, this is "Multi-State". For state standards, this is the state name (e.g., "Iowa", "Massachusetts"). */
-            jurisdiction?: string | null;
+            jurisdiction?: components["schemas"]["JurisdictionENUM"];
             /**
              * Format: float
-             * @description The Jaccard similarity score representing the proportion of shared Learning Components between the state standard and CCSS standard. Values range from greater than 0 to 1, where 1 indicates complete overlap and values closer to 0 indicate minimal overlap. Calculated as sharedLCCount / (stateLCCount + ccssLCCount - sharedLCCount).
+             * @description Jaccard score representing the proportion of shared components between a state and Common Core State Standards (CCSS) standard; calculated as `sharedLCCount / (stateLCCount + ccssLCCount - sharedLCCount)`
              */
             jaccard?: number;
-            /** @description The number of Learning Components that support the state standard */
+            /** @description Number of components supporting the state standard */
             stateLCCount?: number;
-            /** @description The number of Learning Components that support the CCSS standard */
+            /** @description Number of components supporting the Common Core State Standards (CCSS) standard */
             ccssLCCount?: number;
-            /** @description The number of Learning Components shared by both the state standard and the CCSS standard. This is the evidence basis for the crosswalk relationship. */
+            /** @description Number of components supporting both the state and Common Core State Standards (CCSS) standards */
             sharedLCCount?: number;
-            /** @description The author or creator of this content, typically the organization that published the standards framework */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this standard, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
         };
         /**
@@ -1535,109 +1514,95 @@ export interface components {
          *     This summary format is used in relationship endpoints (standards to learning components) to keep responses fast and enable efficient traversal. To retrieve full details for a learning component, use the GET /learning-components/{identifier} endpoint.
          */
         LearningComponentSummary: {
-            /** @description The unique identifier for this learning component in the Knowledge Graph system. Use this identifier to retrieve the full learning component details via GET /learning-components/{identifier}. */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description A clear, concise statement describing the specific skill or concept this learning component represents. */
+            /** @description Description of the specific skill or concept represented */
             description?: string | null;
-            /** @description The author or creator of this learning component, typically the organization that developed the LC framework */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this learning component, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
         };
         /** @description A LearningComponentSummary enriched with a relevance score from the search. */
         LearningComponentSearchResult: components["schemas"]["LearningComponentSummary"] & {
             /**
              * Format: float
-             * @description Relevance score between 0 and 1 reflecting semantic similarity to the search query. Higher values indicate stronger alignment with the query text.
+             * @description Relevance score between 0 and 1 (reflects vector similarity for semantic search)
              */
             score: number;
         };
-        /**
-         * @description Represents a single, well-defined skill or concept that students are expected to learn.
-         *
-         *     Learning Components are granular, precise representations of individual skills or concepts that break down broad educational standards into teachable and measurable parts. While state standards often define learning goals at a high level (sometimes encompassing multiple ideas across weeks of instruction), LCs operate at the level where instruction happens: during a lesson, an activity, or a single question.
-         *
-         *     Each LC is:
-         *     - **Instructionally actionable**: Designed to guide daily teaching decisions and interventions
-         *     - **Aligned to academic standards**: Connected to CASE-aligned standards through semantic relationships
-         *     - **Interoperable**: Usable across diverse curricula, assessments, and platforms
-         *     - **Machine-readable and human-interpretable**: Tagged with unique identifiers to support AI-driven content recommendations with transparent intent
-         *
-         *     LCs are developed through collaborative, expert-driven processes with input from experienced educators.
-         */
+        /** @description A single, well-defined skill or concept that students are expected to learn */
         LearningComponent: {
-            /** @description The unique identifier for this learning component in the Knowledge Graph system. This is a system-generated identifier that remains stable across data updates and can be used to reference this LC in queries and relationships. */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description A clear, concise statement describing the specific skill or concept this learning component represents. This is the instructional target that can be taught in a lesson or assessed in a question. */
+            /** @description Description of the specific skill or concept represented */
             description?: string;
-            /** @description The academic subject area for this learning component. Learning components are available for Mathematics and English Language Arts, with additional subjects being developed. */
             academicSubject?: components["schemas"]["AcademicSubjectENUM"];
-            /** @description The language of the content, in BCP 47 format */
+            /** @description Language used in the resource (BCP 47 format) */
             inLanguage?: components["schemas"]["LanguageENUM"];
             /**
              * Format: date
-             * @description The date on which this learning component was created
+             * @description Date created
              */
             dateCreated?: string | null;
             /**
              * Format: date
-             * @description The date on which this learning component was most recently modified. Use this field to track when LCs were last updated.
+             * @description Date last modified
              */
             dateModified?: string | null;
-            /** @description Illustrative examples of the learning component in practice. Each example demonstrates how the skill or concept might appear in an instructional context. */
+            /** @description Examples of how the skill or concept represented might appear in an instructional context */
             examples?: string[] | null;
-            /** @description The author or creator of this learning component, typically the organization that developed the LC framework */
+            /** @description Author or creator of the resource */
             author: string;
-            /** @description The service provider or organization that makes this data available in the knowledge graph */
+            /** @description Source data provider for the resource */
             provider: string;
             /**
              * Format: uri
-             * @description A URL to the license document that applies to this content
+             * @description URL to the resource's license document
              */
             license: string;
-            /** @description A textual credit that acknowledges the source and creator of this work, as required by the CC BY 4.0 license. If you display or redistribute this learning component, you must include this attribution statement to comply with the license terms. */
+            /** @description Statement that acknowledges the resource's author and provider, as required by the CC BY 4.0 license */
             attributionStatement: string;
         };
-        /** @description A lesson grouping that is depended upon (a prerequisite). */
+        /** @description Lesson grouping that is depended upon (a prerequisite). */
         DependencyTarget: {
-            /** @description The unique identifier of the target lesson grouping */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             identifier: string;
-            /** @description The name of the target lesson grouping */
+            /** @description Name or title of the resource */
             name?: string;
-            /** @description The curriculum label of the target lesson grouping (e.g., "Unit", "Section") */
+            /** @description Curriculum label of the target lesson grouping (e.g., "Unit", "Section") */
             curriculumLabel?: string;
         };
-        /** @description A lesson grouping and the other lesson groupings it depends on (prerequisites). */
+        /** @description Lesson grouping and the other lesson groupings it depends on (prerequisites). */
         Dependency: {
-            /** @description The identifier of the source lesson grouping */
+            /** @description Unique identifier for the resource in Knowledge Graph */
             source: string;
-            /** @description The name of the source lesson grouping */
+            /** @description Name or title of the resource */
             sourceName?: string;
-            /** @description The curriculum label of the source lesson grouping (e.g., "Unit", "Section") */
+            /** @description Curriculum label of the source lesson grouping (e.g., "Unit", "Section") */
             sourceCurriculumLabel?: string;
             /** @description Lesson groupings that this source has a dependency on (prerequisites) */
             hasDependency: components["schemas"]["DependencyTarget"][];
         };
-        /** @description Paginated dependency map for a curriculum, listing dependency relationships between lesson groupings grouped by source. */
         DependencyMapResponse: {
-            /** @description List of dependency relationships between lesson groupings, grouped by source */
+            /** @description Dependency relationships between lesson groupings, grouped by source */
             dependencies: components["schemas"]["Dependency"][];
             pagination: components["schemas"]["Pagination"];
         };
         /** @description Standard error response object returned for all error conditions */
         Error: {
-            /** @description A machine-readable error type identifier (e.g., ValidationError, NotFoundError, InternalServerError) */
+            /** @description Machine-readable error type identifier (e.g., `ValidationError`, `NotFoundError`, `InternalServerError`) */
             error: string;
-            /** @description A human-readable error message that explains what went wrong and may include actionable guidance */
+            /** @description Human-readable error message that explains what went wrong and may include actionable guidance */
             message: string;
-            /** @description A unique identifier for this request, useful for debugging and support */
+            /** @description Unique identifier for this request (for debugging and support) */
             requestId: string;
             /** @description Optional additional details about the error, such as validation failures or field-specific issues */
             details?: {
@@ -1647,20 +1612,17 @@ export interface components {
     };
     responses: never;
     parameters: {
-        /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+        /** @description Maximum number of results to return */
         LimitParam: number;
-        /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+        /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
         CursorParam: string;
-        /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
+        /** @description CASE Network UUID for the resource */
         CaseIdentifierUUIDPath: string;
-        /** @description The unique identifier for the learning component in the Knowledge Graph system */
+        /** @description Unique identifier for the resource in Knowledge Graph */
         LearningComponentIdentifierPath: string;
-        /** @description Filter by jurisdiction (state/territory) */
         JurisdictionParam: components["schemas"]["JurisdictionENUM"];
-        /** @description Filter by academic subject area */
         AcademicSubjectParam: components["schemas"]["AcademicSubjectENUM"];
         /**
-         * @description Filter by grade level. Can be specified multiple times to include multiple grades.
          * @example [
          *       "9",
          *       "10"
@@ -1674,14 +1636,1670 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    listFrameworks: {
+        parameters: {
+            query?: {
+                jurisdiction?: components["parameters"]["JurisdictionParam"];
+                academicSubject?: components["parameters"]["AcademicSubjectParam"];
+                adoptionStatus?: components["schemas"]["AdoptionStatusENUM"];
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of standards frameworks */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "00bcc689-c7a6-5ef4-ac09-c868f9e25a06",
+                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFDocuments/822e5a6e-bcb0-45b8-bb82-a2c88d5b4bb7",
+                     *           "caseIdentifierUUID": "822e5a6e-bcb0-45b8-bb82-a2c88d5b4bb7",
+                     *           "name": "K-12 New Hampshire Social Studies Curriculum Framework",
+                     *           "description": null,
+                     *           "jurisdiction": "New Hampshire",
+                     *           "academicSubject": "Social Studies",
+                     *           "inLanguage": "en-US",
+                     *           "adoptionStatus": "Implemented",
+                     *           "dateCreated": null,
+                     *           "dateModified": "2023-11-19",
+                     *           "notes": null,
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         },
+                     *         {
+                     *           "identifier": "02575dee-30d0-50fd-b0e6-182da76f63a5",
+                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFDocuments/50a88167-d6f5-41ea-a6c1-ee1ea83b6820",
+                     *           "caseIdentifierUUID": "50a88167-d6f5-41ea-a6c1-ee1ea83b6820",
+                     *           "name": "North Carolina Standard Course of Study: Social Studies",
+                     *           "description": null,
+                     *           "jurisdiction": "North Carolina",
+                     *           "academicSubject": "Social Studies",
+                     *           "inLanguage": "en-US",
+                     *           "adoptionStatus": "Implemented",
+                     *           "dateCreated": null,
+                     *           "dateModified": "2024-04-08",
+                     *           "notes": null,
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjczYTJhNWY5LWRjOGUtNWE3Yi1iMzc4LTYzZGNmOWViZjFiNSJ9",
+                     *         "hasMore": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFramework"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid query parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid query parameter value provided",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'Draft', 'Proposed', 'Adopted', 'Implemented', or 'Retired'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving standards frameworks",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getAcademicStandardByCaseIdentifierUUID: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved the standard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "identifier": "b15d0fc6-94b7-5bae-9e62-2c30813b4c0f",
+                     *       "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9ee241-d7cc-11e8-824f-0242ac160002",
+                     *       "caseIdentifierUUID": "6b9ee241-d7cc-11e8-824f-0242ac160002",
+                     *       "name": null,
+                     *       "statementCode": "6.NS.B.4",
+                     *       "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12. Use the distributive property to express a sum of two whole numbers 1—100 with a common factor as a multiple of a sum of two whole numbers with no common factor. *For example, express $36 + 8$ as $4(9 + 2)$.*",
+                     *       "statementType": "Standard",
+                     *       "normalizedStatementType": "Standard",
+                     *       "jurisdiction": "Multi-State",
+                     *       "academicSubject": "Mathematics",
+                     *       "gradeLevel": [
+                     *         "6"
+                     *       ],
+                     *       "inLanguage": "en-US",
+                     *       "dateCreated": null,
+                     *       "dateModified": "2025-02-05",
+                     *       "notes": null,
+                     *       "author": "1EdTech",
+                     *       "provider": "Learning Commons",
+                     *       "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *       "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech.",
+                     *       "hasChildren": false
+                     *     }
+                     */
+                    "application/json": components["schemas"]["StandardsFrameworkItem"];
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid CASE Network UUID (valid format looks like \"6bd8552e-6f8f-4538-bf33-d016ac080178\")",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving the academic standard",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listAcademicStandards: {
+        parameters: {
+            query: {
+                /** @description CASE Network UUID for the resource */
+                standardsFrameworkCaseIdentifierUUID: string;
+                /**
+                 * @example [
+                 *       "9",
+                 *       "10"
+                 *     ]
+                 */
+                gradeLevel?: components["parameters"]["GradeLevelParam"];
+                academicSubject?: components["parameters"]["AcademicSubjectParam"];
+                normalizedStatementType?: components["schemas"]["NormalizedStatementTypeENUM"];
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of standards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "8e73cea8-f61d-5ac4-bcef-a84a331618d6",
+                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/65b82d75-d7cc-11e8-824f-0242ac160002",
+                     *           "caseIdentifierUUID": "65b82d75-d7cc-11e8-824f-0242ac160002",
+                     *           "name": null,
+                     *           "statementCode": null,
+                     *           "description": "Standards for Mathematical Practice",
+                     *           "statementType": null,
+                     *           "normalizedStatementType": null,
+                     *           "jurisdiction": "Vermont",
+                     *           "academicSubject": "Mathematics",
+                     *           "gradeLevel": [
+                     *             "K",
+                     *             "1",
+                     *             "2",
+                     *             "3",
+                     *             "4",
+                     *             "5",
+                     *             "6",
+                     *             "7",
+                     *             "8",
+                     *             "9",
+                     *             "10",
+                     *             "11",
+                     *             "12"
+                     *           ],
+                     *           "inLanguage": "en-US",
+                     *           "dateCreated": null,
+                     *           "dateModified": "2023-11-19",
+                     *           "notes": null,
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech.",
+                     *           "hasChildren": true
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 1,
+                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjhlNzNjZWE4LWY2MWQtNWFjNC1iY2VmLWE4NGEzMzE2MThkNiJ9",
+                     *         "hasMore": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFrameworkItem"][];
+                    };
+                };
+            };
+            /** @description Bad request - Missing required parameter or using invalid filter values */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Missing required parameter: standardsFrameworkCaseIdentifierUUID. Example: ?standardsFrameworkCaseIdentifierUUID=c6493f4d-d7cb-11e8-824f-0242ac160002",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'Standard', 'Standard Grouping', or 'Other'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving academic standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    searchAcademicStandards: {
+        parameters: {
+            query?: {
+                /** @description Free-text query for semantic search against academic standard descriptions (cannot be used with `statementCode`) */
+                query?: string;
+                /** @description Statement code used for case-insensitive exact match – e.g., "3.NF.A.1" matches "3.nf.a.1" (cannot be used with `query`) */
+                statementCode?: string;
+                /**
+                 * @example [
+                 *       "9",
+                 *       "10"
+                 *     ]
+                 */
+                gradeLevel?: components["parameters"]["GradeLevelParam"];
+                academicSubject?: components["schemas"]["AcademicSubjectENUM"];
+                normalizedStatementType?: components["schemas"]["NormalizedStatementTypeENUM"];
+                jurisdiction?: components["schemas"]["JurisdictionENUM"];
+                /** @description Maximum number of results to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved search results (ranked by relevance) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example [
+                     *       {
+                     *         "caseIdentifierUUID": "fa29b90a-2795-4bf5-b6bc-3ac4a695e9e2",
+                     *         "statementCode": "6.NS.B.4",
+                     *         "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12.",
+                     *         "jurisdiction": "Washington, D.C.",
+                     *         "author": "1EdTech",
+                     *         "provider": "Learning Commons",
+                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license.",
+                     *         "score": 0.92
+                     *       },
+                     *       {
+                     *         "caseIdentifierUUID": "61b03523-d7cc-11e8-824f-0242ac160002",
+                     *         "statementCode": "6.NS.B.4",
+                     *         "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12.",
+                     *         "jurisdiction": "Maryland",
+                     *         "author": "1EdTech",
+                     *         "provider": "Learning Commons",
+                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license.",
+                     *         "score": 0.87
+                     *       }
+                     *     ]
+                     */
+                    "application/json": components["schemas"]["AcademicStandardSearchResult"][];
+                };
+            };
+            /** @description Bad request - exactly one of query or statementCode must be provided */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Exactly one of query or statementCode must be provided. Example: ?query=greatest+common+factor or ?statementCode=3.NF.A.1",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'Alabama', 'Alaska', ..., or 'Multi-State'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while searching for academic standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listChildAcademicStandards: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of child standards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "3a650f7a-3b10-55d0-9d07-c2bdf8e08175",
+                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9c2b26-d7cc-11e8-824f-0242ac160002",
+                     *           "caseIdentifierUUID": "6b9c2b26-d7cc-11e8-824f-0242ac160002",
+                     *           "name": null,
+                     *           "statementCode": "6.RP.A.1",
+                     *           "description": "Understand the concept of a ratio and use ratio language to describe a ratio relationship between two quantities. *For example, \"The ratio of wings to beaks in the bird house at the zoo was 2:1, because for every 2 wings there was 1 beak.\" \"For every vote candidate A received, candidate C received nearly three votes.\"*",
+                     *           "statementType": "Standard",
+                     *           "normalizedStatementType": "Standard",
+                     *           "jurisdiction": "Multi-State",
+                     *           "academicSubject": "Mathematics",
+                     *           "gradeLevel": [
+                     *             "6"
+                     *           ],
+                     *           "inLanguage": "en-US",
+                     *           "dateCreated": null,
+                     *           "dateModified": "2025-02-05",
+                     *           "notes": null,
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech.",
+                     *           "hasChildren": false
+                     *         },
+                     *         {
+                     *           "identifier": "c3126032-2984-5b67-9ed5-2f2f0821e99f",
+                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9d6aa3-d7cc-11e8-824f-0242ac160002",
+                     *           "caseIdentifierUUID": "6b9d6aa3-d7cc-11e8-824f-0242ac160002",
+                     *           "name": null,
+                     *           "statementCode": "6.RP.A.2",
+                     *           "description": "Understand the concept of a unit rate $\\frac{a}{b}$ associated with a ratio a:b with $b \\neq 0$, and use rate language in the context of a ratio relationship.",
+                     *           "statementType": "Standard",
+                     *           "normalizedStatementType": "Standard",
+                     *           "jurisdiction": "Multi-State",
+                     *           "academicSubject": "Mathematics",
+                     *           "gradeLevel": [
+                     *             "6"
+                     *           ],
+                     *           "inLanguage": "en-US",
+                     *           "dateCreated": null,
+                     *           "dateModified": "2025-02-05",
+                     *           "notes": "Expectations for unit rates in this grade are limited to non-complex fractions.",
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech.",
+                     *           "hasChildren": false
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 2,
+                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogImMzMTI2MDMyLTI5ODQtNWI2Ny05ZWQ1LTJmMmYwODIxZTk5ZiJ9",
+                     *         "hasMore": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or pagination parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid pagination parameter. Limit must be between 1 and 1000 (e.g., limit=100). Cursor must be a valid base64-encoded string from a previous response.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving child standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listPrerequisiteAcademicStandards: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of prerequisite standards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "caseIdentifierUUID": "6b9ee241-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "5.OA.A.2",
+                     *           "description": "Write simple expressions that record calculations with numbers, and interpret numerical expressions without evaluating them. *For example, express the calculation \"add 8 and 7, then multiply by 2\" as $2 \\times (8 + 7)$. Recognize that $3 \\times (18932 + 921)$ is three times as large as 18932 + 921, without having to calculate the indicated sum or product.*",
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         },
+                     *         {
+                     *           "caseIdentifierUUID": "6b9ed00e-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "4.OA.B.4",
+                     *           "description": "Find all factor pairs for a whole number in the range 1—100. Recognize that a whole number is a multiple of each of its factors. Determine whether a given whole number in the range 1—100 is a multiple of a given one-digit number. Determine whether a given whole number in the range 1—100 is prime or composite.",
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or pagination parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid CASE Network UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving prerequisite standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listBuildsTowardsAcademicStandards: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of standards this standard builds towards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "caseIdentifierUUID": "6b9e3b67-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "6.EE.A.3",
+                     *           "description": "Apply the properties of operations to generate equivalent expressions. *For example, apply the distributive property to the expression $3(2 + x)$ to produce the equivalent expression 6 + 3x; apply the distributive property to the expression 24x + 18y to produce the equivalent expression $6(4x + 3y)$; apply properties of operations to y + y + y to produce the equivalent expression 3y.*",
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         },
+                     *         {
+                     *           "caseIdentifierUUID": "6b9edd45-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "6.EE.A.4",
+                     *           "description": "Identify when two expressions are equivalent (i.e., when the two expressions name the same number regardless of which value is substituted into them). *For example, the expressions y + y + y and 3y are equivalent because they name the same number regardless of which number y stands for.*",
+                     *           "author": "1EdTech",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or pagination parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid CASE Network UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving standards this standard builds towards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listRelatedAcademicStandards: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of related standards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "caseIdentifierUUID": "6ba0feac-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "5.NF.B.7",
+                     *           "description": "Apply and extend previous understandings of division to divide unit fractions"
+                     *         },
+                     *         {
+                     *           "caseIdentifierUUID": "6ba0e123-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "5.NF.B.6",
+                     *           "description": "Solve real world problems involving multiplication of fractions"
+                     *         },
+                     *         {
+                     *           "caseIdentifierUUID": "6ba0c456-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "5.NF.B.5",
+                     *           "description": "Interpret multiplication as scaling (resizing)"
+                     *         },
+                     *         {
+                     *           "caseIdentifierUUID": "6ba0a789-d7cc-11e8-824f-0242ac160002",
+                     *           "statementCode": "5.NF.B.4",
+                     *           "description": "Apply and extend previous understandings of multiplication to multiply a fraction by a whole number"
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": "eyJpZGVudGlmaWVyIjoiNWI3ZjE4ZmUtYmQxNC01NDI3LThkMzUtNWQzNGMzYjhmMTBmIn0=",
+                     *         "hasMore": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or pagination parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid CASE Network UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving related standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listLearningComponentsByAcademicStandard: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of learning components supporting this standard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "926bf4b0-e045-536b-ac02-2089d77cbf6c",
+                     *           "description": "Find the least common multiple of two whole numbers less than or equal to 12",
+                     *           "author": "Achievement Network",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *         },
+                     *         {
+                     *           "identifier": "9bf54462-5fd0-59bf-8360-cd503e45b884",
+                     *           "description": "Find the greatest common factor of two whole numbers less than or equal to 100",
+                     *           "author": "Achievement Network",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *         },
+                     *         {
+                     *           "identifier": "c587f727-0135-571c-8c60-7ad46e0a28c5",
+                     *           "description": "Use the distributive property to express a sum of two whole numbers 1-100 with a common factor as a multiple of a sum of two whole numbers with no common factor",
+                     *           "author": "Achievement Network",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["LearningComponentSummary"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or pagination parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid CASE Network UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving learning components",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listCrosswalkedStandards: {
+        parameters: {
+            query?: {
+                jurisdiction?: components["parameters"]["JurisdictionParam"];
+                /** @description Minimum Jaccard score when focusing on stronger alignments */
+                minJaccardScore?: number;
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of Common Core State Standards (CCSS) standards if a state standard was provided, or a list of state standards if a CCSS standard was provided */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["StandardCrosswalk"][];
+                    };
+                };
+            };
+            /** @description Bad request - Invalid CASE Network UUID or filter parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid minJaccardScore. Must be a number between 0.0 and 1.0.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Academic standard with CASE Network UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'Alabama', 'Alaska', ..., or 'Multi-State'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving crosswalked standards",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getLearningComponentByIdentifier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unique identifier for the resource in Knowledge Graph */
+                identifier: components["parameters"]["LearningComponentIdentifierPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved the learning component */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "identifier": "926bf4b0-e045-536b-ac02-2089d77cbf6c",
+                     *       "description": "Find the least common multiple of two whole numbers less than or equal to 12",
+                     *       "academicSubject": "Mathematics",
+                     *       "inLanguage": "en-US",
+                     *       "dateCreated": "2025-04-01",
+                     *       "dateModified": "2025-04-01",
+                     *       "author": "Achievement Network",
+                     *       "provider": "Learning Commons",
+                     *       "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *       "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *     }
+                     */
+                    "application/json": components["schemas"]["LearningComponent"];
+                };
+            };
+            /** @description Bad request - Invalid identifier format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Invalid identifier format. Must be a valid UUID string (e.g., \"0b4a3aca-ad10-5ad3-b890-e30d7042bd5b\").",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Learning component not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "NotFoundError",
+                     *       "message": "Learning component with identifier \"0b4a3aca-ad10-5ad3-b890-e30d7042bd5b\" not found. Verify the identifier or use GET /learning-components to browse available learning components.",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving the learning component",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getStandardLessons: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of lesson summaries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "im:2ebf72dc-53f8-557b-b804-fca624be807a",
+                     *           "name": "Making a Model for Data",
+                     *           "ordinalName": "Lesson 11",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
+                     *         },
+                     *         {
+                     *           "identifier": "im:b29e2804-6f89-5cd2-90e5-aa0b15c01343",
+                     *           "name": "Predicting Populations",
+                     *           "ordinalName": "Lesson 17",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["LessonSummary"][];
+                    };
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getStandardActivities: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of activity summaries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "im:98928b4e-0183-5e0e-955d-230653db7332",
+                     *           "name": "Water in a Tank",
+                     *           "ordinalName": "Activity 1",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
+                     *         },
+                     *         {
+                     *           "identifier": "im:a859c7f9-ba5c-5b2e-82e9-1b948e4ee01c",
+                     *           "name": "Swing Time",
+                     *           "ordinalName": "Activity 2",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "nKnowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics.l"
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["ActivitySummary"][];
+                    };
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getStandardAssessments: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path: {
+                /** @description CASE Network UUID for the resource */
+                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of assessment summaries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "im:5f1b43a3-a087-5f15-8e0e-b5dd3d2d3d23",
+                     *           "name": "End-of-Unit Assessment",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
+                     *         },
+                     *         {
+                     *           "identifier": "im:b98c7782-3cb1-5198-8ebe-aab294d9227b",
+                     *           "name": "End-of-Unit Assessment",
+                     *           "author": "Illustrative Mathematics",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": null,
+                     *         "hasMore": false
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["AssessmentSummary"][];
+                    };
+                };
+            };
+            /** @description Academic standard not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listLearningComponents: {
+        parameters: {
+            query: {
+                academicSubject: components["schemas"]["AcademicSubjectENUM"];
+                /** @description Maximum number of results to return */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
+                cursor?: components["parameters"]["CursorParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved list of learning components */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "identifier": "0013fbee-3e76-500f-9978-42aa1a65f105",
+                     *           "description": "Use conversions to solve multi-step real-world problems",
+                     *           "academicSubject": "Mathematics",
+                     *           "inLanguage": "en-US",
+                     *           "dateCreated": "2025-04-01",
+                     *           "dateModified": "2025-04-01",
+                     *           "author": "Achievement Network",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *         },
+                     *         {
+                     *           "identifier": "457afeb6-6d17-5cff-8679-7b919d744bdd",
+                     *           "description": "Print uppercase \"A\"",
+                     *           "academicSubject": "English Language Arts",
+                     *           "inLanguage": "en-US",
+                     *           "dateCreated": "2025-04-01",
+                     *           "dateModified": "2025-04-01",
+                     *           "author": "Achievement Network",
+                     *           "provider": "Learning Commons",
+                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
+                     *         }
+                     *       ],
+                     *       "pagination": {
+                     *         "limit": 100,
+                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjA5OWNlY2NiLTQ3MzItNTZjMC1iZGIxLTYxZjljNmZjYmQ2NSJ9",
+                     *         "hasMore": true
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["PaginatedResponse"] & {
+                        data?: components["schemas"]["LearningComponent"][];
+                    };
+                };
+            };
+            /** @description Bad request - Missing required parameter or invalid values */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Missing required parameter: academicSubject. Example: ?academicSubject=Mathematics or ?academicSubject=English Language Arts",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'English Language Arts', 'Mathematics', 'Science', 'Social Studies', or 'Other'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while retrieving learning components",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    searchLearningComponents: {
+        parameters: {
+            query: {
+                /** @description Free-text query for semantic search against learning component descriptions */
+                query: string;
+                academicSubject?: components["parameters"]["AcademicSubjectParam"];
+                /** @description Maximum number of results to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved search results (ranked by relevance) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example [
+                     *       {
+                     *         "identifier": "0013fbee-3e76-500f-9978-42aa1a65f105",
+                     *         "description": "Use conversions to solve multi-step real-world problems",
+                     *         "author": "Achievement Network",
+                     *         "provider": "Learning Commons",
+                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network.",
+                     *         "score": 0.94
+                     *       },
+                     *       {
+                     *         "identifier": "0046446a-0a9b-5ace-92a3-23d4bb158c68",
+                     *         "description": "Determine the lateral surface area of three-dimensional cylinders in real-world problems",
+                     *         "author": "Achievement Network",
+                     *         "provider": "Learning Commons",
+                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
+                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network.",
+                     *         "score": 0.81
+                     *       }
+                     *     ]
+                     */
+                    "application/json": components["schemas"]["LearningComponentSearchResult"][];
+                };
+            };
+            /** @description Bad request - Missing required query parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Missing required parameter: query. Example: ?query=solve+multi-step+real-world+problems",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "ValidationError",
+                     *       "message": "Input should be 'English Language Arts', 'Mathematics', 'Science', 'Social Studies', or 'Other'",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": "InternalServerError",
+                     *       "message": "An unexpected error occurred while searching for learning components",
+                     *       "requestId": "req_12345"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     listCourses: {
         parameters: {
             query: {
-                /** @description The identifier for the curriculum to retrieve courses from. */
                 curriculumId: components["schemas"]["CurriculumIdENUM"];
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
@@ -1816,15 +3434,15 @@ export interface operations {
         parameters: {
             query?: {
                 /**
-                 * @description Controls the level of detail in the response.
-                 *     - `summary`: Returns only identifiers, names, and positions (lightweight)
-                 *     - `full`: Returns complete objects with all properties (heavyweight)
+                 * @description Level of detail in the response
+                 *     - `summary` -  Identifiers, names, and positions only
+                 *     - `full` - All properties
                  */
                 view?: "summary" | "full";
             };
             header?: never;
             path: {
-                /** @description The unique identifier of the course */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 courseId: string;
             };
             cookie?: never;
@@ -1999,7 +3617,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The unique identifier of the lesson grouping */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 groupingId: string;
             };
             cookie?: never;
@@ -2103,7 +3721,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description The unique identifier of the lesson */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 lessonId: string;
             };
             cookie?: never;
@@ -2204,14 +3822,14 @@ export interface operations {
     getLessonActivities: {
         parameters: {
             query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
             path: {
-                /** @description The unique identifier of the lesson */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 lessonId: string;
             };
             cookie?: never;
@@ -2324,14 +3942,14 @@ export interface operations {
     getLessonStandards: {
         parameters: {
             query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
             path: {
-                /** @description The unique identifier of the lesson */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 lessonId: string;
             };
             cookie?: never;
@@ -2391,14 +4009,14 @@ export interface operations {
     getActivityStandards: {
         parameters: {
             query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
             path: {
-                /** @description The unique identifier of the activity */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 activityId: string;
             };
             cookie?: never;
@@ -2458,14 +4076,14 @@ export interface operations {
     getAssessmentStandards: {
         parameters: {
             query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
             path: {
-                /** @description The unique identifier of the assessment */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 assessmentId: string;
             };
             cookie?: never;
@@ -2525,15 +4143,15 @@ export interface operations {
     listAssessments: {
         parameters: {
             query: {
-                /** @description The unique identifier of the course */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 courseId: string;
-                /** @description Filter to assessments for a specific lesson (cannot be used with lessonGroupingId) */
+                /** @description Unique identifier for the resource (cannot use with `lessonGroupingId`) */
                 lessonId?: string;
-                /** @description Filter to assessments for a specific lesson grouping (cannot be used with lessonId) */
+                /** @description Unique identifier for the resource (cannot use with `lessonId`) */
                 lessonGroupingId?: string;
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
@@ -2658,21 +4276,21 @@ export interface operations {
     getCurriculumDependencyMap: {
         parameters: {
             query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
+                /** @description Maximum number of results to return */
                 limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
+                /** @description Pagination cursor obtained from the `nextCursor` field in a previous response (not needed for the first page) */
                 cursor?: components["parameters"]["CursorParam"];
             };
             header?: never;
             path: {
-                /** @description The identifier for the curriculum to retrieve dependencies for. */
+                /** @description Unique identifier for the resource in Knowledge Graph */
                 curriculumId: components["schemas"]["CurriculumIdENUM"];
             };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Successfully retrieved dependency map */
+            /** @description Successfully retrieved paginated dependency map */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2763,1672 +4381,6 @@ export interface operations {
                      * @example {
                      *       "error": "InternalServerError",
                      *       "message": "An unexpected error occurred while retrieving the dependency map",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listFrameworks: {
-        parameters: {
-            query?: {
-                /** @description Filter by jurisdiction (state/territory) */
-                jurisdiction?: components["parameters"]["JurisdictionParam"];
-                /** @description Filter by academic subject area */
-                academicSubject?: components["parameters"]["AcademicSubjectParam"];
-                /** @description Filter standards frameworks by their adoption status */
-                adoptionStatus?: components["schemas"]["AdoptionStatusENUM"];
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of standards frameworks */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "00bcc689-c7a6-5ef4-ac09-c868f9e25a06",
-                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFDocuments/822e5a6e-bcb0-45b8-bb82-a2c88d5b4bb7",
-                     *           "caseIdentifierUUID": "822e5a6e-bcb0-45b8-bb82-a2c88d5b4bb7",
-                     *           "name": "K-12 New Hampshire Social Studies Curriculum Framework",
-                     *           "description": null,
-                     *           "jurisdiction": "New Hampshire",
-                     *           "academicSubject": "Social Studies",
-                     *           "inLanguage": "en-US",
-                     *           "adoptionStatus": "Implemented",
-                     *           "dateCreated": null,
-                     *           "dateModified": "2023-11-19",
-                     *           "notes": null,
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         },
-                     *         {
-                     *           "identifier": "02575dee-30d0-50fd-b0e6-182da76f63a5",
-                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFDocuments/50a88167-d6f5-41ea-a6c1-ee1ea83b6820",
-                     *           "caseIdentifierUUID": "50a88167-d6f5-41ea-a6c1-ee1ea83b6820",
-                     *           "name": "North Carolina Standard Course of Study: Social Studies",
-                     *           "description": null,
-                     *           "jurisdiction": "North Carolina",
-                     *           "academicSubject": "Social Studies",
-                     *           "inLanguage": "en-US",
-                     *           "adoptionStatus": "Implemented",
-                     *           "dateCreated": null,
-                     *           "dateModified": "2024-04-08",
-                     *           "notes": null,
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjczYTJhNWY5LWRjOGUtNWE3Yi1iMzc4LTYzZGNmOWViZjFiNSJ9",
-                     *         "hasMore": true
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFramework"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid query parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid query parameter value provided",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'Draft', 'Proposed', 'Adopted', 'Implemented', or 'Retired'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving standards frameworks",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getAcademicStandardByCaseIdentifierUUID: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved the standard */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "identifier": "b15d0fc6-94b7-5bae-9e62-2c30813b4c0f",
-                     *       "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9ee241-d7cc-11e8-824f-0242ac160002",
-                     *       "caseIdentifierUUID": "6b9ee241-d7cc-11e8-824f-0242ac160002",
-                     *       "name": null,
-                     *       "statementCode": "6.NS.B.4",
-                     *       "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12. Use the distributive property to express a sum of two whole numbers 1—100 with a common factor as a multiple of a sum of two whole numbers with no common factor. *For example, express $36 + 8$ as $4(9 + 2)$.*",
-                     *       "statementType": "Standard",
-                     *       "normalizedStatementType": "Standard",
-                     *       "jurisdiction": "Multi-State",
-                     *       "academicSubject": "Mathematics",
-                     *       "gradeLevel": [
-                     *         "6"
-                     *       ],
-                     *       "inLanguage": "en-US",
-                     *       "dateCreated": null,
-                     *       "dateModified": "2025-02-05",
-                     *       "notes": null,
-                     *       "author": "1EdTech",
-                     *       "provider": "Learning Commons",
-                     *       "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *       "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *     }
-                     */
-                    "application/json": components["schemas"]["StandardsFrameworkItem"];
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID format */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid CASE UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving the academic standard",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listAcademicStandards: {
-        parameters: {
-            query: {
-                /** @description The CASE UUID of the standards framework to retrieve academic standards from. This identifies which state or jurisdictional standards framework to query. You must provide this parameter to scope the academic standards query to a specific standards framework. */
-                standardsFrameworkCaseIdentifierUUID: string;
-                /**
-                 * @description Filter by grade level. Can be specified multiple times to include multiple grades.
-                 * @example [
-                 *       "9",
-                 *       "10"
-                 *     ]
-                 */
-                gradeLevel?: components["parameters"]["GradeLevelParam"];
-                /** @description Filter by academic subject area */
-                academicSubject?: components["parameters"]["AcademicSubjectParam"];
-                /** @description Filter standards by their normalized classification. Use this to retrieve only instructional standards (exclude organizational groupings) or to separate different types of framework elements. */
-                normalizedStatementType?: components["schemas"]["NormalizedStatementTypeENUM"];
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of standards */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "8e73cea8-f61d-5ac4-bcef-a84a331618d6",
-                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/65b82d75-d7cc-11e8-824f-0242ac160002",
-                     *           "caseIdentifierUUID": "65b82d75-d7cc-11e8-824f-0242ac160002",
-                     *           "name": null,
-                     *           "statementCode": null,
-                     *           "description": "Standards for Mathematical Practice",
-                     *           "statementType": null,
-                     *           "normalizedStatementType": null,
-                     *           "jurisdiction": "Vermont",
-                     *           "academicSubject": "Mathematics",
-                     *           "gradeLevel": [
-                     *             "K",
-                     *             "1",
-                     *             "2",
-                     *             "3",
-                     *             "4",
-                     *             "5",
-                     *             "6",
-                     *             "7",
-                     *             "8",
-                     *             "9",
-                     *             "10",
-                     *             "11",
-                     *             "12"
-                     *           ],
-                     *           "inLanguage": "en-US",
-                     *           "dateCreated": null,
-                     *           "dateModified": "2023-11-19",
-                     *           "notes": null,
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 1,
-                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjhlNzNjZWE4LWY2MWQtNWFjNC1iY2VmLWE4NGEzMzE2MThkNiJ9",
-                     *         "hasMore": true
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFrameworkItem"][];
-                    };
-                };
-            };
-            /** @description Bad request - Missing required parameter or using invalid filter values */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Missing required parameter: standardsFrameworkCaseIdentifierUUID. Example: ?standardsFrameworkCaseIdentifierUUID=c6493f4d-d7cb-11e8-824f-0242ac160002",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'Standard', 'Standard Grouping', or 'Other'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving academic standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    searchAcademicStandards: {
-        parameters: {
-            query?: {
-                /** @description Free-text query for semantic search against academic standard descriptions. Results are ranked by relevance score. Mutually exclusive with `statementCode`. */
-                query?: string;
-                /** @description The exact statement code to search for. Case-insensitive exact match only (e.g., "3.NF.A.1" matches "3.nf.a.1"). Mutually exclusive with `query`. */
-                statementCode?: string;
-                /**
-                 * @description Filter by grade level. Can be specified multiple times to include multiple grades.
-                 * @example [
-                 *       "9",
-                 *       "10"
-                 *     ]
-                 */
-                gradeLevel?: components["parameters"]["GradeLevelParam"];
-                /** @description Filter results by academic subject area. */
-                academicSubject?: components["schemas"]["AcademicSubjectENUM"];
-                /** @description Filter results by normalized statement type. Use this to retrieve only instructional standards (exclude organizational groupings) or to separate different types of framework elements. */
-                normalizedStatementType?: components["schemas"]["NormalizedStatementTypeENUM"];
-                /** @description Filter by jurisdiction (state/territory). Defaults to Multi-State. */
-                jurisdiction?: components["schemas"]["JurisdictionENUM"];
-                /** @description Maximum number of results to return. Default is 5. Maximum allowed is 50. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved search results */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "caseIdentifierUUID": "fa29b90a-2795-4bf5-b6bc-3ac4a695e9e2",
-                     *         "statementCode": "6.NS.B.4",
-                     *         "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12.",
-                     *         "jurisdiction": "Washington, D.C.",
-                     *         "author": "1EdTech",
-                     *         "provider": "Learning Commons",
-                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license.",
-                     *         "score": 0.92
-                     *       },
-                     *       {
-                     *         "caseIdentifierUUID": "61b03523-d7cc-11e8-824f-0242ac160002",
-                     *         "statementCode": "6.NS.B.4",
-                     *         "description": "Find the greatest common factor of two whole numbers less than or equal to 100 and the least common multiple of two whole numbers less than or equal to 12.",
-                     *         "jurisdiction": "Maryland",
-                     *         "author": "1EdTech",
-                     *         "provider": "Learning Commons",
-                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license.",
-                     *         "score": 0.87
-                     *       }
-                     *     ]
-                     */
-                    "application/json": components["schemas"]["AcademicStandardSearchResult"][];
-                };
-            };
-            /** @description Bad request - exactly one of query or statementCode must be provided */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Exactly one of query or statementCode must be provided. Example: ?query=greatest+common+factor or ?statementCode=3.NF.A.1",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'Alabama', 'Alaska', ..., or 'Multi-State'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while searching for academic standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listChildAcademicStandards: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of child standards */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "3a650f7a-3b10-55d0-9d07-c2bdf8e08175",
-                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9c2b26-d7cc-11e8-824f-0242ac160002",
-                     *           "caseIdentifierUUID": "6b9c2b26-d7cc-11e8-824f-0242ac160002",
-                     *           "name": null,
-                     *           "statementCode": "6.RP.A.1",
-                     *           "description": "Understand the concept of a ratio and use ratio language to describe a ratio relationship between two quantities. *For example, \"The ratio of wings to beaks in the bird house at the zoo was 2:1, because for every 2 wings there was 1 beak.\" \"For every vote candidate A received, candidate C received nearly three votes.\"*",
-                     *           "statementType": "Standard",
-                     *           "normalizedStatementType": "Standard",
-                     *           "jurisdiction": "Multi-State",
-                     *           "academicSubject": "Mathematics",
-                     *           "gradeLevel": [
-                     *             "6"
-                     *           ],
-                     *           "inLanguage": "en-US",
-                     *           "dateCreated": null,
-                     *           "dateModified": "2025-02-05",
-                     *           "notes": null,
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         },
-                     *         {
-                     *           "identifier": "c3126032-2984-5b67-9ed5-2f2f0821e99f",
-                     *           "caseIdentifierURI": "https://satchelcommons.com/ims/case/v1p0/CFItems/6b9d6aa3-d7cc-11e8-824f-0242ac160002",
-                     *           "caseIdentifierUUID": "6b9d6aa3-d7cc-11e8-824f-0242ac160002",
-                     *           "name": null,
-                     *           "statementCode": "6.RP.A.2",
-                     *           "description": "Understand the concept of a unit rate $\\frac{a}{b}$ associated with a ratio a:b with $b \\neq 0$, and use rate language in the context of a ratio relationship.",
-                     *           "statementType": "Standard",
-                     *           "normalizedStatementType": "Standard",
-                     *           "jurisdiction": "Multi-State",
-                     *           "academicSubject": "Mathematics",
-                     *           "gradeLevel": [
-                     *             "6"
-                     *           ],
-                     *           "inLanguage": "en-US",
-                     *           "dateCreated": null,
-                     *           "dateModified": "2025-02-05",
-                     *           "notes": "Expectations for unit rates in this grade are limited to non-complex fractions.",
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 2,
-                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogImMzMTI2MDMyLTI5ODQtNWI2Ny05ZWQ1LTJmMmYwODIxZTk5ZiJ9",
-                     *         "hasMore": true
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or pagination parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid pagination parameter. Limit must be between 1 and 1000 (e.g., limit=100). Cursor must be a valid base64-encoded string from a previous response.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving child standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listPrerequisiteAcademicStandards: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of prerequisite standards */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "caseIdentifierUUID": "6b9ee241-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "5.OA.A.2",
-                     *           "description": "Write simple expressions that record calculations with numbers, and interpret numerical expressions without evaluating them. *For example, express the calculation \"add 8 and 7, then multiply by 2\" as $2 \\times (8 + 7)$. Recognize that $3 \\times (18932 + 921)$ is three times as large as 18932 + 921, without having to calculate the indicated sum or product.*",
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         },
-                     *         {
-                     *           "caseIdentifierUUID": "6b9ed00e-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "4.OA.B.4",
-                     *           "description": "Find all factor pairs for a whole number in the range 1—100. Recognize that a whole number is a multiple of each of its factors. Determine whether a given whole number in the range 1—100 is a multiple of a given one-digit number. Determine whether a given whole number in the range 1—100 is prime or composite.",
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or pagination parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid CASE UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving prerequisite standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listBuildsTowardsAcademicStandards: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of standards this standard builds towards */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "caseIdentifierUUID": "6b9e3b67-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "6.EE.A.3",
-                     *           "description": "Apply the properties of operations to generate equivalent expressions. *For example, apply the distributive property to the expression $3(2 + x)$ to produce the equivalent expression 6 + 3x; apply the distributive property to the expression 24x + 18y to produce the equivalent expression $6(4x + 3y)$; apply properties of operations to y + y + y to produce the equivalent expression 3y.*",
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         },
-                     *         {
-                     *           "caseIdentifierUUID": "6b9edd45-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "6.EE.A.4",
-                     *           "description": "Identify when two expressions are equivalent (i.e., when the two expressions name the same number regardless of which value is substituted into them). *For example, the expressions y + y + y and 3y are equivalent because they name the same number regardless of which number y stands for.*",
-                     *           "author": "1EdTech",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received state standards and written permission under CC BY-4.0 from 1EdTech."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or pagination parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid CASE UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving standards this standard builds towards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listRelatedAcademicStandards: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of related standards */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "caseIdentifierUUID": "6ba0feac-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "5.NF.B.7",
-                     *           "description": "Apply and extend previous understandings of division to divide unit fractions"
-                     *         },
-                     *         {
-                     *           "caseIdentifierUUID": "6ba0e123-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "5.NF.B.6",
-                     *           "description": "Solve real world problems involving multiplication of fractions"
-                     *         },
-                     *         {
-                     *           "caseIdentifierUUID": "6ba0c456-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "5.NF.B.5",
-                     *           "description": "Interpret multiplication as scaling (resizing)"
-                     *         },
-                     *         {
-                     *           "caseIdentifierUUID": "6ba0a789-d7cc-11e8-824f-0242ac160002",
-                     *           "statementCode": "5.NF.B.4",
-                     *           "description": "Apply and extend previous understandings of multiplication to multiply a fraction by a whole number"
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": "eyJpZGVudGlmaWVyIjoiNWI3ZjE4ZmUtYmQxNC01NDI3LThkMzUtNWQzNGMzYjhmMTBmIn0=",
-                     *         "hasMore": true
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardsFrameworkItemSummary"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or pagination parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid CASE UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving related standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listLearningComponentsByAcademicStandard: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of learning components supporting this standard */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "926bf4b0-e045-536b-ac02-2089d77cbf6c",
-                     *           "description": "Find the least common multiple of two whole numbers less than or equal to 12",
-                     *           "author": "Achievement Network",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *         },
-                     *         {
-                     *           "identifier": "9bf54462-5fd0-59bf-8360-cd503e45b884",
-                     *           "description": "Find the greatest common factor of two whole numbers less than or equal to 100",
-                     *           "author": "Achievement Network",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *         },
-                     *         {
-                     *           "identifier": "c587f727-0135-571c-8c60-7ad46e0a28c5",
-                     *           "description": "Use the distributive property to express a sum of two whole numbers 1-100 with a common factor as a multiple of a sum of two whole numbers with no common factor",
-                     *           "author": "Achievement Network",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["LearningComponentSummary"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or pagination parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid CASE UUID format. Must be a valid UUID (e.g., \"6bd8552e-6f8f-4538-bf33-d016ac080178\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving learning components",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listCrosswalkedStandards: {
-        parameters: {
-            query?: {
-                /** @description Filter by jurisdiction (state/territory) */
-                jurisdiction?: components["parameters"]["JurisdictionParam"];
-                /** @description Filter crosswalks by minimum Jaccard similarity score. Only return standards with a Jaccard score greater than or equal to this value. Use this to focus on stronger alignments. */
-                minJaccardScore?: number;
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of crosswalked standards. If a state standard is provided, returns matching CCSS standards. If a CCSS standard is provided, returns matching state standards (optionally filtered by jurisdiction). */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["StandardCrosswalk"][];
-                    };
-                };
-            };
-            /** @description Bad request - Invalid CASE UUID or filter parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid minJaccardScore. Must be a number between 0.0 and 1.0.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Academic standard with CASE UUID \"6bd8552e-6f8f-4538-bf33-d016ac080178\" not found. Verify the UUID is correct.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'Alabama', 'Alaska', ..., or 'Multi-State'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving crosswalked standards",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getLearningComponentByIdentifier: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The unique identifier for the learning component in the Knowledge Graph system */
-                identifier: components["parameters"]["LearningComponentIdentifierPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved the learning component */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "identifier": "926bf4b0-e045-536b-ac02-2089d77cbf6c",
-                     *       "description": "Find the least common multiple of two whole numbers less than or equal to 12",
-                     *       "academicSubject": "Mathematics",
-                     *       "inLanguage": "en-US",
-                     *       "dateCreated": "2025-04-01",
-                     *       "dateModified": "2025-04-01",
-                     *       "author": "Achievement Network",
-                     *       "provider": "Learning Commons",
-                     *       "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *       "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *     }
-                     */
-                    "application/json": components["schemas"]["LearningComponent"];
-                };
-            };
-            /** @description Bad request - Invalid identifier format */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Invalid identifier format. Must be a valid UUID string (e.g., \"0b4a3aca-ad10-5ad3-b890-e30d7042bd5b\").",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Learning component not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "NotFoundError",
-                     *       "message": "Learning component with identifier \"0b4a3aca-ad10-5ad3-b890-e30d7042bd5b\" not found. Verify the identifier or use GET /learning-components to browse available learning components.",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving the learning component",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getStandardLessons: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of lesson summaries */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "im:2ebf72dc-53f8-557b-b804-fca624be807a",
-                     *           "name": "Making a Model for Data",
-                     *           "ordinalName": "Lesson 11",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
-                     *         },
-                     *         {
-                     *           "identifier": "im:b29e2804-6f89-5cd2-90e5-aa0b15c01343",
-                     *           "name": "Predicting Populations",
-                     *           "ordinalName": "Lesson 17",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["LessonSummary"][];
-                    };
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getStandardActivities: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of activity summaries */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "im:98928b4e-0183-5e0e-955d-230653db7332",
-                     *           "name": "Water in a Tank",
-                     *           "ordinalName": "Activity 1",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
-                     *         },
-                     *         {
-                     *           "identifier": "im:a859c7f9-ba5c-5b2e-82e9-1b948e4ee01c",
-                     *           "name": "Swing Time",
-                     *           "ordinalName": "Activity 2",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "nKnowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics.l"
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["ActivitySummary"][];
-                    };
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getStandardAssessments: {
-        parameters: {
-            query?: {
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path: {
-                /** @description The CASE UUID identifier from the CASE Network published by 1EdTech */
-                caseIdentifierUUID: components["parameters"]["CaseIdentifierUUIDPath"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of assessment summaries */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "im:5f1b43a3-a087-5f15-8e0e-b5dd3d2d3d23",
-                     *           "name": "End-of-Unit Assessment",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
-                     *         },
-                     *         {
-                     *           "identifier": "im:b98c7782-3cb1-5198-8ebe-aab294d9227b",
-                     *           "name": "End-of-Unit Assessment",
-                     *           "author": "Illustrative Mathematics",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by-nc/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received the scope and sequence of the Illustrative Mathematics 360 curriculum under CC BY-4.0 from Illustrative Mathematics."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": null,
-                     *         "hasMore": false
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["AssessmentSummary"][];
-                    };
-                };
-            };
-            /** @description Academic standard not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listLearningComponents: {
-        parameters: {
-            query: {
-                /** @description The academic subject area to retrieve learning components for. Mathematics and English Language Arts have the most comprehensive coverage, with additional subjects being developed. */
-                academicSubject: components["schemas"]["AcademicSubjectENUM"];
-                /** @description Maximum number of results to return. Default is 100. Maximum allowed is 1000. */
-                limit?: components["parameters"]["LimitParam"];
-                /** @description Cursor for pagination. Obtain this value from the 'nextCursor' field in the previous response. Omit for the first page. */
-                cursor?: components["parameters"]["CursorParam"];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved list of learning components */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "data": [
-                     *         {
-                     *           "identifier": "0013fbee-3e76-500f-9978-42aa1a65f105",
-                     *           "description": "Use conversions to solve multi-step real-world problems",
-                     *           "academicSubject": "Mathematics",
-                     *           "inLanguage": "en-US",
-                     *           "dateCreated": "2025-04-01",
-                     *           "dateModified": "2025-04-01",
-                     *           "author": "Achievement Network",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *         },
-                     *         {
-                     *           "identifier": "457afeb6-6d17-5cff-8679-7b919d744bdd",
-                     *           "description": "Print uppercase \"A\"",
-                     *           "academicSubject": "English Language Arts",
-                     *           "inLanguage": "en-US",
-                     *           "dateCreated": "2025-04-01",
-                     *           "dateModified": "2025-04-01",
-                     *           "author": "Achievement Network",
-                     *           "provider": "Learning Commons",
-                     *           "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *           "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network."
-                     *         }
-                     *       ],
-                     *       "pagination": {
-                     *         "limit": 100,
-                     *         "nextCursor": "eyJpZGVudGlmaWVyIjogIjA5OWNlY2NiLTQ3MzItNTZjMC1iZGIxLTYxZjljNmZjYmQ2NSJ9",
-                     *         "hasMore": true
-                     *       }
-                     *     }
-                     */
-                    "application/json": components["schemas"]["PaginatedResponse"] & {
-                        data?: components["schemas"]["LearningComponent"][];
-                    };
-                };
-            };
-            /** @description Bad request - Missing required parameter or invalid values */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Missing required parameter: academicSubject. Example: ?academicSubject=Mathematics or ?academicSubject=English Language Arts",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'English Language Arts', 'Mathematics', 'Science', 'Social Studies', or 'Other'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while retrieving learning components",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    searchLearningComponents: {
-        parameters: {
-            query: {
-                /** @description Free-text query for semantic search against learning component descriptions. Results are ranked by relevance score. */
-                query: string;
-                /** @description Filter by academic subject area */
-                academicSubject?: components["parameters"]["AcademicSubjectParam"];
-                /** @description Maximum number of results to return. Default is 5. Maximum allowed is 50. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved search results */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "identifier": "0013fbee-3e76-500f-9978-42aa1a65f105",
-                     *         "description": "Use conversions to solve multi-step real-world problems",
-                     *         "author": "Achievement Network",
-                     *         "provider": "Learning Commons",
-                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network.",
-                     *         "score": 0.94
-                     *       },
-                     *       {
-                     *         "identifier": "0046446a-0a9b-5ace-92a3-23d4bb158c68",
-                     *         "description": "Determine the lateral surface area of three-dimensional cylinders in real-world problems",
-                     *         "author": "Achievement Network",
-                     *         "provider": "Learning Commons",
-                     *         "license": "https://creativecommons.org/licenses/by/4.0/",
-                     *         "attributionStatement": "Knowledge Graph is provided by Learning Commons under the CC BY-4.0 license. Learning Commons received learning components under CC BY-4.0 from Achievement Network.",
-                     *         "score": 0.81
-                     *       }
-                     *     ]
-                     */
-                    "application/json": components["schemas"]["LearningComponentSearchResult"][];
-                };
-            };
-            /** @description Bad request - Missing required query parameter */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Missing required parameter: query. Example: ?query=solve+multi-step+real-world+problems",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Unprocessable Entity - Invalid parameter values (e.g., enum value not in allowed list) */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "ValidationError",
-                     *       "message": "Input should be 'English Language Arts', 'Mathematics', 'Science', 'Social Studies', or 'Other'",
-                     *       "requestId": "req_12345"
-                     *     }
-                     */
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example {
-                     *       "error": "InternalServerError",
-                     *       "message": "An unexpected error occurred while searching for learning components",
                      *       "requestId": "req_12345"
                      *     }
                      */

--- a/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
@@ -120,20 +120,43 @@ describe('Knowledge Graph spec conformance', () => {
     expect(standard.gradeLevel).toEqual([]);
   });
 
-  it('maps every jurisdiction in the enum onto the framework lookup query', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      okResponse({ data: [{ caseIdentifierUUID: 'fw-1' }] }),
+  it('sends every jurisdiction in the enum through to the framework lookup query', async () => {
+    // Multi-State short-circuits to a hardcoded framework UUID and issues no
+    // framework lookup at all, so it is covered separately below.
+    const jurisdictions = Object.values(Jurisdiction).filter(
+      (j) => j !== Jurisdiction.MultiState,
     );
+
+    const sent: (string | null)[] = [];
+    for (const jurisdiction of jurisdictions) {
+      const fetchMock = vi.fn().mockResolvedValue(
+        okResponse({ data: [{ caseIdentifierUUID: 'fw-1' }] }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await new KnowledgeGraphClient('k').getStandardsByGrade('3', { jurisdiction });
+
+      const url = new URL((fetchMock.mock.calls[0][0] as Request).url);
+      expect(url.pathname).toContain('/standards-frameworks');
+      sent.push(url.searchParams.get('jurisdiction'));
+    }
+
+    // Comparing the whole set proves the loop covered every enum member, and
+    // that values carrying spaces and punctuation ("Washington, D.C.",
+    // "New Hampshire") survive query encoding unaltered.
+    expect([...sent].sort()).toEqual([...jurisdictions].sort());
+  });
+
+  it('resolves Multi-State without a framework lookup request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
     vi.stubGlobal('fetch', fetchMock);
 
-    // Multi-State short-circuits to a hardcoded framework UUID, so exercise a
-    // jurisdiction that actually round-trips through /standards-frameworks.
     await new KnowledgeGraphClient('k').getStandardsByGrade('3', {
-      jurisdiction: Jurisdiction.California,
+      jurisdiction: Jurisdiction.MultiState,
     });
 
-    const frameworkRequest = fetchMock.mock.calls[0][0] as Request;
-    expect(frameworkRequest.url).toContain('/standards-frameworks');
-    expect(frameworkRequest.url).toContain('jurisdiction=California');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = new URL((fetchMock.mock.calls[0][0] as Request).url);
+    expect(url.pathname).toContain('/academic-standards');
   });
 });

--- a/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KnowledgeGraphClient } from '../../../src/knowledge-graph/client.js';
+import { Jurisdiction } from '../../../src/knowledge-graph/types.js';
+import type { AcademicStandard } from '../../../src/knowledge-graph/types.js';
+import type { paths, components } from '../../../src/knowledge-graph/kg-api.js';
+
+// These assertions guard the seam between the generated spec types
+// (kg-api.d.ts, regenerated via `npm run generate:kg-types`) and the
+// hand-written types in types.ts. They are enforced by `tsc --noEmit`, so a
+// spec regeneration that drifts from our implementation fails typecheck
+// rather than silently changing runtime behaviour.
+
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+
+type SpecJurisdiction = components['schemas']['JurisdictionENUM'];
+type SpecGradeLevel = components['schemas']['GradeLevelENUM'];
+
+type SpecStandard = components['schemas']['StandardsFrameworkItem'];
+
+// The spec types /academic-standards as PaginatedResponse (whose `data` is an
+// untyped Record<string, never>[]) intersected with a StandardsFrameworkItem[]
+// override. Reading through that intersection is fine, but it cannot be
+// constructed, so fixtures below use the schema directly. This asserts the
+// endpoint really is the schema we pin them to.
+type StandardsListBody =
+  paths['/academic-standards']['get']['responses'][200]['content']['application/json'];
+export const listEndpointReturnsSpecStandard: NonNullable<
+  StandardsListBody['data']
+>[number] extends SpecStandard
+  ? true
+  : never = true;
+
+// types.ts hand-maintains Jurisdiction to give consumers a named enum. If the
+// spec adds or removes a jurisdiction, this stops compiling.
+export const jurisdictionsMatchSpec: Exact<`${Jurisdiction}`, SpecJurisdiction> = true;
+
+// Mirrors the projection in client.ts getStandardsByGrade. Fails to compile if
+// the spec renames, removes, or incompatibly narrows any mapped field.
+export function projectSpecStandard(item: SpecStandard): AcademicStandard {
+  return {
+    caseIdentifierUUID: item.caseIdentifierUUID,
+    statementCode: item.statementCode ?? null,
+    description: item.description ?? null,
+    statementType: item.statementType ?? null,
+    normalizedStatementType: item.normalizedStatementType ?? null,
+    gradeLevel: item.gradeLevel ?? [],
+  };
+}
+
+// types.ts widens the spec's enums to string deliberately, so the API can
+// return values outside the current spec without breaking consumers.
+export const gradeLevelAcceptsSpecValues: Exact<
+  SpecGradeLevel extends AcademicStandard['gradeLevel'][number] ? true : never,
+  true
+> = true;
+
+function okResponse(body: unknown) {
+  const text = JSON.stringify(body);
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(text),
+  };
+}
+
+beforeEach(() => { vi.unstubAllGlobals(); });
+
+// A response item carrying every field the current spec marks required,
+// including ones we do not project. Regenerating the spec with a new required
+// field should not change what getStandardsByGrade returns.
+const fullSpecItem: SpecStandard = {
+  identifier: 'id-1',
+  caseIdentifierUUID: 'uuid-1',
+  statementCode: '3.MD.C.7.d',
+  description: 'Recognize area as additive',
+  statementType: 'Standard',
+  normalizedStatementType: 'Standard',
+  jurisdiction: 'Multi-State',
+  gradeLevel: ['3'],
+  author: 'Learning Commons',
+  provider: 'Learning Commons',
+  license: 'CC BY-4.0',
+  attributionStatement: 'Provided by Learning Commons under CC BY-4.0.',
+  hasChildren: false,
+};
+
+describe('Knowledge Graph spec conformance', () => {
+  it('projects a fully spec-shaped standard to exactly the AcademicStandard fields', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ data: [fullSpecItem] })));
+
+    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGrade('3');
+
+    expect(standard).toEqual({
+      caseIdentifierUUID: 'uuid-1',
+      statementCode: '3.MD.C.7.d',
+      description: 'Recognize area as additive',
+      statementType: 'Standard',
+      normalizedStatementType: 'Standard',
+      gradeLevel: ['3'],
+    });
+    // Unprojected spec fields must not leak into the public shape.
+    expect(Object.keys(standard).sort()).toEqual([
+      'caseIdentifierUUID',
+      'description',
+      'gradeLevel',
+      'normalizedStatementType',
+      'statementCode',
+      'statementType',
+    ]);
+  });
+
+  it('defaults gradeLevel to an empty array when the spec returns null', async () => {
+    const item: SpecStandard = { ...fullSpecItem, gradeLevel: null };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ data: [item] })));
+
+    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGrade('3');
+
+    expect(standard.gradeLevel).toEqual([]);
+  });
+
+  it('maps every jurisdiction in the enum onto the framework lookup query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ data: [{ caseIdentifierUUID: 'fw-1' }] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Multi-State short-circuits to a hardcoded framework UUID, so exercise a
+    // jurisdiction that actually round-trips through /standards-frameworks.
+    await new KnowledgeGraphClient('k').getStandardsByGrade('3', {
+      jurisdiction: Jurisdiction.California,
+    });
+
+    const frameworkRequest = fetchMock.mock.calls[0][0] as Request;
+    expect(frameworkRequest.url).toContain('/standards-frameworks');
+    expect(frameworkRequest.url).toContain('jurisdiction=California');
+  });
+});

--- a/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
@@ -158,5 +158,9 @@ describe('Knowledge Graph spec conformance', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = new URL((fetchMock.mock.calls[0][0] as Request).url);
     expect(url.pathname).toContain('/academic-standards');
+    // Pins the hardcoded CCSS framework UUID the short-circuit substitutes.
+    expect(url.searchParams.get('standardsFrameworkCaseIdentifierUUID')).toBe(
+      'c6496676-d7cb-11e8-824f-0242ac160002',
+    );
   });
 });


### PR DESCRIPTION
Regenerates `sdks/typescript/src/knowledge-graph/kg-api.d.ts` from the live spec at `docs.learningcommons.org`, which had drifted from the checked-in copy. Split out from #157 to keep that security bump scoped.

## What actually changed in the spec

The raw diff is ~1800 lines, but almost all of it is the curriculum path block (`/courses`, `/lessons`, `/assessments`, …) moving from the top of `paths` to the bottom. All 26 endpoints are unchanged. Filtering comments and ignoring order leaves three real changes, all in `StandardsFrameworkItem`:

| Change | Breaking? |
| --- | --- |
| `hasChildren: boolean` added (required) | No — additive on responses; we project a subset |
| `gradeLevel?: string[]` → `GradeLevelENUM[] \| null` (6 sites) | No — `types.ts` widens to `string[]` by design |
| `jurisdiction?: string \| null` → `JurisdictionENUM` | No — we only send it as a query param |

`GradeLevelENUM` and `JurisdictionENUM` member lists are unchanged. The narrowing is absorbed because `types.ts` deliberately declares these as `string`/`string[]` so the API can return values outside the current spec — the comment at the top of that file already states this.

## Verification

`tsc --noEmit`, lint, and build clean; 321 tests pass (318 + 3 new). Also test-merged into the open KG PRs — clean merge and green on both:

- #148 (`sdk-kg-hardening`) — 346 pass
- #149 (`sdk-standards-api`, stacked on #148) — 380 pass

Based on `main` rather than stacked: no open PR touches `kg-api.d.ts` or `eslint.config.js`, so there is nothing to conflict with.

## New test: `tests/unit/knowledge-graph/spec-conformance.test.ts`

Guards the seam between the generated types and the hand-written ones in `types.ts`, so the next regeneration fails loudly instead of silently changing behaviour. Both type-level guards were verified to actually fail:

- `Jurisdiction` enum ↔ spec `JurisdictionENUM` mutual assignability. All 52 values currently match exactly. Confirmed a bogus added member fails `tsc`. **This is the one real gap** — `client.ts` only ever casts jurisdiction, so nothing else would have caught drift in that hand-maintained enum.
- The `getStandardsByGrade` projection mirrored against the spec schema; confirmed a renamed spec field fails `tsc`.
- Runtime: a fixture carrying every currently-required field (including the new `hasChildren`) still projects to exactly the six `AcademicStandard` keys, so future required-field additions can't leak into the public shape.

## Lint config

`no-irregular-whitespace` began erroring on the regenerated file — the upstream spec text contains a U+00A0 in a `statementCode` description. Rather than strip the character (it would return on the next regeneration), the generated file is now excluded from lint. Nothing hand-maintained lives in it, and upstream prose shouldn't be able to break our lint gate.

## Notes for follow-up (not in this PR)

- **No drift detection exists.** Nothing in `scripts/checks/` or CI regenerates and diffs `kg-api.d.ts`, which is why it went stale. A check would need to hit the live spec URL, coupling CI to an external service — worth deciding deliberately rather than bundling here.
- **`PaginatedResponse.data` is typed `Record<string, never>[]`** in the spec, intersected with the concrete `StandardsFrameworkItem[]` override. Reading through the intersection works, but the element type can't be constructed, which is why the fixtures pin to the schema directly. Upstream spec wart worth reporting.
- **`hasChildren` may simplify #148/#149.** They distinguish organizational groupings from leaf standards via `normalizedStatementType` plus learning-component-set comparison; `hasChildren` now exposes this directly. Adjacent, not overlapping — no change made here.
