### PR TITLE
feat(evals): add stable_id/id_history to the evaluator config contract

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -17,7 +17,7 @@
         "id": { "type": "string", "minLength": 1 },
         "stable_id": {
           "type": "string",
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
           "description": "Permanent UUID, assigned once and never changed, even when `id` changes because the evaluator moves between taxonomy groupings. Optional for now while this is backfilled evaluator-by-evaluator; will become required once every evaluator has one."
         },
         "id_history": {

--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -12,8 +12,19 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "name", "description", "supported_grades"],
+      "dependentRequired": { "id_history": ["stable_id"] },
       "properties": {
         "id": { "type": "string", "minLength": 1 },
+        "stable_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "description": "Permanent UUID, assigned once and never changed, even when `id` changes because the evaluator moves between taxonomy groupings. Optional for now while this is backfilled evaluator-by-evaluator; will become required once every evaluator has one."
+        },
+        "id_history": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Every previous value of `id` for this `stable_id`, oldest first. Append the old `id` here whenever `id` changes -- this is what makes the id <-> stable_id mapping bidirectional and lookups possible in either direction."
+        },
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
         "supported_grades": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ fails the PR (it never auto-fixes) — so fixing locally saves a round-trip.
 | Check | What it does |
 |-------|--------------|
 | `strip-notebooks` | Clears outputs, execution counts, and cell metadata from `.ipynb` files |
