### PR TITLE
feat(evals): add optional condition field to steps and preprocessing

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -76,7 +76,8 @@
           "endpoint": { "type": "string" },
           "params": { "type": "object" },
           "auth": { "type": "string" },
-          "pagination": { "type": "string" }
+          "pagination": { "type": "string" },
+          "condition": { "$ref": "#/$defs/Condition" }
         },
         "allOf": [
           {
@@ -159,7 +160,8 @@
             "properties": {
               "kind": { "const": "structured_output" }
             }
-          }
+          },
+          "condition": { "$ref": "#/$defs/Condition" }
         },
         "allOf": [
           {
@@ -175,6 +177,26 @@
       "properties": {
         "path": { "type": "string" },
         "tolerance": { "type": "object" }
+      }
+    }
+  },
+  "$defs": {
+    "Condition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input", "in"],
+      "properties": {
+        "input": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of a runtime input field (as declared in input_schema.json) this condition tests."
+        },
+        "in": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": ["string", "number"] },
+          "description": "This step/preprocessing entry only applies when the named input's value is one of these."
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Adds an optional `condition` field to `steps[]` and `preprocessing[]` entries in the shared evaluator config contract:
```json
"condition": { "input": "grade_level", "in": ["3", "4"] }
```
A step/preprocessing entry with a `condition` only applies when the named runtime input's value is one of the listed values. Purely structural -- static checks don't evaluate conditions (that's a runtime concern for the notebook/SDK to interpret), so this is fully backward compatible; every existing evaluator omits it and is unaffected.

## Why
First consumer is a follow-up PR merging Vocabulary's two grade-band configs (grades-3-4, other-grades) into one evaluator with one id, using `condition` to express which steps apply to which grades -- instead of two separate directories/configs for what's really one evaluator.

## Verification
`python3 scripts/check.py` passes clean (no existing config uses the new field). Manually verified: a valid `condition` on both a `steps[]` entry and a `preprocessing[]` entry passes; a malformed one (missing required `in`) fails with a clear schema error.
