### PR TITLE
fix(ts-sdk): omit temperature when the registry sends none

### DIFF
--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -124,7 +124,7 @@ export interface MathStandardsAlignmentEvaluatorConfig extends BaseEvaluatorConf
 // ---------------------------------------------------------------------------
 
 const DETAIL_MODEL: string = STEP.model.name;
-const TEMPERATURE: number = STEP.generation.temperature;
+const TEMPERATURE: number | null = STEP.generation.temperature;
 const KG_SUBJECT = 'Mathematics';
 /**
  * Above this many question/standard pairs, evaluateByGrade warns. A grade can carry
@@ -600,6 +600,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
           { role: 'user', content: getCoarseFilterPrompt({ question, standards: standardList }) },
         ],
         schema: CoarseFilterSchema,
+        temperature: TEMPERATURE,
       });
 
       const relevant = new Set<string>();

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -45,7 +45,9 @@ export class VercelAIProvider implements LLMProvider {
       ...(systemMsg ? { system: systemMsg.content } : {}),
       messages: nonSystemMessages,
       output: Output.object({ schema: request.schema }),
-      temperature: request.temperature ?? 0,
+      // A null temperature means "send nothing" — see config.schema.json for
+      // which models require that.
+      ...(request.temperature != null ? { temperature: request.temperature } : {}),
       maxRetries: this.config.maxRetries ?? 0,
       // maxOutputTokens is the vendor option; `maxTokens` is silently discarded.
       ...(request.maxTokens !== undefined ? { maxOutputTokens: request.maxTokens } : {}),
@@ -65,18 +67,25 @@ export class VercelAIProvider implements LLMProvider {
   /**
    * Generate plain text using Vercel AI SDK's generateText
    */
