### PR TITLE
fix(evals): require an explicit temperature of 1 on Gemini 3 steps

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -155,7 +155,7 @@
                 "type": ["number", "null"],
                 "minimum": 0,
                 "maximum": 1,
-                "description": "Sampling temperature to send, or null to send nothing so the model uses its own default. Use null for models that require it: Gemini 3 (Google recommends removing the parameter; below 1.0 risks looping and degraded reasoning), GPT-5 (rejects any value but 1 with a 400), and Claude Opus 5 / Opus 4.8 / Opus 4.7 / Sonnet 5 / Fable 5 (sampling parameters removed, 400). Models that still accept one -- Gemini 2.x, GPT-4.x, Claude 4.6 and below -- should carry an explicit number. Required rather than optional so every step records a deliberate choice; an absent key reads as 'nobody considered it'."
+                "description": "Sampling temperature to send, or null to omit the parameter entirely. Prefer an explicit number: null obliges every client to implement 'omit' correctly, and one that coerces it to 0 silently picks the worst value. Use null only when the model rejects a temperature outright -- Claude Opus 4.7 and later 400 on any non-default value, and the documented guidance there is to omit it. Required so every step records a deliberate choice."
               }
             }
           },

--- a/scripts/checks/eval_config.py
+++ b/scripts/checks/eval_config.py
@@ -37,6 +37,18 @@ _PLACEHOLDER = re.compile(r"\{([a-zA-Z0-9_]+)\}")
 # variants ("format_instructions", "json_format_instructions", …) are caught.
 _OBSOLETE_PLACEHOLDERS = ("format_instructions",)
 
+# Google: "For all Gemini 3 models, we strongly recommend keeping the temperature
+# parameter at its default value of 1.0" -- below 1.0 risks looping and degraded
+# reasoning. Source: https://ai.google.dev/gemini-api/docs/gemini-3
+# We require the 1 to be written out rather than accepting null,
+# because "omit the parameter" is only as safe as the weakest client: our TS
+# provider's `request.temperature ?? 0` turns both null and undefined into 0,
+# the exact value the guidance warns against. Substring match on "gemini-3"
+# mirrors langchain_google_genai._is_gemini_3_or_later; like that function it
+# will need widening when a Gemini 4 lands.
+_GEMINI_3 = "gemini-3"
+_GEMINI_3_TEMPERATURE = 1
+
 
 class EvalConfig(Check):
     name = "eval-config"
@@ -77,6 +89,7 @@ class EvalConfig(Check):
             template_vars = self._check_prompts(prompt, base, fail, step_id)
             self._check_placeholders(prompt, template_vars, fail, step_id)
         self._check_fixtures_path(config, base, fail)
+        self._check_generation(config, fail)
 
     # --- Layer 1: schema -----------------------------------------------------
 
@@ -180,6 +193,21 @@ class EvalConfig(Check):
         path = config.get("fixtures", {}).get("path")
         if path and not os.path.exists(os.path.join(base, path)):
             fail(f"fixtures file not found: {path}")
+
+    @staticmethod
+    def _check_generation(config: dict, fail) -> None:
+        """Gemini 3 steps must pin temperature to an explicit 1 -- see _GEMINI_3."""
+        for step in config.get("steps") or []:
+            if step.get("type") != "llm":
+                continue
+            model = step.get("model", {}).get("name", "")
+            if _GEMINI_3 not in model.lower().replace("models/", ""):
+                continue
+            temperature = step.get("generation", {}).get("temperature")
+            if temperature != _GEMINI_3_TEMPERATURE:
+                fail(f"{step.get('id', '?')}: model {model} is Gemini 3, so "
+                     f"generation.temperature must be an explicit "
+                     f"{_GEMINI_3_TEMPERATURE} (found {temperature!r})")
 
     def _check_stable_ids(self, configs: list[tuple[str, dict]], result: Result) -> None:
         """stable_id is a permanent identity anchor -- it must be globally unique


### PR DESCRIPTION
Adds an `eval-config` rule: any Gemini 3 step must pin `generation.temperature` to an explicit `1`. Also corrects the `temperature` description in the shared schema.

### Why

From Google's Gemini 3 developer guide — [ai.google.dev/gemini-api/docs/gemini-3](https://ai.google.dev/gemini-api/docs/gemini-3), section *Temperature*:

> "For all Gemini 3 models, we strongly recommend keeping the temperature parameter at its default value of `1.0`."
>
> "Changing the temperature (setting it below 1.0) may lead to unexpected behavior, such as looping or degraded performance, particularly in complex mathematical or reasoning tasks."

Confirmed against the API on both models we use. Each reports an advertised default of `1` via [`GET /v1beta/models/{model}`](https://ai.google.dev/api/models#method:-models.get), and each accepts omitted / `1.0` / `0` / `null` with a 200:

| | `gemini-3-flash-preview` | `gemini-3.6-flash` |
|---|---|---|
| advertised default | `1` (max `2`) | `1` (max `2`) |
| omitted / `1.0` / `0` / `null` | all 200 | all 200 |

Nothing rejects a bad value for us — `temperature: 0` returns a clean 200 and quietly degrades — so this has to be caught by a lint rule rather than at runtime.

`null` is deliberately not accepted here. It would mean "omit", which is only as safe as the weakest client, and our TS provider's `request.temperature ?? 0` turns both `null` and `undefined` into `0` — the one value the guidance warns against.

### Changes

- **`scripts/checks/eval_config.py`** — new `_check_generation`: model name containing `gemini-3` requires `temperature == 1`. No model registry; the substring test mirrors `langchain_google_genai._is_gemini_3_or_later` and carries the same caveat about a future Gemini 4. The rationale and source link live in the code comment.
- **`evals/_schemas/config.schema.json`** — the previous description claimed Google "recommends removing the parameter" for Gemini 3. That is wrong; the guidance is to keep it at `1.0`. Rewritten, and cut from ~150 words to ~60. It now also states when `null` *is* correct, which #188 (Claude Opus 5) relies on — see Anthropic's [model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations#api-parameter-deprecations), where `temperature` is deprecated for Opus 4.7 and later and the recommendation is to omit it.

### Sequencing

Blocked on **#175** and **#177**. Two configs on `main` violate the new rule — `prompts/purpose` (`0`) and `qualitative-text-complexity/intertextuality` (`0.0`) — and both files are deleted by those PRs, which already carry `temperature: 1` at the new paths. Fixing them here would only create conflicts, so `eval-config` stays red until they land.

Every other Gemini 3 evaluator is already compliant on its own branch (#159, #161, #173, #175, #176, #177).

### Verification

`strip-notebooks`, `eval-schemas`, `eval-fixtures`, `eval-notebook`, `eval-requirements` pass. `eval-config` fails on exactly the two configs named above and nothing else.
