### PR TITLE
feat(scripts): add prompt_diff.py for reviewing prompt changes across refs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,17 +96,25 @@ produces an empty diff; only real wording changes surface. Word granularity
 matters for prose: a reflowed paragraph is a whole-line change to a line
 differ but a no-op to a word differ.
 
+Diffs are **per LLM call** (one `steps[]` entry in `config.json`) by default —
+the unit that maps to an actual API request.
+
 ```bash
-python3 scripts/prompt_diff.py --list                        # evaluators + calls
-python3 scripts/prompt_diff.py --all                         # verdict per LLM call
-python3 scripts/prompt_diff.py purpose-clarity               # diff one evaluator
-python3 scripts/prompt_diff.py vocabulary-complexity --per-call   # one diff per LLM call
-python3 scripts/prompt_diff.py --all --emit /tmp/pd          # dump every pair to disk
+python3 scripts/prompt_diff.py --list                   # evaluators + calls
+python3 scripts/prompt_diff.py --all                    # verdict per LLM call
+python3 scripts/prompt_diff.py vocabulary-complexity    # one diff per call
+python3 scripts/prompt_diff.py --all --emit /tmp/pd     # dump every pair to disk
 ```
+
+It runs `git fetch origin` first, because both sides are read from
+remote-tracking refs. Skipping that would mean a prompt you just pushed to a
+PR is invisible, and the tool would report a confident verdict on stale
+content. Pass `--no-fetch` when offline.
 
 | Flag | Purpose |
 |------|---------|
-| `--per-call` | One diff per LLM call (config step) rather than per evaluator. The right unit when an evaluator makes several calls — Vocabulary Complexity makes 3, Sentence Structure 2. |
+| `--combined` | Concatenate all of an evaluator's calls into one diff. Off by default: condition-gated branches (Vocabulary Complexity's grade bands) can cancel out when flattened, so a real change to one branch could read as `IDENTICAL`. |
+| `--no-fetch` | Skip the automatic `git fetch origin`. |
 | `--emit DIR` | Write each rendered `BEFORE`/`AFTER` pair to `DIR` and print a `code --diff` line for each, instead of printing the diff inline. Use this to review in VS Code, Meld, Beyond Compare, or any visual difftool. |
 | `--mode content` | *(default)* Ignore role and file boundaries. Answers "did the instruction set change at all?" |
 | `--mode roles` | Keep `===== SYSTEM =====` markers. Answers "what moved between the system and user prompts?" |
@@ -114,10 +122,19 @@ python3 scripts/prompt_diff.py --all --emit /tmp/pd          # dump every pair t
 | `--normalize` | Canonicalize already-agreed renames (`{grade}`→`{grade_level}`, drop `{format_instructions}`) so only *unexpected* changes remain. Reports which substitutions fired, so nothing hides silently. |
 | `--base` / `--head` | Diff any two refs. Defaults: `origin/main` → the evaluator's PR branch. |
 
-Both sides are read with `git show`, so no checkout or worktree is needed —
-just `git fetch origin` first. Once a PR branch merges and is deleted, that
-evaluator automatically falls back to `--fallback-head` (default `origin/main`),
-so the tool keeps working without edits.
+Both sides are read with `git show`, so no checkout or worktree is needed. You
+can even run it without checking this branch out at all:
+
+```bash
+git show <ref>:scripts/prompt_diff.py > /tmp/prompt_diff.py
+python3 /tmp/prompt_diff.py --all      # from anywhere in the repo, any branch
+```
+
+It survives the migration merging. When a PR branch is deleted the head falls
+back to `--fallback-head` (default `origin/main`); and because the base-side
+files are *also* gone from `main` by then — they were `git mv`d away — each
+base path is resolved back to the last commit where it still existed, rather
+than erroring out.
 
 `EVALUATORS` in the script maps each LLM call (a `steps[]` entry in
 `config.json`) to the base-side files it came from, before the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,25 +121,29 @@ deleted, so old comparisons stay reproducible.
 ### Seeing what changed
 
 ```bash
-python3 scripts/prompt_diff.py --all --changed-only          # terminal, skip the identical ones
-python3 scripts/prompt_diff.py <evaluator> --open            # side-by-side in VS Code
-python3 scripts/prompt_diff.py --all --html /tmp/report.html # one shareable HTML report
+python3 scripts/prompt_diff.py --all --changed-only     # terminal, only what moved
+python3 scripts/prompt_diff.py <evaluator> --difftool   # your configured diff tool
+python3 scripts/prompt_diff.py <evaluator> --difftool=opendiff   # pick one explicitly
 ```
 
-`--html` writes a single self-contained page: a clickable index of every call
-with its status, then a side-by-side table per changed call with intraline
-highlighting. It needs no repo, checkout, or difftool to read, so it's the
-format to send someone reviewing the prompt wording rather than the code.
+`--difftool` renders each side to a file and hands the pair to
+`git difftool --no-index`, so it uses whatever you've set as `diff.tool` and
+supports everything git does — `git difftool --tool-help` lists what's
+installed. No bespoke launcher and no extra config of its own. Only calls that
+actually changed are opened.
 
-`--open` uses `$PROMPT_DIFF_TOOL` (default `code --diff`), so
-`PROMPT_DIFF_TOOL=opendiff` or `PROMPT_DIFF_TOOL=meld` works too. It only
-opens calls that actually changed.
+`--emit DIR` writes the pairs without opening anything, if you'd rather drive
+the comparison yourself:
+
+```bash
+python3 scripts/prompt_diff.py --all --changed-only --emit /tmp/pd
+git difftool --no-index /tmp/pd/<call>.BEFORE.txt /tmp/pd/<call>.AFTER.txt
+```
 
 | Flag | Purpose |
 |------|---------|
 | `--changed-only` | Skip calls whose prompt is unchanged. |
-| `--open` | Launch a side-by-side view per changed call, via `$PROMPT_DIFF_TOOL`. |
-| `--html FILE` | Write and open one self-contained side-by-side HTML report. |
+| `--difftool [TOOL]` | Open each changed call via `git difftool --no-index`, using your configured `diff.tool` unless you name one. |
 | `--combined` | Concatenate all of an evaluator's calls into one diff. Off by default: condition-gated branches (Vocabulary Complexity's grade bands) can cancel out when flattened, so a real change to one branch could read as `IDENTICAL`. |
 | `--no-fetch` | Skip the automatic `git fetch origin`. |
 | `--emit DIR` | Write each rendered `BEFORE`/`AFTER` pair to `DIR` and print a `code --diff` line for each, instead of printing the diff inline. Use this to review in VS Code, Meld, Beyond Compare, or any visual difftool. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,11 +100,19 @@ Diffs are **per LLM call** (one `steps[]` entry in `config.json`) by default —
 the unit that maps to an actual API request.
 
 ```bash
-python3 scripts/prompt_diff.py --list                   # evaluators + calls
+python3 scripts/prompt_diff.py --list                   # evaluators + calls, by family
 python3 scripts/prompt_diff.py --all                    # verdict per LLM call
+python3 scripts/prompt_diff.py --all --family feedback  # just one family
 python3 scripts/prompt_diff.py vocabulary-complexity    # one diff per call
 python3 scripts/prompt_diff.py --all --emit /tmp/pd     # dump every pair to disk
 ```
+
+Two families are registered, each with its own destination root:
+
+| Family | Destination | Evaluators |
+|---|---|---|
+| `student-facing-text` | `evals/student-facing-text/ela-reading/` | 8 (11 LLM calls) |
+| `feedback` | `evals/feedback/ela-writing/` | 7 (7 LLM calls) |
 
 It runs `git fetch origin` first, because both sides are read from refs rather
 than the working tree. Skipping that would mean a prompt you just pushed to a
@@ -187,6 +195,7 @@ git diff --no-index BEFORE.txt AFTER.txt | delta --side-by-side | aha > diff.htm
 
 | Flag | Purpose |
 |------|---------|
+| `--family NAME` | Restrict `--all` to one family (`student-facing-text`, `feedback`). |
 | `--changed-only` | Skip calls whose prompt is unchanged. |
 | `--difftool [TOOL]` | Open each changed call via `git difftool --no-index`, using your configured `diff.tool` unless you name one. |
 | `--combined` | Concatenate all of an evaluator's calls into one diff. Off by default: condition-gated branches (Vocabulary Complexity's grade bands) can cancel out when flattened, so a real change to one branch could read as `IDENTICAL`. |
@@ -218,10 +227,11 @@ base path is resolved back to the last commit where it still existed, rather
 than erroring out.
 
 `EVALUATORS` in the script maps each LLM call (a `steps[]` entry in
-`config.json`) to the base-side files it came from, before the
-`evals/prompts/` → `evals/student-facing-text/ela-reading/` migration. That
-mapping is inherently historical — `git` can't infer it once files move and
-merge — so it's maintained by hand as new evaluators land.
+`config.json`) to the base-side files it came from, before the migration that
+moved it. That mapping is inherently historical — `git` can't infer it once
+files move and merge — so it's maintained by hand as new evaluators land. Add
+an entry with its `family`, `pr`, `head_ref`, and per-step `old` paths;
+`FAMILIES` supplies the destination root.
 
 A step's `head_extra` lists files that call depends on but `config.json`
 cannot name: Sentence Structure's grade-band rubrics are `preprocessing`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,8 +137,32 @@ the comparison yourself:
 
 ```bash
 python3 scripts/prompt_diff.py --all --changed-only --emit /tmp/pd
-git difftool --no-index /tmp/pd/<call>.BEFORE.txt /tmp/pd/<call>.AFTER.txt
+git diff --no-index /tmp/pd/<call>.BEFORE.txt /tmp/pd/<call>.AFTER.txt
 ```
+
+### Recommended: delta
+
+Prompts are prose, and stock `git diff` is weak on prose — it marks a whole
+line as changed when one word moved.
+[delta](https://github.com/dandavison/delta) fixes that with side-by-side
+panes and word-level highlighting *within* a line, so a one-word edit inside a
+200-word paragraph shows as exactly that one word.
+
+```bash
+brew install git-delta
+
+git config --global core.pager delta
+git config --global interactive.diffFilter 'delta --color-only'
+git config --global delta.side-by-side true
+git config --global delta.navigate true      # n / N to jump between hunks
+```
+
+That's it — delta is a pager, so every `git diff` in every repo improves,
+including the `git diff --no-index` line this tool prints. Nothing here
+depends on it.
+
+For a GUI instead, set `diff.tool` (`opendiff` ships with Xcode CLT on macOS)
+and use `--difftool`.
 
 | Flag | Purpose |
 |------|---------|

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -118,8 +118,28 @@ names. It's been verified against a `--single-branch` clone that only knew
 `origin/main`. GitHub keeps those refs after a PR merges and its branch is
 deleted, so old comparisons stay reproducible.
 
+### Seeing what changed
+
+```bash
+python3 scripts/prompt_diff.py --all --changed-only          # terminal, skip the identical ones
+python3 scripts/prompt_diff.py <evaluator> --open            # side-by-side in VS Code
+python3 scripts/prompt_diff.py --all --html /tmp/report.html # one shareable HTML report
+```
+
+`--html` writes a single self-contained page: a clickable index of every call
+with its status, then a side-by-side table per changed call with intraline
+highlighting. It needs no repo, checkout, or difftool to read, so it's the
+format to send someone reviewing the prompt wording rather than the code.
+
+`--open` uses `$PROMPT_DIFF_TOOL` (default `code --diff`), so
+`PROMPT_DIFF_TOOL=opendiff` or `PROMPT_DIFF_TOOL=meld` works too. It only
+opens calls that actually changed.
+
 | Flag | Purpose |
 |------|---------|
+| `--changed-only` | Skip calls whose prompt is unchanged. |
+| `--open` | Launch a side-by-side view per changed call, via `$PROMPT_DIFF_TOOL`. |
+| `--html FILE` | Write and open one self-contained side-by-side HTML report. |
 | `--combined` | Concatenate all of an evaluator's calls into one diff. Off by default: condition-gated branches (Vocabulary Complexity's grade bands) can cancel out when flattened, so a real change to one branch could read as `IDENTICAL`. |
 | `--no-fetch` | Skip the automatic `git fetch origin`. |
 | `--emit DIR` | Write each rendered `BEFORE`/`AFTER` pair to `DIR` and print a `code --diff` line for each, instead of printing the diff inline. Use this to review in VS Code, Meld, Beyond Compare, or any visual difftool. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,10 +106,17 @@ python3 scripts/prompt_diff.py vocabulary-complexity    # one diff per call
 python3 scripts/prompt_diff.py --all --emit /tmp/pd     # dump every pair to disk
 ```
 
-It runs `git fetch origin` first, because both sides are read from
-remote-tracking refs. Skipping that would mean a prompt you just pushed to a
+It runs `git fetch origin` first, because both sides are read from refs rather
+than the working tree. Skipping that would mean a prompt you just pushed to a
 PR is invisible, and the tool would report a confident verdict on stale
 content. Pass `--no-fetch` when offline.
+
+That same fetch also pulls each PR head from `refs/pull/<N>/head` into
+`refs/prompt-diff/pr-<N>`, so **the tool works on any clone** — the person
+running it needs no local branches, no worktrees, and no knowledge of branch
+names. It's been verified against a `--single-branch` clone that only knew
+`origin/main`. GitHub keeps those refs after a PR merges and its branch is
+deleted, so old comparisons stay reproducible.
 
 | Flag | Purpose |
 |------|---------|
@@ -123,12 +130,17 @@ content. Pass `--no-fetch` when offline.
 | `--base` / `--head` | Diff any two refs. Defaults: `origin/main` → the evaluator's PR branch. |
 
 Both sides are read with `git show`, so no checkout or worktree is needed. You
-can even run it without checking this branch out at all:
+can run it without checking out the branch it lives on:
 
 ```bash