-  async generateText(messages: Message[], temperature?: number): Promise<import('./base.js').TextGenerationResponse> {
+  async generateText(
+    messages: Message[],
+    temperature?: number | null
+  ): Promise<import('./base.js').TextGenerationResponse> {
     const model = await this.getModel();
     const startTime = Date.now();
 
     const systemMsg = messages.find((m) => m.role === 'system');
     const nonSystemMessages = messages.filter((m) => m.role !== 'system');
+    // Only an absent argument falls back to config; an explicit null means
+    // "send nothing" and must not be overridden by it.
+    const effectiveTemperature =
+      temperature === undefined ? this.config.temperature : temperature;
 
     const { text, usage } = await aiGenerateText({
       model,
       ...(systemMsg ? { system: systemMsg.content } : {}),
       messages: nonSystemMessages,
-      temperature: temperature ?? this.config.temperature ?? 0,
+      ...(effectiveTemperature != null ? { temperature: effectiveTemperature } : {}),
       maxRetries: this.config.maxRetries ?? 0,
     });
 

--- a/sdks/typescript/src/providers/base.ts
+++ b/sdks/typescript/src/providers/base.ts
@@ -14,7 +14,8 @@ export interface Message {
 export interface LLMRequest<T> {
   messages: Message[];
   schema: z.ZodSchema<T>;
-  temperature?: number;
+  /** `null` sends no temperature at all, for models that reject an explicit value. */
+  temperature?: number | null;
   maxTokens?: number;
 }
 
@@ -56,9 +57,10 @@ export interface LLMProvider {
   generateStructured<T>(request: LLMRequest<T>): Promise<LLMResponse<T>>;
 
   /**
-   * Generate plain text from LLM
+   * Generate plain text from LLM. `null` sends no temperature; omitting the
+   * argument falls back to `ProviderConfig.temperature`.
    */
-  generateText(messages: Message[], temperature?: number): Promise<TextGenerationResponse>;
+  generateText(messages: Message[], temperature?: number | null): Promise<TextGenerationResponse>;
 }
 
 /**
@@ -78,7 +80,8 @@ export interface ProviderConfig {
   type: 'openai' | 'anthropic' | 'google' | 'custom';
   apiKey?: string;
   model?: string;
-  temperature?: number;
+  /** `null` sends no temperature at all. */
+  temperature?: number | null;
   baseURL?: string;
   customProvider?: LLMProvider;
   maxRetries?: number;

--- a/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
+++ b/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
@@ -204,3 +204,160 @@ describe('VercelAIProvider - maxTokens', () => {
     expect(generateText.mock.calls[0][0]).not.toHaveProperty('maxOutputTokens');
   });
 });
+
+describe('VercelAIProvider - temperature', () => {
+  const CONFIG: ProviderConfig = { type: 'openai', model: 'gpt-4o-mini', apiKey: 'k' };
+  const schema = z.object({ ok: z.boolean() });
+  const messages = [{ role: 'user' as const, content: 'hi' }];
+
+  it('omits temperature from generateStructured when null', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema, temperature: null });
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  it('omits temperature from generateStructured when undefined', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema });
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  it('forwards an explicit temperature, including 0', async () => {
+    const { mod, generateText } = await loadProvider();
+    const provider = new mod.VercelAIProvider(CONFIG);
+
+    await provider.generateStructured({ messages, schema, temperature: 0 });
+    expect(generateText.mock.calls[0][0].temperature).toBe(0);
+
+    await provider.generateStructured({ messages, schema, temperature: 1 });
+    expect(generateText.mock.calls[1][0].temperature).toBe(1);
+  });
+
+  it('omits temperature from generateText when neither argument nor config supplies one', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateText(messages);
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  it('falls back to the provider config temperature in generateText', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider({ ...CONFIG, temperature: 0.5 }).generateText(messages);
+
+    expect(generateText.mock.calls[0][0].temperature).toBe(0.5);
+  });
+  it('lets an explicit null override a config temperature', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider({ ...CONFIG, temperature: 0.5 }).generateText(messages, null);
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+
+  it('lets an explicit 0 override a config temperature', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider({ ...CONFIG, temperature: 0.5 }).generateText(messages, 0);
+
+    expect(generateText.mock.calls[0][0].temperature).toBe(0);
+  });
+
+  it('omits temperature when config sets it to null', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider({ ...CONFIG, temperature: null }).generateText(messages);
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+  // generateStructured deliberately ignores ProviderConfig.temperature: the
+  // registry value travels per request, so a config default would silently
+  // override what an evaluator asked for.
+  it('does not consult the config temperature in generateStructured', async () => {
+    const { mod, generateText } = await loadProvider();
+    const provider = new mod.VercelAIProvider({ ...CONFIG, temperature: 0.5 });
+
+    await provider.generateStructured({ messages, schema });
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('temperature');
+
+    await provider.generateStructured({ messages, schema, temperature: null });
+    expect(generateText.mock.calls[1][0]).not.toHaveProperty('temperature');
+
+    await provider.generateStructured({ messages, schema, temperature: 0 });
+    expect(generateText.mock.calls[2][0].temperature).toBe(0);
+  });
+});
+
+describe('VercelAIProvider - request assembly', () => {
+  const CONFIG: ProviderConfig = { type: 'openai', model: 'gpt-4o-mini', apiKey: 'k' };
+  const schema = z.object({ ok: z.boolean() });
+
+  const CONVERSATION = [
+    { role: 'system' as const, content: 'you are a rater' },
+    { role: 'user' as const, content: 'rate this' },
+    { role: 'assistant' as const, content: 'ok' },
+  ];
+
+  it('hoists the system message and excludes it from messages', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages: CONVERSATION, schema });
+
+    const call = generateText.mock.calls[0][0];
+    expect(call.system).toBe('you are a rater');
+    expect(call.messages).toEqual([
+      { role: 'user', content: 'rate this' },
+      { role: 'assistant', content: 'ok' },
+    ]);
+  });
+
+  it('omits system entirely when no system message is present', async () => {
+    const { mod, generateText } = await loadProvider();
+    const messages = [{ role: 'user' as const, content: 'rate this' }];
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema });
+
+    const call = generateText.mock.calls[0][0];
+    expect(call).not.toHaveProperty('system');
+    expect(call.messages).toEqual(messages);
+  });
+
+  it('hoists the system message in generateText too', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateText(CONVERSATION);
+
+    const call = generateText.mock.calls[0][0];
+    expect(call.system).toBe('you are a rater');
+    expect(call.messages.map((m: { role: string }) => m.role)).toEqual(['user', 'assistant']);
+  });
+
+  it('defaults maxRetries to 0 so the SDK owns retry policy, and honours an explicit value', async () => {
+    const { mod, generateText } = await loadProvider();
+    const messages = [{ role: 'user' as const, content: 'hi' }];
+
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema });
+    expect(generateText.mock.calls[0][0].maxRetries).toBe(0);
+
+    await new mod.VercelAIProvider({ ...CONFIG, maxRetries: 3 }).generateStructured({ messages, schema });
+    expect(generateText.mock.calls[1][0].maxRetries).toBe(3);
+  });
+});
+
+describe('createProvider - custom provider dispatch', () => {
+  const custom = () => ({
+    label: 'custom:thing',
+    generateStructured: vi.fn(),
+    generateText: vi.fn(),
+  });
+
+  it('ignores a stray customProvider on a vendor type', async () => {
+    const { mod } = await loadProvider();
+    const vendor = mod.createProvider({ type: 'openai', model: 'gpt-4o-mini', customProvider: custom() });
+
+    expect(vendor).toBeInstanceOf(mod.VercelAIProvider);
+  });
+
+  it('rejects the custom type with no instance rather than falling through', async () => {
+    const { mod } = await loadProvider();
+
+    expect(() => mod.createProvider({ type: 'custom' })).toThrow(
+      'VercelAIProvider does not support custom type',
+    );
+  });
+});


