### PR TITLE
feat: Add organization to Typescript SDK + Refactor purpose to use new framework

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -28,9 +28,9 @@
     "src/batch/README.md"
   ],
   "scripts": {
-    "generate:schemas": "tsx scripts/generate-schema.ts ../../evals/prompts/purpose/config.json ../../evals/literacy/qualitative-text-complexity/intertextuality/config.json",
+    "generate:schemas": "tsx scripts/generate-schema.ts ../../evals/prompts/purpose/config.json ../../evals/literacy/qualitative-text-complexity/intertextuality/config.json ../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json",
     "generate:kg-types": "openapi-typescript https://docs.learningcommons.org/api-reference/knowledge-graph-api/openapi.yaml -o src/knowledge-graph/kg-api.d.ts",
-    "generate:schemas:check": "tsx scripts/generate-schema.ts --check ../../evals/prompts/purpose/config.json ../../evals/literacy/qualitative-text-complexity/intertextuality/config.json",
+    "generate:schemas:check": "tsx scripts/generate-schema.ts --check ../../evals/prompts/purpose/config.json ../../evals/literacy/qualitative-text-complexity/intertextuality/config.json ../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json",
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",

--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -50,6 +50,11 @@ export {
 } from './intertextuality.js';
 
 export {
+  OrganizationalStructureEvaluator,
+  evaluateOrganizationalStructure,
+} from './organizational-structure.js';
+
+export {
   MathStandardsAlignmentEvaluator,
   evaluateMathStandardsAlignment,
   type MathStandardsAlignmentEvaluatorConfig,

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -1,0 +1,66 @@
+import {
+  OrganizationalStructureOutputSchema,
+  type OrganizationalStructureInternal,
+} from '../schemas/organizational_structure.js';
+import { getSystemPrompt, getUserPrompt } from '../prompts/organizational-structure/index.js';
+import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import { Provider, type BaseEvaluatorConfig } from './base.js';
+import {
+  SingleStepRubricEvaluator,
+  findEvaluationStep,
+  findFkImplementation,
+  supportedGradesFrom,
+} from './single-step-rubric.js';
+import CONFIG from '../../../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json';
+import INPUT_SCHEMA from '../../../../evals/literacy/qualitative-text-complexity/organizational-structure/input_schema.json';
+
+const STEP = findEvaluationStep(CONFIG);
+
+// Grade range from input_schema — needed for static metadata, so defined at module level.
+const GRADE_MIN = INPUT_SCHEMA.properties.grade_level.minimum;
+const GRADE_MAX = INPUT_SCHEMA.properties.grade_level.maximum;
+
+// Maps snake_case LLM output → SDK-standard sentence case score.
+const COMPLEXITY_SCORE_DISPLAY: Record<OrganizationalStructureInternal['complexity_score'], TextComplexityLevel> = {
+  'slightly_complex': 'Slightly complex',
+  'moderately_complex': 'Moderately complex',
+  'very_complex': 'Very complex',
+  'exceedingly_complex': 'Exceedingly complex',
+};
+
+export class OrganizationalStructureEvaluator extends SingleStepRubricEvaluator<
+  TextComplexityLevel,
+  OrganizationalStructureInternal
+> {
+  static readonly metadata = {
+    id: CONFIG.evaluator.id,
+    name: CONFIG.evaluator.name,
+    description: CONFIG.evaluator.description,
+    supportedGrades: supportedGradesFrom(GRADE_MIN, GRADE_MAX),
+    defaultProviders: [Provider.Google] as const,
+  };
+
+  constructor(config: BaseEvaluatorConfig) {
+    super(config, {
+      id: CONFIG.evaluator.id,
+      displayName: 'Organizational Structure',
+      step: STEP,
+      gradeMin: GRADE_MIN,
+      gradeMax: GRADE_MAX,
+      defaultProvider: Provider.Google,
+      fkImplementation: findFkImplementation(CONFIG),
+      outputSchema: OrganizationalStructureOutputSchema,
+      scoreDisplay: COMPLEXITY_SCORE_DISPLAY,
+      getSystemPrompt,
+      getUserPrompt,
+    });
+  }
+}
+
+export async function evaluateOrganizationalStructure(
+  text: string,
+  grade: string,
+  config: BaseEvaluatorConfig,
+): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
+  return new OrganizationalStructureEvaluator(config).evaluate(text, grade);
+}

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -1,24 +1,21 @@
-import type { LLMProvider } from '../providers/index.js';
 import { PurposeOutputSchema, type PurposeInternal } from '../schemas/purpose.js';
-import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/purpose/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
-import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
-import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { Provider, type BaseEvaluatorConfig } from './base.js';
+import {
+  SingleStepRubricEvaluator,
+  findEvaluationStep,
+  findFkImplementation,
+  supportedGradesFrom,
+} from './single-step-rubric.js';
 import CONFIG from '../../../../evals/prompts/purpose/config.json';
 import INPUT_SCHEMA from '../../../../evals/prompts/purpose/input_schema.json';
 
-// Step ID convention: "evaluate_{slug}" where slug is the last segment of evaluator.id.
-const STEP_ID = `evaluate_${CONFIG.evaluator.id.split('.').pop()}`;
-const _step = CONFIG.steps.find(s => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in purpose config.json`);
-const STEP = _step;
+const STEP = findEvaluationStep(CONFIG);
 
 // Grade range from input_schema — needed for static metadata, so defined at module level.
 const GRADE_MIN = INPUT_SCHEMA.properties.grade_level.minimum;
 const GRADE_MAX = INPUT_SCHEMA.properties.grade_level.maximum;
-const SUPPORTED_GRADES = Array.from({ length: GRADE_MAX - GRADE_MIN + 1 }, (_, i) => String(GRADE_MIN + i));
 
 export type PurposeComplexityLevel = TextComplexityLevel | 'More context needed';
 
@@ -31,169 +28,29 @@ const COMPLEXITY_SCORE_DISPLAY: Record<PurposeInternal['complexity_score'], Purp
   'more_context_needed': 'More context needed',
 };
 
-export class PurposeEvaluator extends BaseEvaluator {
+export class PurposeEvaluator extends SingleStepRubricEvaluator<PurposeComplexityLevel, PurposeInternal> {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
-    supportedGrades: SUPPORTED_GRADES,
+    supportedGrades: supportedGradesFrom(GRADE_MIN, GRADE_MAX),
     defaultProviders: [Provider.Google] as const,
   };
 
-  private static readonly TEMPERATURE = STEP.generation.temperature;
-
-  private static computeFkScore(text: string): number {
-    const fkStep = CONFIG.preprocessing.find(p => p.id === 'fk_score');
-    if (!fkStep) throw new Error('fk_score preprocessing step not found in purpose config.json');
-    return runPreprocessingStep(text, fkStep.implementation.typescript);
-  }
-
-  private provider: LLMProvider;
-
   constructor(config: BaseEvaluatorConfig) {
-    super(config);
-
-    this.provider = this.createConfiguredProvider(
-      Provider.Google, STEP.model.name, config.googleApiKey
-    );
-  }
-
-  /**
-   * Evaluate purpose complexity for a given text and grade level
-   *
-   * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
-   * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
-   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
-   */
-  async evaluate(text: string, grade: string): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
-    this.logger.info('Starting Purpose evaluation', {
-      evaluator: PurposeEvaluator.metadata.id,
-      operation: 'evaluate',
-      grade,
-      textLength: text.length,
+    super(config, {
+      id: CONFIG.evaluator.id,
+      displayName: 'Purpose',
+      step: STEP,
+      gradeMin: GRADE_MIN,
+      gradeMax: GRADE_MAX,
+      defaultProvider: Provider.Google,
+      fkImplementation: findFkImplementation(CONFIG),
+      outputSchema: PurposeOutputSchema,
+      scoreDisplay: COMPLEXITY_SCORE_DISPLAY,
+      getSystemPrompt,
+      getUserPrompt,
     });
-
-    const startTime = Date.now();
-    const stageDetails: StageDetail[] = [];
-
-    try {
-      this.validateText(text);
-      const gradeNum = this.parseAndValidateGrade(grade);
-
-      const fkScore = PurposeEvaluator.computeFkScore(text);
-      const inputs: Record<string, string> = {
-        text,
-        grade_level: String(gradeNum),
-        fk_score: String(fkScore),
-      };
-      const response = await this.callLLM(inputs);
-
-      const latencyMs = Date.now() - startTime;
-      const tokenUsage = {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-      };
-
-      stageDetails.push({
-        stage: STEP.id,
-        provider: this.provider.label,
-        latency_ms: response.latencyMs,
-        token_usage: tokenUsage,
-      });
-
-      const result: EvaluationResult<PurposeComplexityLevel, PurposeInternal> = {
-        score: COMPLEXITY_SCORE_DISPLAY[response.data.complexity_score],
-        reasoning: response.data.reasoning,
-        metadata: {
-          model: this.provider.label,
-          processingTimeMs: latencyMs,
-          inputTokens: tokenUsage.input_tokens,
-          outputTokens: tokenUsage.output_tokens,
-        },
-        _internal: response.data,
-      };
-
-      this.sendTelemetry({
-        status: 'success',
-        latencyMs,
-        textLength: text.length,
-        grade: String(gradeNum),
-        provider: this.provider.label,
-        tokenUsage,
-        metadata: { stage_details: stageDetails },
-        inputText: text,
-      }).catch(() => undefined);
-
-      this.logger.info('Purpose evaluation completed successfully', {
-        evaluator: PurposeEvaluator.metadata.id,
-        operation: 'evaluate',
-        grade: gradeNum,
-        score: result.score,
-        processingTimeMs: latencyMs,
-      });
-
-      return result;
-    } catch (error) {
-      const latencyMs = Date.now() - startTime;
-
-      this.logger.error('Purpose evaluation failed', {
-        evaluator: PurposeEvaluator.metadata.id,
-        operation: 'evaluate',
-        grade,
-        error: error instanceof Error ? error : undefined,
-        processingTimeMs: latencyMs,
-      });
-
-      const tokenUsage = stageDetails.length > 0
-        ? {
-            input_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.input_tokens ?? 0), 0),
-            output_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.output_tokens ?? 0), 0),
-          }
-        : undefined;
-
-      this.sendTelemetry({
-        status: 'error',
-        latencyMs,
-        textLength: text.length,
-        grade: String(grade),
-        provider: this.provider.label,
-        tokenUsage,
-        errorCode: error instanceof Error ? error.name : 'UnknownError',
-        metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: text,
-      }).catch(() => undefined);
-
-      if (error instanceof ValidationError) throw error;
-      throw wrapProviderError(error, 'Purpose evaluation failed');
-    }
-  }
-
-  private parseAndValidateGrade(grade: string): number {
-    const num = Number(grade.trim());
-    if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
-      throw new ValidationError(
-        `Invalid grade "${grade}". Purpose evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
-      );
-    }
-    return num;
-  }
-
-  private async callLLM(
-    inputs: Record<string, string>,
-  ): Promise<{ data: PurposeInternal; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const response = await this.provider.generateStructured({
-      messages: [
-        { role: 'system', content: getSystemPrompt(inputs) },
-        { role: 'user', content: getUserPrompt(inputs) },
-      ],
-      schema: PurposeOutputSchema,
-      temperature: PurposeEvaluator.TEMPERATURE,
-    });
-
-    return { data: response.data, usage: response.usage, latencyMs: response.latencyMs };
   }
 }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -82,6 +82,9 @@ export type { PurposeInternal } from './schemas/purpose.js';
 // Intertextuality exports
 export type { IntertextualityInternal } from './schemas/intertextuality.js';
 