-git show <ref>:scripts/prompt_diff.py > /tmp/prompt_diff.py
+git fetch origin worktree-prompt-diff-tool
+git show FETCH_HEAD:scripts/prompt_diff.py > /tmp/prompt_diff.py
 python3 /tmp/prompt_diff.py --all      # from anywhere in the repo, any branch
 ```
+
+To hand it to someone else while it's still unmerged, that snippet is the
+whole handoff — it needs only clone access, and bootstraps every ref it
+compares.
 
 It survives the migration merging. When a PR branch is deleted the head falls
 back to `--fallback-head` (default `origin/main`); and because the base-side

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,16 +97,20 @@ matters for prose: a reflowed paragraph is a whole-line change to a line
 differ but a no-op to a word differ.
 
 ```bash
-python3 scripts/prompt_diff.py --list          # evaluators it knows about
-python3 scripts/prompt_diff.py --all           # verdict table, every evaluator
-python3 scripts/prompt_diff.py purpose-clarity # word-level diff for one
+python3 scripts/prompt_diff.py --list                        # evaluators + calls
+python3 scripts/prompt_diff.py --all                         # verdict per LLM call
+python3 scripts/prompt_diff.py purpose-clarity               # diff one evaluator
+python3 scripts/prompt_diff.py vocabulary-complexity --per-call   # one diff per LLM call
+python3 scripts/prompt_diff.py --all --emit /tmp/pd          # dump every pair to disk
 ```
 
 | Flag | Purpose |
 |------|---------|
+| `--per-call` | One diff per LLM call (config step) rather than per evaluator. The right unit when an evaluator makes several calls — Vocabulary Complexity makes 3, Sentence Structure 2. |
+| `--emit DIR` | Write each rendered `BEFORE`/`AFTER` pair to `DIR` and print a `code --diff` line for each, instead of printing the diff inline. Use this to review in VS Code, Meld, Beyond Compare, or any visual difftool. |
 | `--mode content` | *(default)* Ignore role and file boundaries. Answers "did the instruction set change at all?" |
 | `--mode roles` | Keep `===== SYSTEM =====` markers. Answers "what moved between the system and user prompts?" |
-| `--mode files` | File inventory per side, no diff. Answers "which files went where?" |
+| `--mode files` | File inventory per call, no diff. Answers "which files went where?" |
 | `--normalize` | Canonicalize already-agreed renames (`{grade}`→`{grade_level}`, drop `{format_instructions}`) so only *unexpected* changes remain. Reports which substitutions fired, so nothing hides silently. |
 | `--base` / `--head` | Diff any two refs. Defaults: `origin/main` → the evaluator's PR branch. |
 
@@ -115,7 +119,15 @@ just `git fetch origin` first. Once a PR branch merges and is deleted, that
 evaluator automatically falls back to `--fallback-head` (default `origin/main`),
 so the tool keeps working without edits.
 
-`EVALUATORS` in the script maps each evaluator to where its prompts lived
-before the `evals/prompts/` → `evals/student-facing-text/ela-reading/`
-migration. That mapping is inherently historical — `git` can't infer it once
-files move and merge — so it's maintained by hand as new evaluators land.
+`EVALUATORS` in the script maps each LLM call (a `steps[]` entry in
+`config.json`) to the base-side files it came from, before the
+`evals/prompts/` → `evals/student-facing-text/ela-reading/` migration. That
+mapping is inherently historical — `git` can't infer it once files move and
+merge — so it's maintained by hand as new evaluators land.
+
+A step's `head_extra` lists files that call depends on but `config.json`
+cannot name: Sentence Structure's grade-band rubrics are `preprocessing`
+entries interpolated into `{rubric}`, and `config.schema.json` has no
+`source_path` field for preprocessing entries. Worth fixing at the schema
+level — `notebook_ci/find_affected.py` derives its dependency closure from
+the same data, so those rubrics are currently outside it too.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,12 +133,25 @@ installed. No bespoke launcher and no extra config of its own. Only calls that
 actually changed are opened.
 
 `--emit DIR` writes the pairs without opening anything, if you'd rather drive
-the comparison yourself:
+the comparison yourself. It finishes by printing ready-to-run commands for
+exactly what it just wrote — a one-liner for all of them, then one per call —
+so there's nothing to remember or retype:
 
 ```bash