### PR DESCRIPTION
`request.temperature ?? 0` coerced a null or absent temperature to `0`. Temperature is now omitted entirely when null or absent, so the model applies its own default.

This matters for two live cases: Claude Opus 4.7 and later return a 400 for any explicit temperature, and Gemini 3 degrades below 1.0 — so `0` was the worst available default.

### Changes

- Both `generateStructured` and `generateText` omit the parameter rather than defaulting it.
- `LLMRequest.temperature`, `ProviderConfig.temperature` and `LLMProvider.generateText` all accept `number | null`, so "send nothing" is expressible everywhere rather than only internally.
- `generateText` falls back to `ProviderConfig.temperature` only when the argument is **absent**. An explicit `null` wins over config — with `??` it did not, which made "omit" unexpressible on that path and inconsistent with `generateStructured`.
- `math/standards-alignment.ts`: the **coarse filter now passes `TEMPERATURE` explicitly**. It was the one `generateStructured` call site relying on the old `?? 0`, so removing that coercion would have silently moved it to the vendor default. It is a fail-open relevance filter, so the regression would have surfaced as nondeterministic extra LLM work rather than an error.
- `TEMPERATURE` is typed `number | null`, so a registry value of `null` compiles rather than failing typecheck at the JSON import boundary.

### Tests

Mutation testing on `src/providers` (StrykerJS, ad-hoc — nothing committed):

| | before | after |
|---|---|---|
| score | 67.89% | **95.41%** |
| survived | 32 | 5 |
| no coverage | 3 | 0 |

Zero survivors on the temperature logic. The run also exposed pre-existing gaps in the same file, now covered: nothing asserted that the system message is hoisted into `system` and excluded from `messages`, and nothing pinned the `maxRetries` default.

Worth knowing which tests actually guard this change: the load-bearing ones are the four `.not.toHaveProperty('temperature')` assertions and the two that only compile because of the type widening. The "forwards an explicit temperature, including 0" and "falls back to config" cases would also pass under the old `?? 0`, so they document intent rather than catching a revert.

The 5 remaining survivors are equivalent mutants — two `Date.now() - startTime` → `+` (asserting exact latency would be brittle) and a schema-object mutant the test double cannot observe.

541/541 unit tests pass · `tsc --noEmit` clean · lint 0 errors · `package-lock.json` unchanged.

### Note for consumers

Callers of `generateStructured` who pass no temperature move from a deterministic `0` to the vendor default. Every in-repo evaluator passes one explicitly after this PR, so nothing internal changes — but a direct user of the exported `VercelAIProvider` would see it.