+// Organizational Structure exports
+export type { OrganizationalStructureInternal } from './schemas/organizational_structure.js';
+
 export {
   VocabularyEvaluator,
   evaluateVocabulary,
@@ -101,6 +104,8 @@ export {
   type PurposeComplexityLevel,
   IntertextualityEvaluator,
   evaluateIntertextuality,
+  OrganizationalStructureEvaluator,
+  evaluateOrganizationalStructure,
   MathStandardsAlignmentEvaluator,
   evaluateMathStandardsAlignment,
   type MathStandardsAlignmentEvaluatorConfig,

--- a/sdks/typescript/src/prompts/organizational-structure/index.ts
+++ b/sdks/typescript/src/prompts/organizational-structure/index.ts
@@ -1,0 +1,8 @@
+import SYSTEM_PROMPT from '../../../../../evals/literacy/qualitative-text-complexity/organizational-structure/system.txt';
+import USER_PROMPT_TEMPLATE from '../../../../../evals/literacy/qualitative-text-complexity/organizational-structure/user.txt';
+import CONFIG from '../../../../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json';
+import { createPromptRenderers } from '../create-prompts.js';
+
+export const { getSystemPrompt, getUserPrompt } = createPromptRenderers(
+  SYSTEM_PROMPT, USER_PROMPT_TEMPLATE, CONFIG,
+);

--- a/sdks/typescript/src/prompts/purpose/index.ts
+++ b/sdks/typescript/src/prompts/purpose/index.ts
@@ -1,23 +1,8 @@
 import SYSTEM_PROMPT from '../../../../../evals/prompts/purpose/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../evals/prompts/purpose/user.txt';
 import CONFIG from '../../../../../evals/prompts/purpose/config.json';
+import { createPromptRenderers } from '../create-prompts.js';
 
-const STEP_ID = `evaluate_${CONFIG.evaluator.id.split('.').pop()}`;
-const _step = CONFIG.steps.find(s => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in purpose config.json`);
-const PLACEHOLDER_KEYS = Object.keys(_step.prompt.placeholders);
-
-function applyPlaceholders(template: string, inputs: Record<string, string>): string {
-  return PLACEHOLDER_KEYS.reduce(
-    (text, key) => key in inputs ? text.replaceAll(`{${key}}`, inputs[key]) : text,
-    template,
-  );
-}
-
-export function getSystemPrompt(inputs: Record<string, string>): string {
-  return applyPlaceholders(SYSTEM_PROMPT, inputs);
-}
-
-export function getUserPrompt(inputs: Record<string, string>): string {
-  return applyPlaceholders(USER_PROMPT_TEMPLATE, inputs);
-}
+export const { getSystemPrompt, getUserPrompt } = createPromptRenderers(
+  SYSTEM_PROMPT, USER_PROMPT_TEMPLATE, CONFIG,
+);

--- a/sdks/typescript/src/schemas/organizational_structure.ts
+++ b/sdks/typescript/src/schemas/organizational_structure.ts
@@ -1,0 +1,10 @@
+// GENERATED — do not edit directly.
+// Source: ../../evals/literacy/qualitative-text-complexity/organizational-structure/output_schema.json
+// Regenerate: npm run generate:schemas
+
+import { z } from 'zod';
+
+// prettier-ignore
+export const OrganizationalStructureOutputSchema = z.object({ "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The Organizational Structure complexity level for the target grade."), "reasoning": z.string().describe("A high-level summary of why the text is at this organizational complexity level for the target grade."), "details": z.object({ "detailed_summary": z.array(z.object({ "factor": z.string().describe("The specific text complexity factor identified."), "description": z.string().describe("How this factor manifests in the text."), "effect_on_complexity_dimension": z.string().describe("How this factor affects the reader's ability to understand the text's specific complexity dimension.") }).strict()).describe("Individual organizational complexity factors with descriptions and their effects."), "adjustment_and_scaffolding": z.array(z.object({ "scaffolding_need": z.string().describe("The complexity factor that requires scaffolding."), "suggestion": z.string().describe("A specific instructional strategy to support students with this factor.") }).strict()).describe("Scaffolding strategies to make the text's structure accessible at the target grade."), "recommended_use_cases": z.array(z.object({ "opportunity": z.string().describe("An instructional opportunity related to the text."), "suggestion": z.string().describe("A specific way to leverage this text for that instructional purpose.") }).strict()).describe("Additional instructional opportunities for using this text's structure.") }).strict().describe("Practical instructional details including scaffolding strategies and recommended use cases.") }).strict();
+
+export type OrganizationalStructureInternal = z.infer<typeof OrganizationalStructureOutputSchema>;

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  OrganizationalStructureEvaluator,
+  evaluateOrganizationalStructure,
+} from '../../../src/evaluators/organizational-structure.js';
+import { Provider } from '../../../src/evaluators/base.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+import CONFIG from '../../../../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json';
+import { getSystemPrompt, getUserPrompt } from '../../../src/prompts/organizational-structure/index.js';
+
+const STEP = CONFIG.steps[0];
+
+const createMockProvider = (config?: { type?: string; model?: string }): LLMProvider => ({
+  label: config?.type && config?.model ? `${config.type}:${config.model}` : 'mock:model',
+  generateStructured: vi.fn(),
+  generateText: vi.fn(),
+});
+
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    createProvider: vi.fn((config) => createMockProvider(config)),
+  };
+});
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class MockTelemetryClient {
+    send = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+const MOCK_RESPONSE = {
+  data: {
+    complexity_score: 'slightly_complex' as const,
+    reasoning: 'Connections between ideas are explicit and the organization is chronological.',
+    details: {
+      detailed_summary: [
+        {
+          factor: 'Chronological organization',
+          description: 'Events are presented in the order they occur.',
+          effect_on_complexity_dimension: 'Readers can follow the structure without inferring connections.',
+        },
+      ],
+      adjustment_and_scaffolding: [
+        { scaffolding_need: 'None required', suggestion: 'Text is accessible as-is.' },
+      ],
+      recommended_use_cases: [
+        { opportunity: 'Independent reading', suggestion: 'Suitable for self-directed reading at grade level.' },
+      ],
+    },
+  },
+  model: STEP.model.name,
+  usage: { inputTokens: 200, outputTokens: 120 },
+  latencyMs: 800,
+};
+
+// --- Constructor ---
+
+describe('OrganizationalStructureEvaluator - Constructor', () => {
+  it('throws when Google API key is missing', () => {
+    expect(() => new OrganizationalStructureEvaluator({ googleApiKey: '' })).toThrow(
+      /Google API key is required/,
+    );
+  });
+});
+
+// --- Metadata derives from config.json ---
+
+describe('OrganizationalStructureEvaluator - Metadata', () => {
+  it('derives id from config.json', () => {
+    expect(OrganizationalStructureEvaluator.metadata.id).toBe(CONFIG.evaluator.id);
+  });
+
+  it('derives name from config.json', () => {
+    expect(OrganizationalStructureEvaluator.metadata.name).toBe(CONFIG.evaluator.name);
+  });
+
+  it('derives description from config.json', () => {
+    expect(OrganizationalStructureEvaluator.metadata.description).toBe(CONFIG.evaluator.description);
+  });
+
+  it('defaultProviders includes Google', () => {
+    expect(OrganizationalStructureEvaluator.metadata.defaultProviders).toContain(Provider.Google);
+  });
+
+  it('defaultProviders does not include OpenAI', () => {
+    expect(OrganizationalStructureEvaluator.metadata.defaultProviders).not.toContain(Provider.OpenAI);
+  });
+
+  it('supports integer grades 3–12', () => {
+    expect(OrganizationalStructureEvaluator.metadata.supportedGrades).toEqual(
+      ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+    );
+  });
+});
+
+// --- Prompt integrity (contract test) ---
+
+describe('OrganizationalStructureEvaluator - Prompt contract', () => {
+  it('system prompt SHA256 matches config.json declaration', () => {
+    const expectedSha = CONFIG.steps[0].prompt.messages[0].sha256;
+    const actualSha = createHash('sha256').update(getSystemPrompt({})).digest('hex');
+    expect(actualSha).toBe(expectedSha);
+  });
+
+  it('user prompt SHA256 matches config.json declaration', () => {
+    const expectedSha = CONFIG.steps[0].prompt.messages[1].sha256;
+    const actualSha = createHash('sha256').update(getUserPrompt({})).digest('hex');
+    expect(actualSha).toBe(expectedSha);
+  });
+
+  it('user prompt substitutes {text}, {grade_level}, and {fk_score}', () => {
+    const prompt = getUserPrompt({ text: 'Sample text here.', grade_level: '5', fk_score: '3.14' });
+    expect(prompt).toContain('Sample text here.');
+    expect(prompt).toContain('5');
+    expect(prompt).toContain('3.14');
+    expect(prompt).not.toContain('{text}');
+    expect(prompt).not.toContain('{grade_level}');
+    expect(prompt).not.toContain('{fk_score}');
+  });
+});
+
+// --- LLM call contract ---
+
+describe('OrganizationalStructureEvaluator - LLM call contract', () => {
+  let evaluator: OrganizationalStructureEvaluator;
+  let mockProvider: LLMProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    evaluator = new OrganizationalStructureEvaluator({ googleApiKey: 'test-key', telemetry: false });
+    // @ts-expect-error accessing private for testing
+    mockProvider = evaluator.provider;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls provider once with model from config.json', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+
+    expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes temperature from config.json', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+
+    const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
+    expect(call.temperature).toBe(STEP.generation.temperature);
+    expect(call.temperature).toBe(1);
+  });
+
+  it('includes text in user prompt', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+    const text = 'Pins are made of either brass or iron wire.';
+
+    await evaluator.evaluate(text, '4');
+
+    const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
+    expect(call.messages[1].content).toContain(text);
+  });
+
+  it('includes grade_level (not grade) in user prompt', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    await evaluator.evaluate('Some sample text for testing purposes.', '7');
+
+    const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
+    expect(call.messages[1].content).toContain('7');
+    expect(call.messages[1].content).not.toContain('{grade_level}');
+  });
+
+  it('includes computed fk_score in user prompt', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    await evaluator.evaluate('The quick brown fox jumps over the lazy dog.', '5');
+
+    const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
+    expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
+  });
+
+  it('maps LLM response to result shape', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+
+    expect(result.score).toBe('Slightly complex');
+    expect(result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
+    expect(result.metadata.model).toBe(`${STEP.model.provider}:${STEP.model.name}`);
+    expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.metadata.inputTokens).toBe(200);
+    expect(result.metadata.outputTokens).toBe(120);
+    expect(result._internal).toEqual(MOCK_RESPONSE.data);
+    expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
+    expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
+    expect(result._internal?.details.recommended_use_cases).toBeInstanceOf(Array);
+  });
+
+  it('reflects modelOverride in metadata.model', async () => {
+    const overrideEvaluator = new OrganizationalStructureEvaluator({
+      anthropicApiKey: 'test-key',
+      modelOverride: { provider: Provider.Anthropic, model: 'claude-haiku-4-5-20251001' },
+      telemetry: false,
+    });
+    // @ts-expect-error accessing private for testing
+    const overrideProvider: LLMProvider = overrideEvaluator.provider;
+
+    vi.mocked(overrideProvider.generateStructured).mockResolvedValue({
+      data: {
+        complexity_score: 'slightly_complex' as const,
+        reasoning: 'Clear chronological structure.',
+        details: {
+          detailed_summary: [],
+          adjustment_and_scaffolding: [],
+          recommended_use_cases: [],
+        },
+      },
+      model: 'claude-haiku-4-5-20251001',
+      usage: { inputTokens: 100, outputTokens: 50 },
+      latencyMs: 300,
+    });
+
+    const result = await overrideEvaluator.evaluate(
+      'When going to the beach, find out which ones have lifeguards.', '3'
+    );
+
+    expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
+  });
+
+  it('evaluateOrganizationalStructure convenience function returns the same result shape', async () => {
+    const injectedProvider = createMockProvider();
+    vi.mocked(injectedProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    const result = await evaluateOrganizationalStructure(
+      'When going to the beach, find out which ones have lifeguards.', '3',
+      { llmProvider: injectedProvider, telemetry: false },
+    );
+
+    expect(result.score).toBe('Slightly complex');
+    expect(injectedProvider.generateStructured).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts string grade (consistent with all other evaluators)', async () => {
+    vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
+
+    await expect(
+      evaluator.evaluate('Some text long enough to evaluate.', '5'),
+    ).resolves.toBeDefined();
+  });
+});
+
+// --- Validation ---
+
+describe('OrganizationalStructureEvaluator - Validation', () => {
+  let evaluator: OrganizationalStructureEvaluator;
+  let mockProvider: LLMProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    evaluator = new OrganizationalStructureEvaluator({ googleApiKey: 'test-key', telemetry: false });
+    // @ts-expect-error accessing private for testing
+    mockProvider = evaluator.provider;
+  });
+
+  it('rejects grade below 3', async () => {
+    await expect(evaluator.evaluate('Some text.', '2')).rejects.toThrow(/Invalid grade/);
+    expect(mockProvider.generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('rejects grade above 12', async () => {
+    await expect(evaluator.evaluate('Some text.', '13')).rejects.toThrow(/Invalid grade/);
+    expect(mockProvider.generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty text', async () => {
+    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    expect(mockProvider.generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('rejects text below minimum length', async () => {
+    await expect(evaluator.evaluate('Short', '5')).rejects.toThrow();
+    expect(mockProvider.generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('propagates LLM errors', async () => {
+    vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
+
+    await expect(
+      evaluator.evaluate('The beach is a fun place to swim and play in the sun.', '4'),
+    ).rejects.toThrow('API timeout');
+  });
+});


### PR DESCRIPTION
Adding QTC Organization evaluator using the new framework + refactoring purpose to use that framework.
For potential follow-ups:
I will add batch handling in a follow-up PR.
I could also refactor SMK and Conventionality to use this framework too if we're okay with them not having explicit config files. Per Claude:

```- SMK and Conventionality — surprisingly close fits. Both are exactly the framework's shape: one structured LLM call, Gemini Flash on Google, FK-score preprocessing, and their output schemas already have complexity_score + reasoning (their LLMs emit the sentence-case levels directly, so the scoreDisplay map would just be an identity mapping — which the types allow). The one philosophical wrinkle: they have no config.json in evals/, so the spec values (model, temperature, ID) would be hardcoded in TS rather than config-derived. You'd get the deduplication benefit now, and if these evaluators later get proper config-driven definitions, they'd slot in fully.```
**Thanks for your interest in our project\!**

This repository is currently being maintained internally, so we’re not accepting external contributors.

However, if you’ve discovered a bug or have a feature suggestion, please feel free to open an issue or reach out to us at [support@learningcommons.org](mailto:support@learningcommons.org). 

If you believe you have found a security issue, please responsibly disclose by contacting us at [security@learningcommons.org](mailto:security@learningcommons.org).

If you are interested in partnering with us, fill out [this form](https://learningcommons.org/contact/?utm_source=github&utm_medium=overview&utm_campaign=privatebeta) to get in touch.