-python3 scripts/prompt_diff.py --all --changed-only --emit /tmp/pd
-git diff --no-index /tmp/pd/<call>.BEFORE.txt /tmp/pd/<call>.AFTER.txt
+$ python3 scripts/prompt_diff.py --all --changed-only --emit /tmp/pd
+...
+All pairs written to /tmp/pd/
+
+Review all 8 in one go:
+  for f in /tmp/pd/*.BEFORE.txt; do git diff --no-index "$f" "${f%.BEFORE.txt}.AFTER.txt"; done
+
+Or one at a time:
+  git diff --no-index /tmp/pd/background-knowledge-demands....BEFORE.txt /tmp/pd/...AFTER.txt
+  ...
 ```
+
+With delta configured as your pager, each of those opens side-by-side; `q`
+moves to the next.
 
 ### Recommended: delta
 
@@ -163,6 +176,14 @@ depends on it.
 
 For a GUI instead, set `diff.tool` (`opendiff` ships with Xcode CLT on macOS)
 and use `--difftool`.
+
+delta has no HTML export of its own. If you ever need a diff as a file to send
+someone, pipe its ANSI output through [`aha`](https://github.com/theZiz/aha)
+(`brew install aha`) rather than reaching for a bespoke generator:
+
+```bash
+git diff --no-index BEFORE.txt AFTER.txt | delta --side-by-side | aha > diff.html
+```
 
 | Flag | Purpose |
 |------|---------|

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,3 +82,40 @@ evaluators with a `config.json` are covered, same as every check above.
 ```bash
 python3 scripts/notebook_ci/find_affected.py --changed-files-from <(git diff --name-only main)
 ```
+
+## `scripts/prompt_diff.py` — review what actually changed in a prompt
+
+A plain `git diff` is a poor review tool for prompt changes, for two reasons:
+files move (so everything reads as delete + add), and content moves *between*
+files (rubric text relocated from a user prompt to a system prompt reads as a
+large deletion plus a large addition, when nothing the model sees changed).
+
+This renders each side into one normalized blob — every message concatenated in
+the order `config.json` declares — and word-diffs that. A pure restructure
+produces an empty diff; only real wording changes surface. Word granularity
+matters for prose: a reflowed paragraph is a whole-line change to a line
+differ but a no-op to a word differ.
+
+```bash
+python3 scripts/prompt_diff.py --list          # evaluators it knows about
+python3 scripts/prompt_diff.py --all           # verdict table, every evaluator
+python3 scripts/prompt_diff.py purpose-clarity # word-level diff for one
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--mode content` | *(default)* Ignore role and file boundaries. Answers "did the instruction set change at all?" |
+| `--mode roles` | Keep `===== SYSTEM =====` markers. Answers "what moved between the system and user prompts?" |
+| `--mode files` | File inventory per side, no diff. Answers "which files went where?" |
+| `--normalize` | Canonicalize already-agreed renames (`{grade}`→`{grade_level}`, drop `{format_instructions}`) so only *unexpected* changes remain. Reports which substitutions fired, so nothing hides silently. |
+| `--base` / `--head` | Diff any two refs. Defaults: `origin/main` → the evaluator's PR branch. |
+
+Both sides are read with `git show`, so no checkout or worktree is needed —
+just `git fetch origin` first. Once a PR branch merges and is deleted, that
+evaluator automatically falls back to `--fallback-head` (default `origin/main`),
+so the tool keeps working without edits.
+
+`EVALUATORS` in the script maps each evaluator to where its prompts lived
+before the `evals/prompts/` → `evals/student-facing-text/ela-reading/`
+migration. That mapping is inherently historical — `git` can't infer it once
+files move and merge — so it's maintained by hand as new evaluators land.

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Diff an evaluator's prompts between two git refs.
+
+Prompt review is hard with a plain `git diff` for two reasons:
+
+  1. The files moved. `evals/prompts/vocabulary/` became
+     `evals/student-facing-text/ela-reading/vocabulary-complexity/`, so a
+     path-based diff shows every file as deleted-and-added.
+
+  2. Content moved *between* files. Rubric text that used to sit in a user
+     prompt now sits in a system prompt. A per-file diff reports that as a
+     large deletion plus a large addition, when nothing the model sees
+     actually changed.
+
+This tool answers the question that matters -- "did the bytes we send to the
+model change?" -- by rendering each side into one normalized blob, in the
+order the config declares, and diffing that. A pure restructure produces an
+empty diff. Only real wording changes show up.
+
+Three modes, for three different questions:
+
+  content  (default)  Concatenate every message, drop role boundaries.
+                      "Did the instruction set change at all?"
+  roles               Same, but keep `===== SYSTEM =====` markers.
+                      "What moved between the system and user prompts?"
+  files               List the file inventory on each side, no diff.
+                      "Which files went where?"
+
+Usage:
+  scripts/prompt_diff.py --list
+  scripts/prompt_diff.py vocabulary-complexity
+  scripts/prompt_diff.py vocabulary-complexity --mode roles
+  scripts/prompt_diff.py --all
+  scripts/prompt_diff.py purpose-clarity --base origin/main --head my-branch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# Where each evaluator's prompts lived before the migration, and which branch
+# carries the migrated version. `old_paths` is ordered -- it defines the
+# concatenation order for the base side, mirroring the order the config
+# declares on the head side.
+#
+# Once these branches merge, `head_ref` entries can drop to "origin/main" and
+# this manifest becomes a historical record of where things used to live.
+EVALUATORS: dict[str, dict] = {
+    "grade-level-appropriateness": {
+        "old_name": "Grade Level Appropriateness",
+        "pr": 159,
+        "head_ref": "origin/worktree-ga-gla-prompt-fixes",
+        "old_paths": [
+            "evals/prompts/grade-level-appropriateness/system.txt",
+            "evals/prompts/grade-level-appropriateness/user.txt",
+        ],
+    },
+    "meaning-directness": {
+        "old_name": "Conventionality",
+        "pr": 161,
+        "head_ref": "origin/worktree-ga-conventionality-fixes",
+        "old_paths": [
+            "evals/prompts/conventionality/system.txt",
+            "evals/prompts/conventionality/user.txt",
+        ],
+    },
+    "vocabulary-complexity": {
+        "old_name": "Vocabulary",
+        "pr": 163,
+        "head_ref": "origin/worktree-ga-vocabulary-fixes",
+        "old_paths": [
+            "evals/prompts/vocabulary/background-knowledge.txt",
+            "evals/prompts/vocabulary/grades-3-4-system.txt",
+            "evals/prompts/vocabulary/grades-3-4-user.txt",
+            "evals/prompts/vocabulary/other-grades-system.txt",
+            "evals/prompts/vocabulary/other-grades-user.txt",
+        ],
+    },
+    "background-knowledge-demands": {
+        "old_name": "Subject Matter Knowledge",
+        "pr": 173,
+        "head_ref": "origin/worktree-background-knowledge-demands",
+        "old_paths": [
+            "evals/prompts/subject-matter-knowledge/system.txt",
+            "evals/prompts/subject-matter-knowledge/user.txt",
+        ],
+    },
+    "sentence-structure": {
+        "old_name": "Sentence Structure",
+        "pr": 174,
+        "head_ref": "origin/worktree-sentence-structure",
+        "old_paths": [
+            "evals/prompts/sentence-structure/analysis-system.txt",
+            "evals/prompts/sentence-structure/analysis-user.txt",
+            "evals/prompts/sentence-structure/complexity-system.txt",
+            "evals/prompts/sentence-structure/complexity-user.txt",
+            "evals/prompts/sentence-structure/rubric-grade-3.txt",
+            "evals/prompts/sentence-structure/rubric-grade-4.txt",
+            "evals/prompts/sentence-structure/rubric-grades-5-12.txt",
+        ],
+    },
+    "purpose-clarity": {
+        "old_name": "Purpose",
+        "pr": 175,
+        "head_ref": "origin/worktree-purpose-clarity",
+        "old_paths": [
+            "evals/prompts/purpose/system.txt",
+            "evals/prompts/purpose/user.txt",
+        ],
+    },
+    "organizational-structure": {
+        "old_name": "Organizational Structure",
+        "pr": 176,
+        "head_ref": "origin/worktree-organizational-structure",
+        "old_paths": [
+            "evals/literacy/qualitative-text-complexity/organizational-structure/system.txt",
+            "evals/literacy/qualitative-text-complexity/organizational-structure/user.txt",
+        ],
+    },
+    "reference-knowledge-demands": {
+        "old_name": "Intertextuality",
+        "pr": 177,
+        "head_ref": "origin/worktree-reference-knowledge-demands",
+        "old_paths": [
+            "evals/literacy/qualitative-text-complexity/intertextuality/system.txt",
+            "evals/literacy/qualitative-text-complexity/intertextuality/user.txt",
+        ],
+    },
+}
+
+NEW_DIR = "evals/student-facing-text/ela-reading"
+
+# Substitutions applied under --normalize, to answer "ignoring the renames we
+# already know about, is anything else different?" Reported when applied, so a
+# clean diff never silently hides one of these.
+KNOWN_RENAMES = [("{grade}", "{grade_level}")]
+
+# Dropped under --normalize: structured output made these obsolete, and their
+# removal is a decision already made, not something to re-review per evaluator.
+KNOWN_DROPS = ["{format_instructions}"]
+
+
+class GitError(RuntimeError):
+    pass
+
+
+def git_show(ref: str, path: str) -> str:
+    """Read one file at one ref. Raises GitError if it isn't there."""
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise GitError(f"{ref}:{path} -- {result.stderr.strip()}")
+    return result.stdout
+
+
+def role_from_filename(path: str) -> str:
+    """Infer a message's role from its filename.
+
+    Only used for the base side, which predates config.json declaring roles
+    explicitly. The naming convention was consistent enough to rely on:
+    *-system.txt / system.txt are system prompts, everything else is a user
+    prompt (rubric-*.txt are fragments interpolated into a user prompt).
+    """
+    stem = Path(path).stem
+    return "system" if stem == "system" or stem.endswith("-system") else "user"
+
+
+def ls_tree(ref: str, directory: str) -> list[str]:
+    """List filenames directly under a directory at a ref."""
+    result = subprocess.run(
+        ["git", "ls-tree", "--name-only", ref, f"{directory}/"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [Path(line).name for line in result.stdout.splitlines() if line.strip()]
+
+
+def head_messages(ref: str, slug: str) -> list[tuple[str, str, str]]:
+    """Read the head side's prompt files: config-declared messages first, then
+    any remaining .txt files in the directory.
+
+    Driving the ordered part off config.json keeps the tool correct as steps
+    are added or reordered. The trailing sweep exists because not every prompt
+    file is declared as a `messages` entry -- Sentence Structure's grade-band
+    rubrics are `preprocessing` entries interpolated into `{rubric}`, and the
+    schema has no `source_path` for those. Without the sweep they'd read as
+    deletions, which is exactly the false alarm this tool exists to prevent.
+    """
+    base_dir = f"{NEW_DIR}/{slug}"
+    config = json.loads(git_show(ref, f"{base_dir}/config.json"))
+
+    messages: list[tuple[str, str, str]] = []
+    declared: set[str] = set()
+    for step in config.get("steps", []):
+        for msg in step.get("prompt", {}).get("messages", []):
+            source = msg["source_path"]
+            declared.add(source)
+            messages.append(
+                (msg.get("role", "user"), source, git_show(ref, f"{base_dir}/{source}"))
+            )
+
+    for name in sorted(ls_tree(ref, base_dir)):
+        if name.endswith(".txt") and name not in declared:
+            messages.append(("undeclared", name, git_show(ref, f"{base_dir}/{name}")))
+
+    return messages
+
+
+def base_messages(ref: str, old_paths: list[str]) -> list[tuple[str, str, str]]:
+    """Read the base side's messages from the manifest's ordered path list."""
+    return [
+        (role_from_filename(path), Path(path).name, git_show(ref, path))
+        for path in old_paths
+    ]
+
+
+def normalize(text: str) -> str:
+    """Strip differences that are formatting, not meaning.
+
+    Trailing whitespace and blank-line runs vary between hand-edited files and
+    tell you nothing about what the model receives.
+    """
+    lines = [line.rstrip() for line in text.split("\n")]
+    out: list[str] = []
+    for line in lines:
+        if not line and out and not out[-1]:
+            continue
+        out.append(line)
+    return "\n".join(out).strip() + "\n"
+
+
+def apply_known_renames(text: str) -> tuple[str, list[str]]:
+    """Canonicalize the placeholder renames, reporting which ones fired."""
+    applied = []
+    for old, new in KNOWN_RENAMES:
+        if old in text:
+            text = text.replace(old, new)
+            applied.append(f"{old} -> {new}")
+    for token in KNOWN_DROPS:
+        if token in text:
+            text = text.replace(token, "")
+            applied.append(f"dropped {token}")
+    return text, applied
+
+
+def render(messages: list[tuple[str, str, str]], mode: str) -> str:
+    """Flatten messages into the blob that gets diffed."""
+    if mode == "roles":
+        parts = [
+            f"===== {role.upper()} ({source}) =====\n{text}"
+            for role, source, text in messages
+        ]
+    else:  # content -- role and file boundaries deliberately erased
+        parts = [text for _, _, text in messages]
+    return normalize("\n".join(parts))
+
+
+def strip_file_header(diff: str) -> str:
+    """Drop git's file-header lines -- they'd show temp paths, not real ones.
+
+    The `@@` hunk headers are kept: they carry the surrounding prose, which is
+    the useful part for locating a change in a long prompt.
+    """
+    skip = ("diff --git ", "index ", "--- ", "+++ ")
+    lines = [ln for ln in diff.split("\n") if not _ANSI.sub("", ln).startswith(skip)]
+    return "\n".join(lines).strip("\n")
+
+
+def word_diff(base_text: str, head_text: str, base_label: str, head_label: str,
+              color: bool) -> tuple[str, bool]:
+    """Word-level diff via git. Returns (output, changed).
+
+    Word granularity matters for prose: a reflowed paragraph is a whole-line
+    change to a line differ, but a no-op to a word differ.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        base_file = Path(tmp) / "base"
+        head_file = Path(tmp) / "head"
+        base_file.write_text(base_text)
+        head_file.write_text(head_text)
+
+        cmd = [
+            "git", "diff", "--no-index", "--patience",
+            f"--word-diff={'color' if color else 'plain'}",
+            f"--color={'always' if color else 'never'}",
+            str(base_file), str(head_file),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        # git diff exits 1 when files differ -- that's data, not failure.
+        return strip_file_header(result.stdout), result.returncode != 0
+
+
+def ref_exists(ref: str) -> bool:
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        capture_output=True,
+    ).returncode == 0
+
+
+def resolve(slug: str, args) -> tuple[str, str]:
+    """Resolve the base and head refs for one evaluator.
+
+    Falls back to the default branch once a PR branch is gone, so this keeps
+    working unchanged after the migration PRs merge and their branches are
+    deleted.
+    """
+    if args.head:
+        return args.base, args.head
+
+    head = EVALUATORS[slug]["head_ref"]
+    if not ref_exists(head):
+        head = args.fallback_head
+    return args.base, head
+
+
+def diff_one(slug: str, args) -> bool:
+    """Diff one evaluator. Returns True if the rendered prompt changed."""
+    meta = EVALUATORS[slug]
+    base_ref, head_ref = resolve(slug, args)
+
+    base_msgs = base_messages(base_ref, meta["old_paths"])
+    head_msgs = head_messages(head_ref, slug)
+
+    if args.mode == "files":
+        print(f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']})")
+        print(f"  base  {base_ref}")
+        for role, source, text in base_msgs:
+            print(f"    {role:>6}  {source:<28} {len(text):>6} chars")
+        print(f"  head  {head_ref}")
+        for role, source, text in head_msgs:
+            print(f"    {role:>6}  {source:<28} {len(text):>6} chars")
+        return False
+
+    base_text = render(base_msgs, args.mode)
+    head_text = render(head_msgs, args.mode)
+
+    notes: list[str] = []
+    if args.normalize:
+        base_text, applied = apply_known_renames(base_text)
+        notes = applied
+        head_text, _ = apply_known_renames(head_text)
+        base_text, head_text = normalize(base_text), normalize(head_text)
+
+    output, changed = word_diff(
+        base_text, head_text, meta["old_name"].replace(" ", "-"), slug,
+        color=args.color,
+    )
+
+    header = f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']}, mode={args.mode})"
+    print(header)
+    print(f"  {base_ref}  ->  {head_ref}")
+    if notes:
+        print(f"  normalized: {', '.join(notes)}")
+
+    if not changed:
+        print("  \033[32mIDENTICAL\033[0m -- restructured only, the model sees the same bytes")
+    else:
+        print()
+        print(output)
+    return changed
+
+
+def summary(args) -> int:
+    """Verdict table across every evaluator."""
+    print(f"\n{'EVALUATOR':<30}  {'PR':>5}  {'VERDICT':<12}  BASE -> HEAD")
+    print("=" * 100)
+
+    changed_any = False
+    for slug, meta in EVALUATORS.items():
+        base_ref, head_ref = resolve(slug, args)
+        try:
+            base_text = render(base_messages(base_ref, meta["old_paths"]), args.mode)
+            head_text = render(head_messages(head_ref, slug), args.mode)
+            if args.normalize:
+                base_text, _ = apply_known_renames(base_text)
+                head_text, _ = apply_known_renames(head_text)
+                base_text, head_text = normalize(base_text), normalize(head_text)
+            _, changed = word_diff(base_text, head_text, "a", "b", color=False)
+        except GitError as e:
+            print(f"{slug:<30}  {meta['pr']:>5}  \033[31mERROR\033[0m         {e}")
+            changed_any = True
+            continue
+
+        verdict = "\033[33mCHANGED\033[0m     " if changed else "\033[32mIDENTICAL\033[0m   "
+        changed_any = changed_any or changed
+        print(f"{slug:<30}  {meta['pr']:>5}  {verdict}  {base_ref} -> {head_ref.replace('origin/', '')}")
+
+    print("=" * 100)
+    print(f"mode={args.mode}" + (", normalized" if args.normalize else ""))
+    print("IDENTICAL = prompt text is byte-identical after restructuring; only file layout changed.")
+    print("Run without --all on a CHANGED evaluator to see the word-level diff.\n")
+    return 1 if changed_any else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff an evaluator's prompts between two git refs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:")[1] if "Usage:" in __doc__ else None,
+    )
+    parser.add_argument("evaluator", nargs="?", help="evaluator slug (see --list)")
+    parser.add_argument("--list", action="store_true", help="list known evaluators")
+    parser.add_argument("--all", action="store_true", help="verdict table for every evaluator")
+    parser.add_argument(
+        "--mode", choices=["content", "roles", "files"], default="content",
+        help="content: ignore role/file boundaries (default). "
+             "roles: keep role markers. files: inventory only, no diff",
+    )
+    parser.add_argument("--base", default="origin/main", help="base ref (default: origin/main)")
+    parser.add_argument("--head", help="head ref (default: the evaluator's PR branch)")
+    parser.add_argument(
+        "--fallback-head", default="origin/main",
+        help="ref to use when an evaluator's PR branch no longer exists, e.g. "
+             "after it merges (default: origin/main)",
+    )
+    parser.add_argument(
+        "--normalize", action="store_true",
+        help="canonicalize known placeholder renames ({grade}->{grade_level}, "
+             "drop {format_instructions}) so only unexpected changes surface",
+    )
+    parser.add_argument("--no-color", dest="color", action="store_false", help="disable color")
+    args = parser.parse_args()
+
+    if args.list:
+        print(f"\n{'SLUG':<30}  {'PR':>5}  WAS")
+        print("-" * 70)
+        for slug, meta in EVALUATORS.items():
+            print(f"{slug:<30}  {meta['pr']:>5}  {meta['old_name']}")
+        print()
+        return 0
+
+    if args.all:
+        return summary(args)
+
+    if not args.evaluator:
+        parser.print_help()
+        return 2
+
+    if args.evaluator not in EVALUATORS:
+        print(f"unknown evaluator: {args.evaluator!r}", file=sys.stderr)
+        print(f"known: {', '.join(EVALUATORS)}", file=sys.stderr)
+        return 2
+
+    try:
+        diff_one(args.evaluator, args)
+    except GitError as e:
+        print(f"error: {e}", file=sys.stderr)
+        print("hint: run `git fetch origin` if a PR branch is missing", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -46,15 +46,23 @@ from pathlib import Path
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
+# Destination root per family. Each evaluator names its family rather than
+# repeating the path.
+FAMILIES = {
+    "student-facing-text": "evals/student-facing-text/ela-reading",
+    "feedback": "evals/feedback/ela-writing",
+}
+
 # Where each evaluator's prompts lived before the migration, and which branch
-# carries the migrated version. `old_paths` is ordered -- it defines the
-# concatenation order for the base side, mirroring the order the config
+# carries the migrated version. Each step's `old` list is ordered -- it defines
+# the concatenation order for the base side, mirroring the order the config
 # declares on the head side.
 #
 # Once these branches merge, `head_ref` entries can drop to "origin/main" and
 # this manifest becomes a historical record of where things used to live.
 EVALUATORS: dict[str, dict] = {
     "grade-level-appropriateness": {
+        "family": "student-facing-text",
         "old_name": "Grade Level Appropriateness",
         "pr": 159,
         "head_ref": "origin/worktree-ga-gla-prompt-fixes",
@@ -68,6 +76,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "meaning-directness": {
+        "family": "student-facing-text",
         "old_name": "Conventionality",
         "pr": 161,
         "head_ref": "origin/worktree-ga-conventionality-fixes",
@@ -81,6 +90,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "vocabulary-complexity": {
+        "family": "student-facing-text",
         "old_name": "Vocabulary",
         "pr": 163,
         "head_ref": "origin/worktree-ga-vocabulary-fixes",
@@ -103,6 +113,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "background-knowledge-demands": {
+        "family": "student-facing-text",
         "old_name": "Subject Matter Knowledge",
         "pr": 173,
         "head_ref": "origin/worktree-background-knowledge-demands",
@@ -116,6 +127,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "sentence-structure": {
+        "family": "student-facing-text",
         "old_name": "Sentence Structure",
         "pr": 174,
         "head_ref": "origin/worktree-sentence-structure",
@@ -147,6 +159,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "purpose-clarity": {
+        "family": "student-facing-text",
         "old_name": "Purpose",
         "pr": 175,
         "head_ref": "origin/worktree-purpose-clarity",
@@ -160,6 +173,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "organizational-structure": {
+        "family": "student-facing-text",
         "old_name": "Organizational Structure",
         "pr": 176,
         "head_ref": "origin/worktree-organizational-structure",
@@ -173,6 +187,7 @@ EVALUATORS: dict[str, dict] = {
         },
     },
     "reference-knowledge-demands": {
+        "family": "student-facing-text",
         "old_name": "Intertextuality",
         "pr": 177,
         "head_ref": "origin/worktree-reference-knowledge-demands",
@@ -185,9 +200,113 @@ EVALUATORS: dict[str, dict] = {
             },
         },
     },
+
+    # --- feedback family -------------------------------------------------
+    # All seven moved from evals/feedback/productive-coaching-writing-feedback/
+    # to evals/feedback/ela-writing/. Single LLM step each, system + user.
+    "strength-acknowledgement": {
+        "family": "feedback",
+        "old_name": "Acknowledges Strength",
+        "pr": 185,
+        "head_ref": "origin/feedback-strength-acknowledgement",
+        "steps": {
+            "evaluate_strength_acknowledgement": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/acknowledges-strength/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/acknowledges-strength/user.txt",
+                ],
+            },
+        },
+    },
+    "revision-actionability": {
+        "family": "feedback",
+        "old_name": "Actionable Revision",
+        "pr": 180,
+        "head_ref": "origin/feedback-revision-actionability",
+        "steps": {
+            "evaluate_revision_actionability": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/actionable-revision/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/actionable-revision/user.txt",
+                ],
+            },
+        },
+    },
+    "student-response-specificity": {
+        "family": "feedback",
+        "old_name": "Anchored In Student Response",
+        "pr": 181,
+        "head_ref": "origin/feedback-student-response-specificity",
+        "steps": {
+            "evaluate_student_response_specificity": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/anchored-in-student-response/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/anchored-in-student-response/user.txt",
+                ],
+            },
+        },
+    },
+    "revision-accuracy": {
+        "family": "feedback",
+        "old_name": "Appropriate Feedback",
+        "pr": 182,
+        "head_ref": "origin/feedback-revision-accuracy",
+        "steps": {
+            "evaluate_revision_accuracy": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/appropriate-feedback/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/appropriate-feedback/user.txt",
+                ],
+            },
+        },
+    },
+    "revision-manageability": {
+        "family": "feedback",
+        "old_name": "Manageable",
+        "pr": 179,
+        "head_ref": "origin/feedback-revision-manageability",
+        "steps": {
+            "evaluate_revision_manageability": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/manageable/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/manageable/user.txt",
+                ],
+            },
+        },
+    },
+    "tone-appropriateness": {
+        "family": "feedback",
+        "old_name": "Tone Appropriateness",
+        "pr": 183,
+        "head_ref": "origin/feedback-tone-appropriateness",
+        "steps": {
+            "evaluate_tone_appropriateness": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/tone-appropriateness/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/tone-appropriateness/user.txt",
+                ],
+            },
+        },
+    },
+    "withholding-answers": {
+        "family": "feedback",
+        "old_name": "Withholding Answers",
+        "pr": 184,
+        "head_ref": "origin/feedback-withholding-answers",
+        "steps": {
+            "evaluate_withholding_answers": {
+                "old": [
+                    "evals/feedback/productive-coaching-writing-feedback/withholding-answers/system.txt",
+                    "evals/feedback/productive-coaching-writing-feedback/withholding-answers/user.txt",
+                ],
+            },
+        },
+    },
 }
 
-NEW_DIR = "evals/student-facing-text/ela-reading"
+def new_dir(slug: str) -> str:
+    """Destination directory for an evaluator, from its family."""
+    return f"{FAMILIES[EVALUATORS[slug]['family']]}/{slug}"
 
 # Substitutions applied under --normalize, to answer "ignoring the renames we
 # already know about, is anything else different?" Reported when applied, so a
@@ -321,7 +440,7 @@ def head_step_messages(ref: str, slug: str, step_id: str,
     field for preprocessing. Without them the rubrics would read as deletions
     -- exactly the false alarm this tool exists to prevent.
     """
-    base_dir = f"{NEW_DIR}/{slug}"
+    base_dir = new_dir(slug)
     config = json.loads(git_show(ref, f"{base_dir}/config.json"))
 
     step = next((s for s in config.get("steps", []) if s.get("id") == step_id), None)
@@ -622,6 +741,12 @@ def diff_one(slug: str, args) -> bool:
     )
 
 
+def selected(args) -> list[str]:
+    """Evaluator slugs in scope, honouring --family."""
+    return [s for s, m in EVALUATORS.items()
+            if not args.family or m["family"] == args.family]
+
+
 def exit_code(changed: bool, args) -> int:
     """Finding changes is the expected outcome here, not a failure.
 
@@ -638,7 +763,7 @@ def summary(args) -> int:
     # `files` is an inventory view, not a diff -- there's no verdict to report,
     # so hand each evaluator to diff_one rather than producing bogus rows.
     if args.mode == "files":
-        for slug in EVALUATORS:
+        for slug in selected(args):
             try:
                 diff_one(slug, args)
             except GitError as e:
@@ -650,7 +775,8 @@ def summary(args) -> int:
 
     changed_any = False
     all_notes: set[str] = set()
-    for slug, meta in EVALUATORS.items():
+    for slug in selected(args):
+        meta = EVALUATORS[slug]
         try:
             base_ref, head_ref = resolve(slug, args)
         except GitError as e:
@@ -696,6 +822,10 @@ def main() -> int:
     parser.add_argument("evaluator", nargs="?", help="evaluator slug (see --list)")
     parser.add_argument("--list", action="store_true", help="list known evaluators")
     parser.add_argument("--all", action="store_true", help="verdict table for every evaluator")
+    parser.add_argument(
+        "--family", choices=sorted(FAMILIES), metavar="NAME",
+        help=f"restrict --all to one family ({', '.join(sorted(FAMILIES))})",
+    )
     parser.add_argument(
         "--mode", choices=["content", "roles", "files"], default="content",
         help="content: ignore role/file boundaries (default). "
@@ -760,10 +890,14 @@ def main() -> int:
         fetch()
 
     if args.list:
-        print(f"\n{'SLUG':<30}  {'PR':>5}  WAS")
-        print("-" * 70)
-        for slug, meta in EVALUATORS.items():
-            print(f"{slug:<30}  {meta['pr']:>5}  {meta['old_name']}")
+        for family, root in FAMILIES.items():
+            print(f"\n{c(family, 'bold')}  ({root}/)")
+            print(f"  {'SLUG':<30}  {'PR':>5}  {'CALLS':>5}  WAS")
+            print("  " + "-" * 74)
+            for slug, meta in EVALUATORS.items():
+                if meta["family"] != family:
+                    continue
+                print(f"  {slug:<30}  {meta['pr']:>5}  {len(meta['steps']):>5}  {meta['old_name']}")
         print()
         return 0
 
@@ -772,7 +906,7 @@ def main() -> int:
         if args.emit or args.difftool:
             args.combined = False
             changed = failed = False
-            for slug in EVALUATORS:
+            for slug in selected(args):
                 try:
                     changed |= diff_one(slug, args)
                 except GitError as e:

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -537,7 +537,10 @@ def report(label: str, subtitle: str, base_text: str, head_text: str,
         if args.emit:
             print(f"  wrote {base_file}")
             print(f"  wrote {head_file}")
-        print(f"  {c('visual:', 'cyan')} git difftool --no-index {base_file} {head_file}")
+        # `git diff` rather than `git difftool`: it works everywhere, and picks
+        # up delta (or any configured pager) automatically. --difftool covers
+        # the GUI case.
+        print(f"  {c('visual:', 'cyan')} git diff --no-index {base_file} {head_file}")
         if args.difftool and changed:
             tool = None if args.difftool == "auto" else args.difftool
             open_in_difftool(base_file, head_file, tool)

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -504,6 +504,26 @@ def emit_pair(out_dir: Path, name: str, base_text: str, head_text: str) -> tuple
     return base_file, head_file
 
 
+def print_review_commands(out_dir: Path) -> None:
+    """Print ready-to-run commands for the pairs just written.
+
+    The per-call `visual:` lines are already above, but they're scattered
+    through the output. One loop over the directory beats hunting for them or
+    retyping paths, and the naming convention makes it a one-liner.
+    """
+    pairs = sorted(out_dir.glob("*.BEFORE.txt"))
+    if not pairs:
+        return
+
+    print(f"\n{c('Review all ' + str(len(pairs)) + ' in one go:', 'bold')}")
+    print(f'  for f in {out_dir}/*.BEFORE.txt; do '
+          f'git diff --no-index "$f" "${{f%.BEFORE.txt}}.AFTER.txt"; done')
+    print(f"\n{c('Or one at a time:', 'bold')}")
+    for base_file in pairs:
+        head_file = base_file.with_name(base_file.name.replace(".BEFORE.", ".AFTER."))
+        print(f"  git diff --no-index {base_file} {head_file}")
+
+
 def open_in_difftool(base_file: Path, head_file: Path, tool: str | None) -> None:
     """Hand the pair to `git difftool`.
 
@@ -760,6 +780,7 @@ def main() -> int:
                     failed = True
             if args.emit:
                 print(f"\nAll pairs written to {args.emit}/")
+                print_review_commands(Path(args.emit))
             # A failure is a real error; a change is just the answer.
             return 1 if failed else exit_code(changed, args)
         return summary(args)

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -203,6 +203,20 @@ class GitError(RuntimeError):
     pass
 
 
+# Set once from --no-color, so every styled string honours it -- not just the
+# diff body.
+_USE_COLOR = True
+
+_STYLES = {"bold": "1", "red": "31", "green": "32", "yellow": "33", "cyan": "36"}
+
+
+def c(text: str, style: str) -> str:
+    """Style text, or return it untouched when colour is off."""
+    if not _USE_COLOR:
+        return text
+    return f"\033[{_STYLES[style]}m{text}\033[0m"
+
+
 def git_show(ref: str, path: str) -> str:
     """Read one file at one ref. Raises GitError if it isn't there."""
     result = subprocess.run(
@@ -213,6 +227,44 @@ def git_show(ref: str, path: str) -> str:
     if result.returncode != 0:
         raise GitError(f"{ref}:{path} -- {result.stderr.strip()}")
     return result.stdout
+
+
+def path_exists(ref: str, path: str) -> bool:
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}:{path}"], capture_output=True
+    ).returncode == 0
+
+
+def ref_with_path(ref: str, path: str) -> str:
+    """Return a ref where `path` exists, starting from `ref`.
+
+    Once a migration PR merges, the base-side files are gone from the default
+    branch -- they were `git mv`d away. Reading them at `origin/main` then
+    fails, which would make the whole post-merge fallback useless. So when the
+    path is missing we walk back to the commit that removed it and read from
+    its first parent, i.e. the last state where the file still existed.
+    """
+    if path_exists(ref, path):
+        return ref
+
+    result = subprocess.run(
+        ["git", "rev-list", "-1", ref, "--", path], capture_output=True, text=True
+    )
+    sha = result.stdout.strip()
+    if not sha:
+        raise GitError(f"{path} never existed in the history of {ref}")
+    return f"{sha}^"
+
+
+def fetch(remote: str = "origin") -> None:
+    """Refresh remote-tracking refs.
+
+    The tool reads `origin/<branch>`, which is a local cache. Without this, a
+    prompt pushed to a PR five minutes ago is invisible and the tool would
+    happily report a stale verdict -- worse than an error, because it looks
+    like a real answer.
+    """
+    subprocess.run(["git", "fetch", remote, "--quiet"], capture_output=True)
 
 
 def role_from_filename(path: str) -> str:
@@ -282,9 +334,14 @@ def old_paths_for(slug: str) -> list[str]:
 
 
 def base_messages(ref: str, old_paths: list[str]) -> list[tuple[str, str, str]]:
-    """Read the base side's messages from the manifest's ordered path list."""
+    """Read the base side's messages from the manifest's ordered path list.
+
+    Each path is resolved independently via ref_with_path, so this keeps
+    working after the migration PRs merge and delete the originals.
+    """
     return [
-        (role_from_filename(path), Path(path).name, git_show(ref, path))
+        (role_from_filename(path), Path(path).name,
+         git_show(ref_with_path(ref, path), path))
         for path in old_paths
     ]
 
@@ -389,13 +446,23 @@ def resolve(slug: str, args) -> tuple[str, str]:
 
 
 def prepare(base_msgs, head_msgs, args) -> tuple[str, str, list[str]]:
-    """Render both sides and apply optional normalization."""
+    """Render both sides and apply optional normalization.
+
+    Substitutions from *both* sides are reported. Collecting only the base
+    side's would silently hide a head-only substitution, breaking the
+    guarantee that normalization never conceals a change without saying so.
+    """
     base_text = render(base_msgs, args.mode)
     head_text = render(head_msgs, args.mode)
     notes: list[str] = []
     if args.normalize:
-        base_text, notes = apply_known_renames(base_text)
-        head_text, _ = apply_known_renames(head_text)
+        base_text, base_applied = apply_known_renames(base_text)
+        head_text, head_applied = apply_known_renames(head_text)
+        seen: set[str] = set()
+        for note in base_applied + head_applied:
+            if note not in seen:
+                seen.add(note)
+                notes.append(note)
         base_text, head_text = normalize(base_text), normalize(head_text)
     return base_text, head_text, notes
 
@@ -415,7 +482,7 @@ def report(label: str, subtitle: str, base_text: str, head_text: str,
     """Diff one rendered pair and print the result. Returns True if changed."""
     output, changed = word_diff(base_text, head_text, "before", "after", color=args.color)
 
-    print(f"\n\033[1m{label}\033[0m")
+    print(f"\n{c(label, 'bold')}")
     print(f"  {subtitle}")
     if notes:
         print(f"  normalized: {', '.join(notes)}")
@@ -424,15 +491,15 @@ def report(label: str, subtitle: str, base_text: str, head_text: str,
         base_file, head_file = emit_pair(Path(args.emit), label.split()[0], base_text, head_text)
         print(f"  wrote {base_file}")
         print(f"  wrote {head_file}")
-        print(f"  \033[36mvisual:\033[0m code --diff {base_file} {head_file}")
+        print(f"  {c('visual:', 'cyan')} code --diff {base_file} {head_file}")
 
     if not changed:
-        print("  \033[32mIDENTICAL\033[0m -- restructured only, the model sees the same bytes")
+        print(f"  {c('IDENTICAL', 'green')} -- restructured only, the model sees the same bytes")
     elif not args.emit:
         print()
         print(output)
     else:
-        print("  \033[33mCHANGED\033[0m -- open the pair above in your diff tool")
+        print(f"  {c('CHANGED', 'yellow')} -- open the pair above in your diff tool")
     return changed
 
 
@@ -443,9 +510,10 @@ def diff_one(slug: str, args) -> bool:
     refs = f"{base_ref}  ->  {head_ref}"
 
     if args.mode == "files":
-        print(f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']})")
+        title = f"{meta['old_name']} -> {slug}"
+        print(f"\n{c(title, 'bold')}  (PR #{meta['pr']})")
         for step_id, step_meta in meta["steps"].items():
-            print(f"\n  \033[1mcall: {step_id}\033[0m")
+            print(f"\n  {c(f'call: {step_id}', 'bold')}")
             print(f"    base  {base_ref}")
             for role, source, text in base_messages(base_ref, step_meta["old"]):
                 print(f"      {role:>13}  {source:<28} {len(text):>6} chars")
@@ -457,7 +525,7 @@ def diff_one(slug: str, args) -> bool:
         return False
 
     # Per-LLM-call: one diff per step, the unit that maps to an actual API call.
-    if args.per_call:
+    if not args.combined:
         changed_any = False
         for step_id, step_meta in meta["steps"].items():
             base_msgs = base_messages(base_ref, step_meta["old"])
@@ -484,10 +552,21 @@ def diff_one(slug: str, args) -> bool:
 
 def summary(args) -> int:
     """Verdict table across every evaluator, one row per LLM call."""
+    # `files` is an inventory view, not a diff -- there's no verdict to report,
+    # so hand each evaluator to diff_one rather than producing bogus rows.
+    if args.mode == "files":
+        for slug in EVALUATORS:
+            try:
+                diff_one(slug, args)
+            except GitError as e:
+                print(f"error ({slug}): {e}", file=sys.stderr)
+        return 0
+
     print(f"\n{'EVALUATOR':<30} {'CALL':<38} {'PR':>4}  VERDICT")
     print("=" * 96)
 
     changed_any = False
+    all_notes: set[str] = set()
     for slug, meta in EVALUATORS.items():
         base_ref, head_ref = resolve(slug, args)
         for step_id, step_meta in meta["steps"].items():
@@ -496,21 +575,25 @@ def summary(args) -> int:
                 head_msgs = head_step_messages(
                     head_ref, slug, step_id, step_meta.get("head_extra", [])
                 )
-                base_text, head_text, _ = prepare(base_msgs, head_msgs, args)
+                base_text, head_text, notes = prepare(base_msgs, head_msgs, args)
+                all_notes.update(notes)
                 _, changed = word_diff(base_text, head_text, "a", "b", color=False)
             except GitError as e:
-                print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  \033[31mERROR\033[0m  {e}")
+                print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  {c('ERROR', 'red')}  {e}")
                 changed_any = True
                 continue
 
-            verdict = "\033[33mCHANGED\033[0m" if changed else "\033[32mIDENTICAL\033[0m"
+            verdict = c("CHANGED", "yellow") if changed else c("IDENTICAL", "green")
             changed_any = changed_any or changed
             print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  {verdict}")
 
     print("=" * 96)
     print(f"mode={args.mode}" + (", normalized" if args.normalize else ""))
+    if all_notes:
+        # Never let normalization hide a substitution without naming it.
+        print(f"normalized away: {', '.join(sorted(all_notes))}")
     print("IDENTICAL = this LLM call's prompt is byte-identical after restructuring.")
-    print("Drill in:  scripts/prompt_diff.py <evaluator> --per-call\n")
+    print("Drill in:  scripts/prompt_diff.py <evaluator>\n")
     return 1 if changed_any else 0
 
 
@@ -541,8 +624,11 @@ def main() -> int:
              "drop {format_instructions}) so only unexpected changes surface",
     )
     parser.add_argument(
-        "--per-call", action="store_true",
-        help="one diff per LLM call (config step) instead of one per evaluator",
+        "--combined", action="store_true",
+        help="concatenate all of an evaluator's LLM calls into one diff. Off by "
+             "default: condition-gated branches (Vocabulary Complexity's grade "
+             "bands, for instance) can cancel out when flattened, so a real "
+             "change to one branch could read as IDENTICAL",
     )
     parser.add_argument(
         "--emit", metavar="DIR",
@@ -550,8 +636,21 @@ def main() -> int:
              "diff inline, and print a `code --diff` command for each -- use this "
              "to review in VS Code, Meld, Beyond Compare, or any visual difftool",
     )
+    parser.add_argument(
+        "--no-fetch", dest="fetch", action="store_false",
+        help="skip the `git fetch origin` this runs first. Fetching is the "
+             "default because both sides are read from remote-tracking refs: "
+             "without it, a prompt you just pushed is invisible and the tool "
+             "reports a confident verdict on stale content",
+    )
     parser.add_argument("--no-color", dest="color", action="store_false", help="disable color")
     args = parser.parse_args()
+
+    global _USE_COLOR
+    _USE_COLOR = args.color and sys.stdout.isatty()
+
+    if args.fetch and not args.list:
+        fetch()
 
     if args.list:
         print(f"\n{'SLUG':<30}  {'PR':>5}  WAS")
@@ -564,7 +663,7 @@ def main() -> int:
     if args.all:
         # --emit wants files for every pair, not a verdict table.
         if args.emit:
-            args.per_call = True
+            args.combined = False
             changed = False
             for slug in EVALUATORS:
                 try:

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -599,6 +599,17 @@ def diff_one(slug: str, args) -> bool:
     )
 
 
+def exit_code(changed: bool, args) -> int:
+    """Finding changes is the expected outcome here, not a failure.
+
+    Exiting non-zero for it would make every normal run look like an error --
+    shells paint it red, `&&` chains break. Follows `git diff`, which is 0 by
+    default and only reports differences through the exit status when you ask
+    with --exit-code.
+    """
+    return 1 if (changed and args.exit_code) else 0
+
+
 def summary(args) -> int:
     """Verdict table across every evaluator, one row per LLM call."""
     # `files` is an inventory view, not a diff -- there's no verdict to report,
@@ -650,7 +661,7 @@ def summary(args) -> int:
         print(f"normalized away: {', '.join(sorted(all_notes))}")
     print("IDENTICAL = this LLM call's prompt is byte-identical after restructuring.")
     print("Drill in:  scripts/prompt_diff.py <evaluator>\n")
-    return 1 if changed_any else 0
+    return exit_code(changed_any, args)
 
 
 def main() -> int:
@@ -710,6 +721,12 @@ def main() -> int:
         "--changed-only", action="store_true",
         help="skip calls whose prompt is unchanged",
     )
+    parser.add_argument(
+        "--exit-code", action="store_true",
+        help="exit 1 when any prompt changed, like `git diff --exit-code`. Off "
+             "by default: finding changes is the point, not a failure, and a "
+             "non-zero exit makes every normal run look like an error",
+    )
     parser.add_argument("--no-color", dest="color", action="store_false", help="disable color")
     args = parser.parse_args()
 
@@ -731,15 +748,17 @@ def main() -> int:
         # --emit / --difftool want a pair per call, not a verdict table.
         if args.emit or args.difftool:
             args.combined = False
-            changed = False
+            changed = failed = False
             for slug in EVALUATORS:
                 try:
                     changed |= diff_one(slug, args)
                 except GitError as e:
                     print(f"error ({slug}): {e}", file=sys.stderr)
-                    changed = True
-            print(f"\nAll pairs written to {args.emit}/")
-            return 1 if changed else 0
+                    failed = True
+            if args.emit:
+                print(f"\nAll pairs written to {args.emit}/")
+            # A failure is a real error; a change is just the answer.
+            return 1 if failed else exit_code(changed, args)
         return summary(args)
 
     if not args.evaluator:
@@ -752,12 +771,12 @@ def main() -> int:
         return 2
 
     try:
-        diff_one(args.evaluator, args)
+        changed = diff_one(args.evaluator, args)
     except GitError as e:
         print(f"error: {e}", file=sys.stderr)
         print("hint: run `git fetch origin` if a PR branch is missing", file=sys.stderr)
         return 1
-    return 0
+    return exit_code(changed, args)
 
 
 if __name__ == "__main__":

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -256,15 +256,35 @@ def ref_with_path(ref: str, path: str) -> str:
     return f"{sha}^"
 
 
-def fetch(remote: str = "origin") -> None:
-    """Refresh remote-tracking refs.
+# Where PR refs get cached locally. GitHub publishes every PR head at
+# refs/pull/<N>/head, which beats a branch name on all three counts that
+# matter here: it exists on any clone without the contributor having set up
+# branches, it survives the branch being deleted after merge, and it can't be
+# invalidated by a rename.
+PR_REF_NS = "refs/prompt-diff"
 
-    The tool reads `origin/<branch>`, which is a local cache. Without this, a
-    prompt pushed to a PR five minutes ago is invisible and the tool would
-    happily report a stale verdict -- worse than an error, because it looks
-    like a real answer.
+
+def pr_ref(pr: int) -> str:
+    return f"{PR_REF_NS}/pr-{pr}"
+
+
+def fetch(remote: str = "origin") -> None:
+    """Refresh remote-tracking refs and cache every PR head locally.
+
+    Both sides are read from refs, not the working tree, so a stale ref means
+    a confident verdict on old content -- worse than an error, because it
+    looks like a real answer. Fetching the PR heads in the same round trip is
+    what lets this work on a clone that has never seen the PR branches.
     """
     subprocess.run(["git", "fetch", remote, "--quiet"], capture_output=True)
+
+    refspecs = [
+        f"+refs/pull/{meta['pr']}/head:{pr_ref(meta['pr'])}"
+        for meta in EVALUATORS.values()
+    ]
+    subprocess.run(
+        ["git", "fetch", remote, "--quiet", *refspecs], capture_output=True
+    )
 
 
 def role_from_filename(path: str) -> str:
@@ -432,17 +452,24 @@ def ref_exists(ref: str) -> bool:
 def resolve(slug: str, args) -> tuple[str, str]:
     """Resolve the base and head refs for one evaluator.
 
-    Falls back to the default branch once a PR branch is gone, so this keeps
-    working unchanged after the migration PRs merge and their branches are
-    deleted.
+    Head is tried in descending order of robustness: the cached PR ref (works
+    on any clone, outlives the branch), then the branch itself (covers a
+    local-only branch that was never pushed, and the offline case), then the
+    default branch once the work has merged.
     """
     if args.head:
         return args.base, args.head
 
-    head = EVALUATORS[slug]["head_ref"]
-    if not ref_exists(head):
-        head = args.fallback_head
-    return args.base, head
+    meta = EVALUATORS[slug]
+    for candidate in (pr_ref(meta["pr"]), meta["head_ref"], args.fallback_head):
+        if ref_exists(candidate):
+            return args.base, candidate
+
+    raise GitError(
+        f"no usable head ref for {slug}: tried {pr_ref(meta['pr'])}, "
+        f"{meta['head_ref']}, {args.fallback_head}. "
+        f"Run with network access so PR #{meta['pr']} can be fetched."
+    )
 
 
 def prepare(base_msgs, head_msgs, args) -> tuple[str, str, list[str]]:
@@ -568,7 +595,12 @@ def summary(args) -> int:
     changed_any = False
     all_notes: set[str] = set()
     for slug, meta in EVALUATORS.items():
-        base_ref, head_ref = resolve(slug, args)
+        try:
+            base_ref, head_ref = resolve(slug, args)
+        except GitError as e:
+            print(f"{slug:<30} {'-':<38} {meta['pr']:>4}  {c('ERROR', 'red')}  {e}")
+            changed_any = True
+            continue
         for step_id, step_meta in meta["steps"].items():
             try:
                 base_msgs = base_messages(base_ref, step_meta["old"])

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -58,81 +58,132 @@ EVALUATORS: dict[str, dict] = {
         "old_name": "Grade Level Appropriateness",
         "pr": 159,
         "head_ref": "origin/worktree-ga-gla-prompt-fixes",
-        "old_paths": [
-            "evals/prompts/grade-level-appropriateness/system.txt",
-            "evals/prompts/grade-level-appropriateness/user.txt",
-        ],
+        "steps": {
+            "evaluate_grade_level_appropriateness": {
+                "old": [
+                    "evals/prompts/grade-level-appropriateness/system.txt",
+                    "evals/prompts/grade-level-appropriateness/user.txt",
+                ],
+            },
+        },
     },
     "meaning-directness": {
         "old_name": "Conventionality",
         "pr": 161,
         "head_ref": "origin/worktree-ga-conventionality-fixes",
-        "old_paths": [
-            "evals/prompts/conventionality/system.txt",
-            "evals/prompts/conventionality/user.txt",
-        ],
+        "steps": {
+            "evaluate_conventionality": {
+                "old": [
+                    "evals/prompts/conventionality/system.txt",
+                    "evals/prompts/conventionality/user.txt",
+                ],
+            },
+        },
     },
     "vocabulary-complexity": {
         "old_name": "Vocabulary",
         "pr": 163,
         "head_ref": "origin/worktree-ga-vocabulary-fixes",
-        "old_paths": [
-            "evals/prompts/vocabulary/background-knowledge.txt",
-            "evals/prompts/vocabulary/grades-3-4-system.txt",
-            "evals/prompts/vocabulary/grades-3-4-user.txt",
-            "evals/prompts/vocabulary/other-grades-system.txt",
-            "evals/prompts/vocabulary/other-grades-user.txt",
-        ],
+        "steps": {
+            "background_knowledge": {
+                "old": ["evals/prompts/vocabulary/background-knowledge.txt"],
+            },
+            "vocab_complexity_grades_3_4": {
+                "old": [
+                    "evals/prompts/vocabulary/grades-3-4-system.txt",
+                    "evals/prompts/vocabulary/grades-3-4-user.txt",
+                ],
+            },
+            "vocab_complexity_other_grades": {
+                "old": [
+                    "evals/prompts/vocabulary/other-grades-system.txt",
+                    "evals/prompts/vocabulary/other-grades-user.txt",
+                ],
+            },
+        },
     },
     "background-knowledge-demands": {
         "old_name": "Subject Matter Knowledge",
         "pr": 173,
         "head_ref": "origin/worktree-background-knowledge-demands",
-        "old_paths": [
-            "evals/prompts/subject-matter-knowledge/system.txt",
-            "evals/prompts/subject-matter-knowledge/user.txt",
-        ],
+        "steps": {
+            "evaluate_background_knowledge_demands": {
+                "old": [
+                    "evals/prompts/subject-matter-knowledge/system.txt",
+                    "evals/prompts/subject-matter-knowledge/user.txt",
+                ],
+            },
+        },
     },
     "sentence-structure": {
         "old_name": "Sentence Structure",
         "pr": 174,
         "head_ref": "origin/worktree-sentence-structure",
-        "old_paths": [
-            "evals/prompts/sentence-structure/analysis-system.txt",
-            "evals/prompts/sentence-structure/analysis-user.txt",
-            "evals/prompts/sentence-structure/complexity-system.txt",
-            "evals/prompts/sentence-structure/complexity-user.txt",
-            "evals/prompts/sentence-structure/rubric-grade-3.txt",
-            "evals/prompts/sentence-structure/rubric-grade-4.txt",
-            "evals/prompts/sentence-structure/rubric-grades-5-12.txt",
-        ],
+        "steps": {
+            "sentence_analysis": {
+                "old": [
+                    "evals/prompts/sentence-structure/analysis-system.txt",
+                    "evals/prompts/sentence-structure/analysis-user.txt",
+                ],
+            },
+            "classify_complexity": {
+                "old": [
+                    "evals/prompts/sentence-structure/complexity-system.txt",
+                    "evals/prompts/sentence-structure/complexity-user.txt",
+                    "evals/prompts/sentence-structure/rubric-grade-3.txt",
+                    "evals/prompts/sentence-structure/rubric-grade-4.txt",
+                    "evals/prompts/sentence-structure/rubric-grades-5-12.txt",
+                ],
+                # Interpolated into this step's {rubric}. They're `preprocessing`
+                # entries, and the schema has no source_path for those, so the
+                # config can't tell us they belong to this call -- hence listing
+                # them here. See the note in head_step_messages().
+                "head_extra": [
+                    "rubric-grade-3.txt",
+                    "rubric-grade-4.txt",
+                    "rubric-grades-5-12.txt",
+                ],
+            },
+        },
     },
     "purpose-clarity": {
         "old_name": "Purpose",
         "pr": 175,
         "head_ref": "origin/worktree-purpose-clarity",
-        "old_paths": [
-            "evals/prompts/purpose/system.txt",
-            "evals/prompts/purpose/user.txt",
-        ],
+        "steps": {
+            "evaluate_purpose_clarity": {
+                "old": [
+                    "evals/prompts/purpose/system.txt",
+                    "evals/prompts/purpose/user.txt",
+                ],
+            },
+        },
     },
     "organizational-structure": {
         "old_name": "Organizational Structure",
         "pr": 176,
         "head_ref": "origin/worktree-organizational-structure",
-        "old_paths": [
-            "evals/literacy/qualitative-text-complexity/organizational-structure/system.txt",
-            "evals/literacy/qualitative-text-complexity/organizational-structure/user.txt",
-        ],
+        "steps": {
+            "evaluate_organizational_structure": {
+                "old": [
+                    "evals/literacy/qualitative-text-complexity/organizational-structure/system.txt",
+                    "evals/literacy/qualitative-text-complexity/organizational-structure/user.txt",
+                ],
+            },
+        },
     },
     "reference-knowledge-demands": {
         "old_name": "Intertextuality",
         "pr": 177,
         "head_ref": "origin/worktree-reference-knowledge-demands",
-        "old_paths": [
-            "evals/literacy/qualitative-text-complexity/intertextuality/system.txt",
-            "evals/literacy/qualitative-text-complexity/intertextuality/user.txt",
-        ],
+        "steps": {
+            "evaluate_intertextuality": {
+                "old": [
+                    "evals/literacy/qualitative-text-complexity/intertextuality/system.txt",
+                    "evals/literacy/qualitative-text-complexity/intertextuality/user.txt",
+                ],
+            },
+        },
     },
 }
 
@@ -187,35 +238,47 @@ def ls_tree(ref: str, directory: str) -> list[str]:
     return [Path(line).name for line in result.stdout.splitlines() if line.strip()]
 
 
-def head_messages(ref: str, slug: str) -> list[tuple[str, str, str]]:
-    """Read the head side's prompt files: config-declared messages first, then
-    any remaining .txt files in the directory.
+def head_step_messages(ref: str, slug: str, step_id: str,
+                       extra: list[str]) -> list[tuple[str, str, str]]:
+    """Read one LLM call's prompt files from the head side.
 
-    Driving the ordered part off config.json keeps the tool correct as steps
-    are added or reordered. The trailing sweep exists because not every prompt
-    file is declared as a `messages` entry -- Sentence Structure's grade-band
-    rubrics are `preprocessing` entries interpolated into `{rubric}`, and the
-    schema has no `source_path` for those. Without the sweep they'd read as
-    deletions, which is exactly the false alarm this tool exists to prevent.
+    The declared messages come from config.json, so the tool stays correct as
+    steps are reordered. `extra` covers files the config depends on but cannot
+    name: Sentence Structure's grade-band rubrics are `preprocessing` entries
+    interpolated into `{rubric}`, and config.schema.json has no `source_path`
+    field for preprocessing. Without them the rubrics would read as deletions
+    -- exactly the false alarm this tool exists to prevent.
     """
     base_dir = f"{NEW_DIR}/{slug}"
     config = json.loads(git_show(ref, f"{base_dir}/config.json"))
 
-    messages: list[tuple[str, str, str]] = []
-    declared: set[str] = set()
-    for step in config.get("steps", []):
-        for msg in step.get("prompt", {}).get("messages", []):
-            source = msg["source_path"]
-            declared.add(source)
-            messages.append(
-                (msg.get("role", "user"), source, git_show(ref, f"{base_dir}/{source}"))
-            )
+    step = next((s for s in config.get("steps", []) if s.get("id") == step_id), None)
+    if step is None:
+        known = ", ".join(s.get("id", "?") for s in config.get("steps", []))
+        raise GitError(f"step {step_id!r} not in {ref}:{base_dir}/config.json (has: {known})")
 
-    for name in sorted(ls_tree(ref, base_dir)):
-        if name.endswith(".txt") and name not in declared:
-            messages.append(("undeclared", name, git_show(ref, f"{base_dir}/{name}")))
-
+    messages = [
+        (msg.get("role", "user"), msg["source_path"],
+         git_show(ref, f"{base_dir}/{msg['source_path']}"))
+        for msg in step.get("prompt", {}).get("messages", [])
+    ]
+    messages += [
+        ("interpolated", name, git_show(ref, f"{base_dir}/{name}")) for name in extra
+    ]
     return messages
+
+
+def head_messages(ref: str, slug: str) -> list[tuple[str, str, str]]:
+    """Every prompt file on the head side, all steps concatenated in order."""
+    out: list[tuple[str, str, str]] = []
+    for step_id, step_meta in EVALUATORS[slug]["steps"].items():
+        out += head_step_messages(ref, slug, step_id, step_meta.get("head_extra", []))
+    return out
+
+
+def old_paths_for(slug: str) -> list[str]:
+    """Every base-side path for an evaluator, all steps in order."""
+    return [p for s in EVALUATORS[slug]["steps"].values() for p in s["old"]]
 
 
 def base_messages(ref: str, old_paths: list[str]) -> list[tuple[str, str, str]]:
@@ -325,82 +388,129 @@ def resolve(slug: str, args) -> tuple[str, str]:
     return args.base, head
 
 
-def diff_one(slug: str, args) -> bool:
-    """Diff one evaluator. Returns True if the rendered prompt changed."""
-    meta = EVALUATORS[slug]
-    base_ref, head_ref = resolve(slug, args)
-
-    base_msgs = base_messages(base_ref, meta["old_paths"])
-    head_msgs = head_messages(head_ref, slug)
-
-    if args.mode == "files":
-        print(f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']})")
-        print(f"  base  {base_ref}")
-        for role, source, text in base_msgs:
-            print(f"    {role:>6}  {source:<28} {len(text):>6} chars")
-        print(f"  head  {head_ref}")
-        for role, source, text in head_msgs:
-            print(f"    {role:>6}  {source:<28} {len(text):>6} chars")
-        return False
-
+def prepare(base_msgs, head_msgs, args) -> tuple[str, str, list[str]]:
+    """Render both sides and apply optional normalization."""
     base_text = render(base_msgs, args.mode)
     head_text = render(head_msgs, args.mode)
-
     notes: list[str] = []
     if args.normalize:
-        base_text, applied = apply_known_renames(base_text)
-        notes = applied
+        base_text, notes = apply_known_renames(base_text)
         head_text, _ = apply_known_renames(head_text)
         base_text, head_text = normalize(base_text), normalize(head_text)
+    return base_text, head_text, notes
 
-    output, changed = word_diff(
-        base_text, head_text, meta["old_name"].replace(" ", "-"), slug,
-        color=args.color,
-    )
 
-    header = f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']}, mode={args.mode})"
-    print(header)
-    print(f"  {base_ref}  ->  {head_ref}")
+def emit_pair(out_dir: Path, name: str, base_text: str, head_text: str) -> tuple[Path, Path]:
+    """Write a rendered pair to disk for use with any external diff tool."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base_file = out_dir / f"{name}.BEFORE.txt"
+    head_file = out_dir / f"{name}.AFTER.txt"
+    base_file.write_text(base_text)
+    head_file.write_text(head_text)
+    return base_file, head_file
+
+
+def report(label: str, subtitle: str, base_text: str, head_text: str,
+           notes: list[str], args) -> bool:
+    """Diff one rendered pair and print the result. Returns True if changed."""
+    output, changed = word_diff(base_text, head_text, "before", "after", color=args.color)
+
+    print(f"\n\033[1m{label}\033[0m")
+    print(f"  {subtitle}")
     if notes:
         print(f"  normalized: {', '.join(notes)}")
 
+    if args.emit:
+        base_file, head_file = emit_pair(Path(args.emit), label.split()[0], base_text, head_text)
+        print(f"  wrote {base_file}")
+        print(f"  wrote {head_file}")
+        print(f"  \033[36mvisual:\033[0m code --diff {base_file} {head_file}")
+
     if not changed:
         print("  \033[32mIDENTICAL\033[0m -- restructured only, the model sees the same bytes")
-    else:
+    elif not args.emit:
         print()
         print(output)
+    else:
+        print("  \033[33mCHANGED\033[0m -- open the pair above in your diff tool")
     return changed
 
 
+def diff_one(slug: str, args) -> bool:
+    """Diff one evaluator. Returns True if anything changed."""
+    meta = EVALUATORS[slug]
+    base_ref, head_ref = resolve(slug, args)
+    refs = f"{base_ref}  ->  {head_ref}"
+
+    if args.mode == "files":
+        print(f"\n\033[1m{meta['old_name']} -> {slug}\033[0m  (PR #{meta['pr']})")
+        for step_id, step_meta in meta["steps"].items():
+            print(f"\n  \033[1mcall: {step_id}\033[0m")
+            print(f"    base  {base_ref}")
+            for role, source, text in base_messages(base_ref, step_meta["old"]):
+                print(f"      {role:>13}  {source:<28} {len(text):>6} chars")
+            print(f"    head  {head_ref}")
+            for role, source, text in head_step_messages(
+                head_ref, slug, step_id, step_meta.get("head_extra", [])
+            ):
+                print(f"      {role:>13}  {source:<28} {len(text):>6} chars")
+        return False
+
+    # Per-LLM-call: one diff per step, the unit that maps to an actual API call.
+    if args.per_call:
+        changed_any = False
+        for step_id, step_meta in meta["steps"].items():
+            base_msgs = base_messages(base_ref, step_meta["old"])
+            head_msgs = head_step_messages(
+                head_ref, slug, step_id, step_meta.get("head_extra", [])
+            )
+            base_text, head_text, notes = prepare(base_msgs, head_msgs, args)
+            changed_any |= report(
+                f"{slug}.{step_id}",
+                f"{meta['old_name']} -> {slug}  (PR #{meta['pr']}, call {step_id}, mode={args.mode})\n  {refs}",
+                base_text, head_text, notes, args,
+            )
+        return changed_any
+
+    base_text, head_text, notes = prepare(
+        base_messages(base_ref, old_paths_for(slug)), head_messages(head_ref, slug), args
+    )
+    return report(
+        slug,
+        f"{meta['old_name']} -> {slug}  (PR #{meta['pr']}, all calls, mode={args.mode})\n  {refs}",
+        base_text, head_text, notes, args,
+    )
+
+
 def summary(args) -> int:
-    """Verdict table across every evaluator."""
-    print(f"\n{'EVALUATOR':<30}  {'PR':>5}  {'VERDICT':<12}  BASE -> HEAD")
-    print("=" * 100)
+    """Verdict table across every evaluator, one row per LLM call."""
+    print(f"\n{'EVALUATOR':<30} {'CALL':<38} {'PR':>4}  VERDICT")
+    print("=" * 96)
 
     changed_any = False
     for slug, meta in EVALUATORS.items():
         base_ref, head_ref = resolve(slug, args)
-        try:
-            base_text = render(base_messages(base_ref, meta["old_paths"]), args.mode)
-            head_text = render(head_messages(head_ref, slug), args.mode)
-            if args.normalize:
-                base_text, _ = apply_known_renames(base_text)
-                head_text, _ = apply_known_renames(head_text)
-                base_text, head_text = normalize(base_text), normalize(head_text)
-            _, changed = word_diff(base_text, head_text, "a", "b", color=False)
-        except GitError as e:
-            print(f"{slug:<30}  {meta['pr']:>5}  \033[31mERROR\033[0m         {e}")
-            changed_any = True
-            continue
+        for step_id, step_meta in meta["steps"].items():
+            try:
+                base_msgs = base_messages(base_ref, step_meta["old"])
+                head_msgs = head_step_messages(
+                    head_ref, slug, step_id, step_meta.get("head_extra", [])
+                )
+                base_text, head_text, _ = prepare(base_msgs, head_msgs, args)
+                _, changed = word_diff(base_text, head_text, "a", "b", color=False)
+            except GitError as e:
+                print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  \033[31mERROR\033[0m  {e}")
+                changed_any = True
+                continue
 
-        verdict = "\033[33mCHANGED\033[0m     " if changed else "\033[32mIDENTICAL\033[0m   "
-        changed_any = changed_any or changed
-        print(f"{slug:<30}  {meta['pr']:>5}  {verdict}  {base_ref} -> {head_ref.replace('origin/', '')}")
+            verdict = "\033[33mCHANGED\033[0m" if changed else "\033[32mIDENTICAL\033[0m"
+            changed_any = changed_any or changed
+            print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  {verdict}")
 
-    print("=" * 100)
+    print("=" * 96)
     print(f"mode={args.mode}" + (", normalized" if args.normalize else ""))
-    print("IDENTICAL = prompt text is byte-identical after restructuring; only file layout changed.")
-    print("Run without --all on a CHANGED evaluator to see the word-level diff.\n")
+    print("IDENTICAL = this LLM call's prompt is byte-identical after restructuring.")
+    print("Drill in:  scripts/prompt_diff.py <evaluator> --per-call\n")
     return 1 if changed_any else 0
 
 
@@ -430,6 +540,16 @@ def main() -> int:
         help="canonicalize known placeholder renames ({grade}->{grade_level}, "
              "drop {format_instructions}) so only unexpected changes surface",
     )
+    parser.add_argument(
+        "--per-call", action="store_true",
+        help="one diff per LLM call (config step) instead of one per evaluator",
+    )
+    parser.add_argument(
+        "--emit", metavar="DIR",
+        help="write each rendered BEFORE/AFTER pair to DIR instead of printing the "
+             "diff inline, and print a `code --diff` command for each -- use this "
+             "to review in VS Code, Meld, Beyond Compare, or any visual difftool",
+    )
     parser.add_argument("--no-color", dest="color", action="store_false", help="disable color")
     args = parser.parse_args()
 
@@ -442,6 +562,18 @@ def main() -> int:
         return 0
 
     if args.all:
+        # --emit wants files for every pair, not a verdict table.
+        if args.emit:
+            args.per_call = True
+            changed = False
+            for slug in EVALUATORS:
+                try:
+                    changed |= diff_one(slug, args)
+                except GitError as e:
+                    print(f"error ({slug}): {e}", file=sys.stderr)
+                    changed = True
+            print(f"\nAll pairs written to {args.emit}/")
+            return 1 if changed else 0
         return summary(args)
 
     if not args.evaluator:

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
@@ -505,69 +504,17 @@ def emit_pair(out_dir: Path, name: str, base_text: str, head_text: str) -> tuple
     return base_file, head_file
 
 
-def open_in_difftool(base_file: Path, head_file: Path) -> None:
-    """Launch a side-by-side view. Honours $PROMPT_DIFF_TOOL, else VS Code."""
-    tool = os.environ.get("PROMPT_DIFF_TOOL", "code --diff")
-    subprocess.run([*tool.split(), str(base_file), str(head_file)], capture_output=True)
+def open_in_difftool(base_file: Path, head_file: Path, tool: str | None) -> None:
+    """Hand the pair to `git difftool`.
 
-
-HTML_CSS = """
-body { font: 14px -apple-system, BlinkMacSystemFont, sans-serif; margin: 2rem; color: #1f2328; }
-h1 { font-size: 1.4rem; } h2 { font-size: 1rem; margin-top: 2.5rem; }
-table.diff { font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-             font-size: 12px; border-collapse: collapse; width: 100%;
-             table-layout: fixed; border: 1px solid #d0d7de; }
-table.diff td { padding: 2px 6px; vertical-align: top;
-                white-space: pre-wrap; word-break: break-word; }
-table.diff td.diff_header { background: #f6f8fa; color: #656d76;
-                            text-align: right; width: 3.5rem; user-select: none; }
-.diff_next { display: none; }
-.diff_add { background: #d1f8d4; } .diff_sub { background: #ffd7d5; }
-.diff_chg { background: #fff3c9; }
-.idx a { text-decoration: none; } .idx li { margin: .2rem 0; }
-.ok { color: #1a7f37; } .chg { color: #9a6700; }
-"""
-
-
-def html_report(entries: list[tuple[str, str, str, bool]], out_path: Path,
-                base_ref: str, changed_only: bool) -> Path:
-    """One self-contained side-by-side report for every call.
-
-    Self-contained so it can be handed to someone who doesn't have the repo,
-    a checkout, or a difftool -- they just open it in a browser.
+    Deliberately not a bespoke launcher: git already knows how to drive 25+
+    diff tools and honours whatever the user configured in `diff.tool`, so
+    reinventing that would just be a worse version with its own config.
     """
-    import difflib
-
-    differ = difflib.HtmlDiff(wrapcolumn=80)
-    index, bodies = [], []
-
-    for name, base_text, head_text, changed in entries:
-        if changed_only and not changed:
-            continue
-        status = "chg" if changed else "ok"
-        label = "CHANGED" if changed else "IDENTICAL"
-        index.append(f'<li class="idx"><a href="#{name}">{name}</a> '
-                     f'<span class="{status}">[{label}]</span></li>')
-        bodies.append(f'<h2 id="{name}">{name} <span class="{status}">[{label}]</span></h2>')
-        if changed:
-            bodies.append(differ.make_table(
-                base_text.splitlines(), head_text.splitlines(),
-                fromdesc="BEFORE", todesc="AFTER", context=True, numlines=3,
-            ))
-        else:
-            bodies.append("<p>Byte-identical after restructuring.</p>")
-
-    html = (
-        f"<!doctype html><meta charset=utf-8><title>Prompt diff</title>"
-        f"<style>{HTML_CSS}</style>"
-        f"<h1>Prompt diff &mdash; rendered per LLM call</h1>"
-        f"<p>base <code>{base_ref}</code>. Each section is one LLM call's full "
-        f"rendered prompt, before and after.</p>"
-        f"<ul>{''.join(index)}</ul>{''.join(bodies)}"
-    )
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(html)
-    return out_path
+    cmd = ["git", "difftool", "--no-index", "--no-prompt"]
+    if tool:
+        cmd.append(f"--tool={tool}")
+    subprocess.run([*cmd, str(base_file), str(head_file)])
 
 
 def report(label: str, subtitle: str, base_text: str, head_text: str,
@@ -584,49 +531,25 @@ def report(label: str, subtitle: str, base_text: str, head_text: str,
     if notes:
         print(f"  normalized: {', '.join(notes)}")
 
-    if args.emit or args.open:
+    if args.emit or args.difftool:
         out_dir = Path(args.emit) if args.emit else Path(tempfile.gettempdir()) / "prompt-diff"
         base_file, head_file = emit_pair(out_dir, label.split()[0], base_text, head_text)
         if args.emit:
             print(f"  wrote {base_file}")
             print(f"  wrote {head_file}")
-        tool = os.environ.get("PROMPT_DIFF_TOOL", "code --diff")
-        print(f"  {c('visual:', 'cyan')} {tool} {base_file} {head_file}")
-        if args.open and changed:
-            open_in_difftool(base_file, head_file)
+        print(f"  {c('visual:', 'cyan')} git difftool --no-index {base_file} {head_file}")
+        if args.difftool and changed:
+            tool = None if args.difftool == "auto" else args.difftool
+            open_in_difftool(base_file, head_file, tool)
 
     if not changed:
         print(f"  {c('IDENTICAL', 'green')} -- restructured only, the model sees the same bytes")
-    elif args.emit or args.open:
+    elif args.emit or args.difftool:
         print(f"  {c('CHANGED', 'yellow')} -- open the pair above in your diff tool")
     else:
         print()
         print(output)
     return changed
-
-
-def collect_entries(slugs: list[str], args) -> list[tuple[str, str, str, bool]]:
-    """Render every LLM call for the given evaluators, for the HTML report."""
-    entries: list[tuple[str, str, str, bool]] = []
-    for slug in slugs:
-        meta = EVALUATORS[slug]
-        try:
-            base_ref, head_ref = resolve(slug, args)
-        except GitError as e:
-            print(f"error ({slug}): {e}", file=sys.stderr)
-            continue
-        for step_id, step_meta in meta["steps"].items():
-            try:
-                base_msgs = base_messages(base_ref, step_meta["old"])
-                head_msgs = head_step_messages(
-                    head_ref, slug, step_id, step_meta.get("head_extra", [])
-                )
-                base_text, head_text, _ = prepare(base_msgs, head_msgs, args)
-                _, changed = word_diff(base_text, head_text, "a", "b", color=False)
-                entries.append((f"{slug}.{step_id}", base_text, head_text, changed))
-            except GitError as e:
-                print(f"error ({slug}.{step_id}): {e}", file=sys.stderr)
-    return entries
 
 
 def diff_one(slug: str, args) -> bool:
@@ -714,8 +637,10 @@ def summary(args) -> int:
                 changed_any = True
                 continue
 
-            verdict = c("CHANGED", "yellow") if changed else c("IDENTICAL", "green")
             changed_any = changed_any or changed
+            if args.changed_only and not changed:
+                continue
+            verdict = c("CHANGED", "yellow") if changed else c("IDENTICAL", "green")
             print(f"{slug:<30} {step_id:<38} {meta['pr']:>4}  {verdict}")
 
     print("=" * 96)
@@ -775,15 +700,11 @@ def main() -> int:
              "reports a confident verdict on stale content",
     )
     parser.add_argument(
-        "--open", action="store_true",
-        help="launch a side-by-side view for each CHANGED call. Uses "
-             "$PROMPT_DIFF_TOOL, defaulting to `code --diff`",
-    )
-    parser.add_argument(
-        "--html", metavar="FILE",
-        help="write one self-contained side-by-side HTML report covering every "
-             "call, and open it. Needs no repo, checkout, or difftool to read, "
-             "so it's the format to hand to a reviewer",
+        "--difftool", nargs="?", const="auto", metavar="TOOL",
+        help="open each CHANGED call in `git difftool --no-index`. Uses your "
+             "configured diff.tool by default; pass a name (opendiff, vimdiff, "
+             "meld, bc, kdiff3, ...) to override. `git difftool --tool-help` "
+             "lists what's available",
     )
     parser.add_argument(
         "--changed-only", action="store_true",
@@ -806,23 +727,9 @@ def main() -> int:
         print()
         return 0
 
-    # --html covers one evaluator or all of them, so handle it before the split.
-    if args.html:
-        slugs = list(EVALUATORS) if args.all else [args.evaluator]
-        if not slugs or slugs == [None]:
-            print("--html needs an evaluator or --all", file=sys.stderr)
-            return 2
-        entries = collect_entries(slugs, args)
-        base_ref = resolve(slugs[0], args)[0]
-        out = html_report(entries, Path(args.html), base_ref, args.changed_only)
-        n_changed = sum(1 for _, _, _, ch in entries if ch)
-        print(f"\nwrote {out}  ({n_changed} of {len(entries)} calls changed)")
-        subprocess.run(["open", str(out)], capture_output=True)
-        return 1 if n_changed else 0
-
     if args.all:
-        # --emit wants files for every pair, not a verdict table.
-        if args.emit or args.open:
+        # --emit / --difftool want a pair per call, not a verdict table.
+        if args.emit or args.difftool:
             args.combined = False
             changed = False
             for slug in EVALUATORS:

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -94,7 +94,7 @@ EVALUATORS: dict[str, dict] = {
         "pr": 161,
         "head_ref": "origin/worktree-ga-conventionality-fixes",
         "steps": {
-            "evaluate_conventionality": {
+            "evaluate_meaning_directness": {
                 "old": [
                     "evals/prompts/conventionality/system.txt",
                     "evals/prompts/conventionality/user.txt",
@@ -217,13 +217,13 @@ EVALUATORS: dict[str, dict] = {
     # --- feedback family -------------------------------------------------
     # All seven moved from evals/feedback/productive-coaching-writing-feedback/
     # to evals/feedback/ela-writing/. Single LLM step each, system + user.
-    "strength-acknowledgement": {
+    "strength-acknowledgment": {
         "family": "feedback",
         "old_name": "Acknowledges Strength",
         "pr": 185,
         "head_ref": "origin/feedback-strength-acknowledgement",
         "steps": {
-            "evaluate_strength_acknowledgement": {
+            "evaluate_strength_acknowledgment": {
                 "old": [
                     "evals/feedback/productive-coaching-writing-feedback/acknowledges-strength/system.txt",
                     "evals/feedback/productive-coaching-writing-feedback/acknowledges-strength/user.txt",

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -17,6 +17,10 @@ model change?" -- by rendering each side into one normalized blob, in the
 order the config declares, and diffing that. A pure restructure produces an
 empty diff. Only real wording changes show up.
 
+Diffs are per LLM call (one `steps[]` entry) by default -- the unit that maps
+to an actual API request. `git fetch origin` runs first, so a prompt you just
+pushed to a PR is never reviewed from a stale ref.
+
 Three modes, for three different questions:
 
   content  (default)  Concatenate every message, drop role boundaries.
@@ -27,10 +31,19 @@ Three modes, for three different questions:
                       "Which files went where?"
 
 Usage:
-  scripts/prompt_diff.py --list
-  scripts/prompt_diff.py vocabulary-complexity
-  scripts/prompt_diff.py vocabulary-complexity --mode roles
-  scripts/prompt_diff.py --all
+  scripts/prompt_diff.py --list                      # evaluators + calls, by family
+  scripts/prompt_diff.py --all                       # verdict per LLM call
+  scripts/prompt_diff.py --all --family feedback     # scope to one family
+  scripts/prompt_diff.py --all --changed-only        # only what moved
+  scripts/prompt_diff.py vocabulary-complexity       # drill into one evaluator
+  scripts/prompt_diff.py sentence-structure --mode roles
+  scripts/prompt_diff.py --all --normalize           # hide already-agreed renames
+
+Reviewing visually:
+  scripts/prompt_diff.py <evaluator> --difftool      # via your configured diff.tool
+  scripts/prompt_diff.py --all --emit /tmp/pd        # write pairs + print commands
+
+Any two refs:
   scripts/prompt_diff.py purpose-clarity --base origin/main --head my-branch
 """
 
@@ -852,9 +865,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--emit", metavar="DIR",
-        help="write each rendered BEFORE/AFTER pair to DIR instead of printing the "
-             "diff inline, and print a `code --diff` command for each -- use this "
-             "to review in VS Code, Meld, Beyond Compare, or any visual difftool",
+        help="write each rendered BEFORE/AFTER pair to DIR instead of printing "
+             "the diff inline, then print ready-to-run `git diff --no-index` "
+             "commands for them -- one loop covering every pair, and one per "
+             "call. Use with --difftool, or drive the comparison yourself",
     )
     parser.add_argument(
         "--no-fetch", dest="fetch", action="store_false",

--- a/scripts/prompt_diff.py
+++ b/scripts/prompt_diff.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -504,30 +505,128 @@ def emit_pair(out_dir: Path, name: str, base_text: str, head_text: str) -> tuple
     return base_file, head_file
 
 
+def open_in_difftool(base_file: Path, head_file: Path) -> None:
+    """Launch a side-by-side view. Honours $PROMPT_DIFF_TOOL, else VS Code."""
+    tool = os.environ.get("PROMPT_DIFF_TOOL", "code --diff")
+    subprocess.run([*tool.split(), str(base_file), str(head_file)], capture_output=True)
+
+
+HTML_CSS = """
+body { font: 14px -apple-system, BlinkMacSystemFont, sans-serif; margin: 2rem; color: #1f2328; }
+h1 { font-size: 1.4rem; } h2 { font-size: 1rem; margin-top: 2.5rem; }
+table.diff { font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+             font-size: 12px; border-collapse: collapse; width: 100%;
+             table-layout: fixed; border: 1px solid #d0d7de; }
+table.diff td { padding: 2px 6px; vertical-align: top;
+                white-space: pre-wrap; word-break: break-word; }
+table.diff td.diff_header { background: #f6f8fa; color: #656d76;
+                            text-align: right; width: 3.5rem; user-select: none; }
+.diff_next { display: none; }
+.diff_add { background: #d1f8d4; } .diff_sub { background: #ffd7d5; }
+.diff_chg { background: #fff3c9; }
+.idx a { text-decoration: none; } .idx li { margin: .2rem 0; }
+.ok { color: #1a7f37; } .chg { color: #9a6700; }
+"""
+
+
+def html_report(entries: list[tuple[str, str, str, bool]], out_path: Path,
+                base_ref: str, changed_only: bool) -> Path:
+    """One self-contained side-by-side report for every call.
+
+    Self-contained so it can be handed to someone who doesn't have the repo,
+    a checkout, or a difftool -- they just open it in a browser.
+    """
+    import difflib
+
+    differ = difflib.HtmlDiff(wrapcolumn=80)
+    index, bodies = [], []
+
+    for name, base_text, head_text, changed in entries:
+        if changed_only and not changed:
+            continue
+        status = "chg" if changed else "ok"
+        label = "CHANGED" if changed else "IDENTICAL"
+        index.append(f'<li class="idx"><a href="#{name}">{name}</a> '
+                     f'<span class="{status}">[{label}]</span></li>')
+        bodies.append(f'<h2 id="{name}">{name} <span class="{status}">[{label}]</span></h2>')
+        if changed:
+            bodies.append(differ.make_table(
+                base_text.splitlines(), head_text.splitlines(),
+                fromdesc="BEFORE", todesc="AFTER", context=True, numlines=3,
+            ))
+        else:
+            bodies.append("<p>Byte-identical after restructuring.</p>")
+
+    html = (
+        f"<!doctype html><meta charset=utf-8><title>Prompt diff</title>"
+        f"<style>{HTML_CSS}</style>"
+        f"<h1>Prompt diff &mdash; rendered per LLM call</h1>"
+        f"<p>base <code>{base_ref}</code>. Each section is one LLM call's full "
+        f"rendered prompt, before and after.</p>"
+        f"<ul>{''.join(index)}</ul>{''.join(bodies)}"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html)
+    return out_path
+
+
 def report(label: str, subtitle: str, base_text: str, head_text: str,
            notes: list[str], args) -> bool:
     """Diff one rendered pair and print the result. Returns True if changed."""
     output, changed = word_diff(base_text, head_text, "before", "after", color=args.color)
+
+    # "Show me what changed" usually means only what changed.
+    if args.changed_only and not changed:
+        return False
 
     print(f"\n{c(label, 'bold')}")
     print(f"  {subtitle}")
     if notes:
         print(f"  normalized: {', '.join(notes)}")
 
-    if args.emit:
-        base_file, head_file = emit_pair(Path(args.emit), label.split()[0], base_text, head_text)
-        print(f"  wrote {base_file}")
-        print(f"  wrote {head_file}")
-        print(f"  {c('visual:', 'cyan')} code --diff {base_file} {head_file}")
+    if args.emit or args.open:
+        out_dir = Path(args.emit) if args.emit else Path(tempfile.gettempdir()) / "prompt-diff"
+        base_file, head_file = emit_pair(out_dir, label.split()[0], base_text, head_text)
+        if args.emit:
+            print(f"  wrote {base_file}")
+            print(f"  wrote {head_file}")
+        tool = os.environ.get("PROMPT_DIFF_TOOL", "code --diff")
+        print(f"  {c('visual:', 'cyan')} {tool} {base_file} {head_file}")
+        if args.open and changed:
+            open_in_difftool(base_file, head_file)
 
     if not changed:
         print(f"  {c('IDENTICAL', 'green')} -- restructured only, the model sees the same bytes")
-    elif not args.emit:
+    elif args.emit or args.open:
+        print(f"  {c('CHANGED', 'yellow')} -- open the pair above in your diff tool")
+    else:
         print()
         print(output)
-    else:
-        print(f"  {c('CHANGED', 'yellow')} -- open the pair above in your diff tool")
     return changed
+
+
+def collect_entries(slugs: list[str], args) -> list[tuple[str, str, str, bool]]:
+    """Render every LLM call for the given evaluators, for the HTML report."""
+    entries: list[tuple[str, str, str, bool]] = []
+    for slug in slugs:
+        meta = EVALUATORS[slug]
+        try:
+            base_ref, head_ref = resolve(slug, args)
+        except GitError as e:
+            print(f"error ({slug}): {e}", file=sys.stderr)
+            continue
+        for step_id, step_meta in meta["steps"].items():
+            try:
+                base_msgs = base_messages(base_ref, step_meta["old"])
+                head_msgs = head_step_messages(
+                    head_ref, slug, step_id, step_meta.get("head_extra", [])
+                )
+                base_text, head_text, _ = prepare(base_msgs, head_msgs, args)
+                _, changed = word_diff(base_text, head_text, "a", "b", color=False)
+                entries.append((f"{slug}.{step_id}", base_text, head_text, changed))
+            except GitError as e:
+                print(f"error ({slug}.{step_id}): {e}", file=sys.stderr)
+    return entries
 
 
 def diff_one(slug: str, args) -> bool:
@@ -675,6 +774,21 @@ def main() -> int:
              "without it, a prompt you just pushed is invisible and the tool "
              "reports a confident verdict on stale content",
     )
+    parser.add_argument(
+        "--open", action="store_true",
+        help="launch a side-by-side view for each CHANGED call. Uses "
+             "$PROMPT_DIFF_TOOL, defaulting to `code --diff`",
+    )
+    parser.add_argument(
+        "--html", metavar="FILE",
+        help="write one self-contained side-by-side HTML report covering every "
+             "call, and open it. Needs no repo, checkout, or difftool to read, "
+             "so it's the format to hand to a reviewer",
+    )
+    parser.add_argument(
+        "--changed-only", action="store_true",
+        help="skip calls whose prompt is unchanged",
+    )
     parser.add_argument("--no-color", dest="color", action="store_false", help="disable color")
     args = parser.parse_args()
 
@@ -692,9 +806,23 @@ def main() -> int:
         print()
         return 0
 
+    # --html covers one evaluator or all of them, so handle it before the split.
+    if args.html:
+        slugs = list(EVALUATORS) if args.all else [args.evaluator]
+        if not slugs or slugs == [None]:
+            print("--html needs an evaluator or --all", file=sys.stderr)
+            return 2
+        entries = collect_entries(slugs, args)
+        base_ref = resolve(slugs[0], args)[0]
+        out = html_report(entries, Path(args.html), base_ref, args.changed_only)
+        n_changed = sum(1 for _, _, _, ch in entries if ch)
+        print(f"\nwrote {out}  ({n_changed} of {len(entries)} calls changed)")
+        subprocess.run(["open", str(out)], capture_output=True)
+        return 1 if n_changed else 0
+
     if args.all:
         # --emit wants files for every pair, not a verdict table.
-        if args.emit:
+        if args.emit or args.open:
             args.combined = False
             changed = False
             for slug in EVALUATORS:


### PR DESCRIPTION
Adds `scripts/prompt_diff.py`, a review tool for prompt changes across git refs.

## Why

A plain `git diff` is a poor review tool for the evaluator migration, for two reasons:

1. **Files moved.** `evals/prompts/vocabulary/` → `evals/student-facing-text/ela-reading/vocabulary-complexity/`, so a path-based diff shows every file as deleted-and-added.
2. **Content moved *between* files.** Grade Level Appropriateness's user prompt went from 4938 chars → 22 chars while its system prompt went 563 → 5317: rubric text relocated from one to the other. A per-file diff reports that as a large deletion plus a large addition, when nothing the model actually receives changed.

This renders each side into one normalized blob — every message concatenated in the order `config.json` declares — and word-diffs that. A pure restructure produces an **empty** diff; only real wording changes surface. Word granularity matters for prose: a reflowed paragraph is a whole-line change to a line differ but a no-op to a word differ.

## Usage

```bash
python3 scripts/prompt_diff.py --list           # evaluators it knows about
python3 scripts/prompt_diff.py --all            # verdict table, every evaluator
python3 scripts/prompt_diff.py purpose-clarity  # word-level diff for one
```

| Flag | Purpose |
|------|---------|
| `--mode content` | *(default)* Ignore role/file boundaries. "Did the instruction set change at all?" |
| `--mode roles` | Keep `===== SYSTEM =====` markers. "What moved between system and user prompts?" |
| `--mode files` | File inventory per side, no diff. "Which files went where?" |
| `--normalize` | Canonicalize already-agreed renames (`{grade}`→`{grade_level}`, drop `{format_instructions}`) so only *unexpected* changes remain. Reports which substitutions fired, so nothing hides silently. |
| `--base` / `--head` | Diff any two refs. Defaults: `origin/main` → the evaluator's PR branch. |

Both sides are read with `git show`, so no checkout or worktree is needed — just `git fetch origin` first. Once a PR branch merges and is deleted, that evaluator falls back to `--fallback-head` (default `origin/main`) automatically, so the tool keeps working without edits.

## Current output across the 8 migration PRs

```
EVALUATOR                          PR  VERDICT     (--mode content)
grade-level-appropriateness       159  CHANGED
meaning-directness                161  CHANGED     -> IDENTICAL with --normalize
vocabulary-complexity             163  CHANGED
background-knowledge-demands      173  CHANGED
sentence-structure                174  CHANGED
purpose-clarity                   175  IDENTICAL
organizational-structure          176  IDENTICAL
reference-knowledge-demands       177  IDENTICAL
```

Three evaluators are provably pure restructures. Meaning Directness's only change was the `{grade}` → `{grade_level}` rename. The remaining four have real, reviewable wording changes, each now a handful of word-level edits on one screen instead of a wall of moved text.

## Contract gap this surfaced

Sentence Structure's three grade-band rubric files are `preprocessing` entries (`kind: "load_rubric_text"`), and `config.schema.json` has no `source_path` field for preprocessing entries — so the config never names the files it depends on. Config-driven discovery initially read them as deletions.

The tool works around it by sweeping any `.txt` in the evaluator directory that the config didn't declare, but the underlying gap is real and worth a follow-up: `find_affected.py` builds its notebook dependency closure from the same config data, so those rubric files are currently outside that closure too — editing one would not trigger a notebook re-run. Filing separately rather than expanding this PR.

## Verification

`scripts/check.py` all pass. Exercised all three modes against all 8 evaluators.
