### PR TITLE
feat(evals): allow temperature: null so newer models use their own default

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -149,8 +149,14 @@
           "generation": {
             "type": "object",
             "additionalProperties": false,
+            "required": ["temperature"],
             "properties": {
-              "temperature": { "type": "number", "minimum": 0, "maximum": 1 }
+              "temperature": {
+                "type": ["number", "null"],
+                "minimum": 0,
+                "maximum": 1,
+                "description": "Sampling temperature to send, or null to send nothing so the model uses its own default. Use null for models that require it: Gemini 3 (Google recommends removing the parameter; below 1.0 risks looping and degraded reasoning), GPT-5 (rejects any value but 1 with a 400), and Claude Opus 5 / Opus 4.8 / Opus 4.7 / Sonnet 5 / Fable 5 (sampling parameters removed, 400). Models that still accept one -- Gemini 2.x, GPT-4.x, Claude 4.6 and below -- should carry an explicit number. Required rather than optional so every step records a deliberate choice; an absent key reads as 'nobody considered it'."
+              }
             }
           },
           "parser": {
@@ -166,7 +172,7 @@
         "allOf": [
           {
             "if": { "properties": { "type": { "const": "llm" } } },
-            "then": { "required": ["prompt", "model", "parser"] }
+            "then": { "required": ["prompt", "model", "parser", "generation"] }
           }
         ]
       }


### PR DESCRIPTION
Lets a config express "send no temperature, use the model's own default" — previously `temperature` was `type: number`, so the only option was a value that newer reasoning models reject or silently degrade on.

Schema-only change: one file, `evals/_schemas/config.schema.json`.

## What changes

1. **`temperature` accepts `null`** — send nothing; the model uses its own default.
2. **`temperature` is required** within `generation`, and **`generation` is required** for `llm` steps, so every step records a deliberate choice.
3. **The property description names which families need `null`** (Gemini 3, GPT-5, Claude Opus 5 / 4.8 / 4.7 / Sonnet 5 / Fable 5) and which take a number (Gemini 2.x, GPT-4.x, Claude 4.6 and below), so the rule is at hand when authoring.

Sources: [Gemini 3](https://ai.google.dev/gemini-api/docs/gemini-3) — recommends removing the parameter; below 1.0 risks looping and degraded reasoning. [GPT-5](https://community.openai.com/t/temperature-in-gpt-5-models/1337133) — 400 on anything but 1. Claude Opus 5 / 4.8 / 4.7, Sonnet 5, Fable 5 — sampling parameters removed, 400.

## Merge impact: nothing breaks

Validated every branch's evaluator configs against the new schema — `main` and all eight open evaluator PRs pass. Every existing config already has a `generation` block with a numeric `temperature`, which stays valid.

| Case | Result |
|---|---|
| `0`, `0.7` | valid |
| `null` | valid — the new capability |
| `5`, `"off"` | rejected |
| missing `temperature` / `generation` | rejected |

`scripts/check.py` → 6/6 pass.

## Follow-ups (not in this PR)

- **Flipping evaluators to `null`.** Nothing enforces this — configs on Gemini 3 will stay green while still sending `temperature: 0`, so it needs catching in review. Affected: #159, #161, #173, #175, #176, #177. #163 and #174 are fine — their steps run on tunable models.
- **SDK changes.** `ai-sdk-provider.ts` hardcodes `request.temperature ?? 0` in both `generateStructured` and `generateText`, so **`null` is inert until that's fixed** — sequence it before the flips or they're no-ops. `conventionality.ts` and `smk.ts` also hardcode `temperature: 0` on `gemini-3-flash-preview`. A working implementation is parked on `temperature-followups-wip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