-| `eval-config` | Validates each evaluator `config.json` against the shared schema (`evals/_schemas/config.schema.json`, referenced by the config's own `$schema`), plus cross-file rules: referenced files exist, prompt `sha256` matches, placeholders ⇄ template `{vars}` are in sync, system prompts carry no placeholders, and no obsolete `format_instructions` survive |
+| `eval-config` | Validates each evaluator `config.json` against the shared schema (`evals/_schemas/config.schema.json`, referenced by the config's own `$schema`), plus cross-file rules: referenced files exist, prompt `sha256` matches, placeholders ⇄ template `{vars}` are in sync, system prompts carry no placeholders, no obsolete `format_instructions` survive, and `stable_id`/`id`/`id_history` values are never reused across evaluators |
 | `eval-schemas` | Meta-validates each `input_schema.json` / `output_schema.json` is a well-formed JSON Schema document |
 | `eval-fixtures` | Validates `fixtures.json` against the shared `evals/_schemas/fixtures.schema.json`, and binds each case's `input`/`expected` to that evaluator's own input/output schema |
 | `eval-notebook` | Where an evaluator ships an example notebook, confirms it loads the config + prompt files from disk rather than hardcoding them |

--- a/scripts/checks/eval_config.py
+++ b/scripts/checks/eval_config.py
@@ -44,8 +44,14 @@ class EvalConfig(Check):
 
     def run(self, fix: bool) -> Result:
         result = Result(self.name)
+        configs: list[tuple[str, dict]] = []
         for cfg_path in evaluator_configs():
             self._check_config(cfg_path, result)
+            try:
+                configs.append((cfg_path, load_json(cfg_path)))
+            except (OSError, json.JSONDecodeError):
+                continue
+        self._check_stable_ids(configs, result)
         return result
 
     def _check_config(self, cfg_path: str, result: Result) -> None:
@@ -168,6 +174,36 @@ class EvalConfig(Check):
         path = config.get("fixtures", {}).get("path")
         if path and not os.path.exists(os.path.join(base, path)):
             fail(f"fixtures file not found: {path}")
+
+    def _check_stable_ids(self, configs: list[tuple[str, dict]], result: Result) -> None:
+        """stable_id is a permanent identity anchor -- it (and every id it has ever
+        had) must be globally unique across evaluators. Evaluators without a
+        stable_id yet are skipped (it's optional while being backfilled)."""
+        stable_id_owners: dict[str, list[str]] = {}
+        id_owners: dict[str, list[str]] = {}
+
+        for cfg_path, config in configs:
+            evaluator = config.get("evaluator", {})
+            stable_id = evaluator.get("stable_id")
+            if stable_id:
+                stable_id_owners.setdefault(stable_id, []).append(cfg_path)
+            for id_value in [evaluator.get("id"), *evaluator.get("id_history", [])]:
+                if id_value:
+                    id_owners.setdefault(id_value, []).append(cfg_path)
+
+        for stable_id, owners in sorted(stable_id_owners.items()):
+            if len(owners) > 1:
+                result.violations.append(Violation(
+                    owners[0],
+                    f"stable_id {stable_id!r} is used by more than one evaluator: {', '.join(owners)}",
+                ))
+        for id_value, owners in sorted(id_owners.items()):
+            if len(owners) > 1:
+                result.violations.append(Violation(
+                    owners[0],
+                    f"id {id_value!r} appears (as id or id_history) on more than one evaluator: "
+                    f"{', '.join(owners)} -- a retired id must never be reused for a different evaluator",
+                ))
 
     # --- helpers -------------------------------------------------------------
 

--- a/scripts/checks/eval_config.py
+++ b/scripts/checks/eval_config.py
@@ -176,33 +176,47 @@ class EvalConfig(Check):
             fail(f"fixtures file not found: {path}")
 
     def _check_stable_ids(self, configs: list[tuple[str, dict]], result: Result) -> None:
-        """stable_id is a permanent identity anchor -- it (and every id it has ever
-        had) must be globally unique across evaluators. Evaluators without a
-        stable_id yet are skipped (it's optional while being backfilled)."""
-        stable_id_owners: dict[str, list[str]] = {}
-        id_owners: dict[str, list[str]] = {}
+        """stable_id is a permanent identity anchor -- it must be globally unique
+        across evaluators (skipped for evaluators that don't have one yet, since
+        it's optional while being backfilled). id/id_history reuse is checked
+        regardless of whether stable_id is present.
+
+        Defensive against structurally invalid configs (already reported by
+        _check_schema) -- a non-dict `evaluator` or non-list `id_history` must
+        not crash this check and hide every other config's violations."""
+        stable_id_owners: dict[str, set[str]] = {}
+        id_owners: dict[str, set[str]] = {}
 
         for cfg_path, config in configs:
-            evaluator = config.get("evaluator", {})
+            evaluator = config.get("evaluator")
+            if not isinstance(evaluator, dict):
+                continue
+
             stable_id = evaluator.get("stable_id")
-            if stable_id:
-                stable_id_owners.setdefault(stable_id, []).append(cfg_path)
-            for id_value in [evaluator.get("id"), *evaluator.get("id_history", [])]:
-                if id_value:
-                    id_owners.setdefault(id_value, []).append(cfg_path)
+            if isinstance(stable_id, str) and stable_id:
+                stable_id_owners.setdefault(stable_id, set()).add(cfg_path)
+
+            id_history = evaluator.get("id_history")
+            if not isinstance(id_history, list):
+                id_history = []
+            for id_value in [evaluator.get("id"), *id_history]:
+                if isinstance(id_value, str) and id_value:
+                    id_owners.setdefault(id_value, set()).add(cfg_path)
 
         for stable_id, owners in sorted(stable_id_owners.items()):
             if len(owners) > 1:
+                paths = sorted(owners)
                 result.violations.append(Violation(
-                    owners[0],
-                    f"stable_id {stable_id!r} is used by more than one evaluator: {', '.join(owners)}",
+                    paths[0],
+                    f"stable_id {stable_id!r} is used by more than one evaluator: {', '.join(paths)}",
                 ))
         for id_value, owners in sorted(id_owners.items()):
             if len(owners) > 1:
+                paths = sorted(owners)
                 result.violations.append(Violation(
-                    owners[0],
+                    paths[0],
                     f"id {id_value!r} appears (as id or id_history) on more than one evaluator: "
-                    f"{', '.join(owners)} -- a retired id must never be reused for a different evaluator",
+                    f"{', '.join(paths)} -- a retired id must never be reused for a different evaluator",
                 ))
 
     # --- helpers -------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds an optional `stable_id` (permanent UUID) and `id_history` (retired `id` values) to the evaluator config contract, so an evaluator's identity survives folder/taxonomy reorganizations. `id` today is derived from folder structure, so it breaks for any consumer that stored it (SDKs, telemetry, past results) whenever things move. Fields are optional for now, backfilled evaluator-by-evaluator like the folder taxonomy migration.

## New check behavior (`eval-config`)
- `stable_id` must never be reused across evaluators.
- No `id` value (current or historical) may be reused across evaluators.
- `id_history` requires `stable_id` to be present.

## Fixed 4 Copilot findings
Crash on structurally invalid configs, a false-positive when a value repeats within one config's own `id_history`, a misleading docstring, and the UUID pattern rejecting uppercase hex.

## Verification
`python3 scripts/check.py` passes; manually verified every failure mode (duplicate `stable_id`, reused retired `id`, missing `stable_id`) and the happy path, plus all 4 Copilot fixes.
