### PR TITLE
refactor(ts-sdk)!: fault-domain error taxonomy with structured classification

### DIFF
--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -34,7 +34,7 @@ export type DependencyId = 'openai' | 'google' | 'anthropic' | 'knowledge-graph'
  * prefix. `knowledge-graph` never does — that client raises its own errors — and
  * `custom` is the fallback for a label none of these match, not a match itself.
  */
-export const PROVIDER_DEPENDENCIES: ReadonlySet<DependencyId> = new Set<DependencyId>([
+export const PROVIDER_DEPENDENCIES: ReadonlySet<string> = new Set<DependencyId>([
   'openai',
   'google',
   'anthropic',
@@ -189,10 +189,18 @@ const NETWORK_CODES = new Set([
 
 /** Timeouts, by Node errno or the DOMException name `AbortSignal.timeout` raises. */
 const TIMEOUT_CODES = new Set(['ETIMEDOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT']);
-const TIMEOUT_NAMES = new Set(['TimeoutError', 'AbortError']);
+/**
+ * Only `TimeoutError`, which is what `AbortSignal.timeout` raises. `AbortError`
+ * is deliberate caller cancellation — retrying that would re-issue a request
+ * the caller just called off, so it stays in the non-retryable catch-all.
+ */
+const TIMEOUT_NAMES = new Set(['TimeoutError']);
 
 /** Header names providers use for the request ID, in preference order. */
 const REQUEST_ID_HEADERS = ['x-request-id', 'request-id', 'x-amzn-requestid'];
+
+/** Beyond this, a `Retry-After` is more likely malformed than meant. */
+const MAX_RETRY_AFTER_MS = 60 * 60 * 1000;
 
 interface ProviderSignals {
   message: string;
@@ -212,18 +220,35 @@ function* causeChain(error: unknown): Generator<unknown> {
   }
 }
 
+/**
+ * A delay is only usable if it is a positive, finite, plausible number of
+ * milliseconds. `Number('')` is `0`, and a zero delay reads as "retry now",
+ * which is worse than having no hint at all — so anything non-positive, and
+ * anything past the ceiling, is discarded.
+ */
+function usableDelayMs(value: number): number | null {
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return Math.min(Math.round(value), MAX_RETRY_AFTER_MS);
+}
+
 function readRetryAfterMs(headers: Record<string, string> | undefined): number | null {
-  const seconds = headers?.['retry-after'];
+  if (!headers) return null;
+  // `Retry-After` may also be an HTTP-date, which is not a delay we can use.
+  const seconds = lookupHeader(headers, 'retry-after');
   if (seconds !== undefined) {
-    const parsed = Number(seconds);
-    if (Number.isFinite(parsed)) return Math.round(parsed * 1000);
+    const fromSeconds = usableDelayMs(Number(seconds) * 1000);
+    if (fromSeconds !== null) return fromSeconds;
   }
-  const ms = headers?.['retry-after-ms'];
-  if (ms !== undefined) {
-    const parsed = Number(ms);
-    if (Number.isFinite(parsed)) return Math.round(parsed);
-  }
-  return null;
+  const ms = lookupHeader(headers, 'retry-after-ms');
+  return ms === undefined ? null : usableDelayMs(Number(ms));
+}
+
+/** Header names are case-insensitive; a custom `fetch` may not normalise them. */
+function lookupHeader(headers: Record<string, string>, name: string): string | undefined {
+  const direct = headers[name];
+  if (direct !== undefined) return direct;
+  const match = Object.keys(headers).find((key) => key.toLowerCase() === name);
+  return match === undefined ? undefined : headers[match];
 }
 
 /**
@@ -244,15 +269,24 @@ function readProviderSignals(error: unknown): ProviderSignals {
     return {
       ...base,
       statusCode: link.statusCode ?? null,
-      requestId: REQUEST_ID_HEADERS.map((h) => headers?.[h]).find((v) => v != null) ?? null,
+      requestId:
+        headers === undefined
+          ? null
+          : REQUEST_ID_HEADERS.map((h) => lookupHeader(headers, h)).find((v) => v != null) ?? null,
       retryable: link.isRetryable,
       retryAfterMs: readRetryAfterMs(headers),
     };
   }
 
-  // Not an AI SDK error: fall back to the loose properties other clients set.
-  const loose = error as { statusCode?: number; status?: number };
-  return { ...base, statusCode: loose?.statusCode ?? loose?.status ?? null };
+  // No AI SDK error in the chain: fall back to the loose properties other
+  // clients set. Searched along the chain too, since a bring-your-own provider
+  // typically wraps its vendor's error rather than re-raising it.
+  for (const link of causeChain(error)) {
+    const loose = link as { statusCode?: unknown; status?: unknown };
+    const status = typeof loose?.statusCode === 'number' ? loose.statusCode : loose?.status;
+    if (typeof status === 'number') return { ...base, statusCode: status };
+  }
+  return base;
 }
 
 /** Schema/parse failures are the model's fault, not the dependency's. */
@@ -298,13 +332,15 @@ export function wrapProviderError(
     statusCode,
     requestId: signals.requestId,
     model: context.model ?? null,
-    retryable: signals.retryable,
     cause: error,
   };
 
-  // The model returned something unusable — our fault to re-sample, not the
-  // dependency's to fix, so this outranks any transport signal.
-  if (isOutputProcessingFailure(error)) {
+  // A parse failure carrying an HTTP error status is the server erroring, not
+  // the model: the body is an error page, not a malformed completion. Treating
+  // it as our own output failure would resample immediately against a service
+  // that is already failing, so only unparseable *successful* responses count.
+  const httpFailed = statusCode !== null && statusCode >= 400;
+  if (!httpFailed && isOutputProcessingFailure(error)) {
     return new LLMOutputProcessingError(message, null, error);
   }
 
@@ -325,5 +361,12 @@ export function wrapProviderError(
   if (transport === 'timeout') return new RequestTimeoutError(message, options);
   if (transport === 'network') return new NetworkError(message, options);
 
-  return new LLMProviderError(message || 'API request failed', options);
+  // The dependency's own verdict only reaches the catch-all, whose class rule is
+  // "retryable iff 5xx" and so genuinely benefits from it. Classes with a
+  // definite policy keep theirs — an upstream flag must not make an auth failure
+  // retryable. It can only widen: a `false` never defeats the 5xx floor.
+  return new LLMProviderError(message || 'API request failed', {
+    ...options,
+    ...(signals.retryable === true ? { retryable: true } : {}),
+  });
 }

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -1,301 +1,212 @@
 /**
- * Custom error types for the Evaluators SDK
+ * Canonical error taxonomy.
  *
- * This module provides a hierarchy of error types to help users
- * distinguish between different error scenarios and implement
- * appropriate error handling strategies.
+ * Errors classify by **fault domain** — who must act — not by mechanism:
+ * caller (`ConfigurationError`, `InputValidationError`), our own evaluation
+ * logic (`EvaluationError`), or an external system (`DependencyError`).
+ *
+ * `retryable` is data, not hierarchy: callers read the flag rather than
+ * memorizing which classes retry. Strategy follows the category — dependency
+ * failures back off, evaluation failures resample immediately.
  */
 
-/**
- * Base error class for all evaluator errors
- */
-export class EvaluatorError extends Error {
-  constructor(
-    message: string,
-    public readonly code?: string
-  ) {
-    super(message);
-    this.name = 'EvaluatorError';
-    // Maintains proper stack trace for where error was thrown (only available on V8)
+/** Canonical ID of an external system, for `DependencyError.dependency`. */
+export type DependencyId = 'openai' | 'google' | 'anthropic' | 'knowledge-graph';
+
+export interface DependencyErrorOptions {
+  dependency: DependencyId;
+  statusCode?: number | null;
+  requestId?: string | null;
+  /** Model in use, when the dependency is an LLM provider. */
+  model?: string | null;
+  /** Overrides the class default; a 5xx forces `true`. */
+  retryable?: boolean;
+  cause?: unknown;
+}
+
+export abstract class EvaluatorError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, retryable: boolean, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.retryable = retryable;
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
   }
 }
 
-/**
- * Configuration error - thrown when the evaluator is misconfigured
- * These are developer errors (e.g. missing API keys) that should NOT be retried
- *
- * @example
- * ```typescript
- * try {
- *   const evaluator = new VocabularyEvaluator({ googleApiKey: '' });
- * } catch (error) {
- *   if (error instanceof ConfigurationError) {
- *     console.error('Check your evaluator config:', error.message);
- *   }
- * }
- * ```
- */
+/** Caller: missing or invalid key, unknown provider or model, malformed settings. */
 export class ConfigurationError extends EvaluatorError {
-  constructor(message: string) {
-    super(message, 'CONFIGURATION_ERROR');
+  constructor(message: string, cause?: unknown) {
+    super(message, false, cause);
     this.name = 'ConfigurationError';
   }
 }
 
 /**
- * Validation error - thrown when input validation fails
- * These are client-side errors that should NOT be retried
- *
- * @example
- * ```typescript
- * try {
- *   await evaluator.evaluate('', '5');
- * } catch (error) {
- *   if (error instanceof ValidationError) {
- *     // Show user-friendly error message
- *     console.error('Invalid input:', error.message);
- *   }
- * }
- * ```
+ * Caller: text or grade failed validation. Also covers caller-supplied
+ * identifiers a dependency rejects — fault domain decides, not subsystem.
  */
-export class ValidationError extends EvaluatorError {
-  constructor(message: string) {
-    super(message, 'VALIDATION_ERROR');
-    this.name = 'ValidationError';
+export class InputValidationError extends EvaluatorError {
+  constructor(message: string, cause?: unknown) {
+    super(message, false, cause);
+    this.name = 'InputValidationError';
   }
 }
 
+/** A caller-supplied standards code that does not exist in the jurisdiction. */
+export class StandardNotFoundError extends InputValidationError {
+  constructor(message: string, readonly statementCode: string, cause?: unknown) {
+    super(message, cause);
+    this.name = 'StandardNotFoundError';
+  }
+}
+
+/** Our own evaluation logic failed after the dependency call succeeded. */
+export abstract class EvaluationError extends EvaluatorError {}
+
 /**
- * Base API error - thrown when LLM API calls fail
- * Contains additional context about the API error
+ * Model response failed parsing, normalization, or its output schema.
+ * Retryable immediately: the failure is sampling variance, so backing off
+ * only adds latency.
  */
-export class APIError extends EvaluatorError {
+export class LLMOutputProcessingError extends EvaluationError {
   constructor(
     message: string,
-    public readonly statusCode?: number,
-    public readonly retryable: boolean = false,
-    code?: string
+    readonly validationErrors: unknown[] | null = null,
+    cause?: unknown
   ) {
-    super(message, code);
-    this.name = 'APIError';
+    super(message, true, cause);
+    this.name = 'LLMOutputProcessingError';
   }
 }
 
-/**
- * Authentication error - thrown when API keys are invalid or missing
- * HTTP 401 or 403 responses
- * Should NOT be retried
- *
- * @example
- * ```typescript
- * try {
- *   await evaluator.evaluate(text, grade);
- * } catch (error) {
- *   if (error instanceof AuthenticationError) {
- *     // Prompt user to check API keys
- *     console.error('Invalid API keys. Please check your credentials.');
- *   }
- * }
- * ```
- */
-export class AuthenticationError extends APIError {
-  constructor(message: string, statusCode?: number) {
-    super(message, statusCode, false, 'AUTHENTICATION_ERROR');
+/** An external system failed. Which system is data (`dependency`), not a class. */
+export abstract class DependencyError extends EvaluatorError {
+  readonly dependency: DependencyId;
+  readonly statusCode: number | null;
+  readonly requestId: string | null;
+  readonly model: string | null;
+
+  constructor(message: string, classRetryable: boolean, options: DependencyErrorOptions) {
+    const statusCode = options.statusCode ?? null;
+    const is5xx = statusCode !== null && statusCode >= 500;
+    super(message, options.retryable ?? (is5xx || classRetryable), options.cause);
+    this.dependency = options.dependency;
+    this.statusCode = statusCode;
+    this.requestId = options.requestId ?? null;
+    this.model = options.model ?? null;
+  }
+}
+
+export class AuthenticationError extends DependencyError {
+  constructor(message: string, options: DependencyErrorOptions) {
+    super(message, false, options);
     this.name = 'AuthenticationError';
   }
 }
 
-/**
- * Rate limit error - thrown when API rate limits are exceeded
- * HTTP 429 responses
- * Should be retried with exponential backoff
- *
- * @example
- * ```typescript
- * try {
- *   await evaluator.evaluate(text, grade);
- * } catch (error) {
- *   if (error instanceof RateLimitError) {
- *     // Wait and retry
- *     await sleep(error.retryAfter || 5000);
- *     // retry...
- *   }
- * }
- * ```
- */
-export class RateLimitError extends APIError {
-  constructor(
-    message: string,
-    public readonly retryAfter?: number // milliseconds
-  ) {
-    super(message, 429, true, 'RATE_LIMIT_ERROR');
+export class RateLimitError extends DependencyError {
+  readonly retryAfterMs: number | null;
+
+  constructor(message: string, options: DependencyErrorOptions & { retryAfterMs?: number | null }) {
+    super(message, true, { statusCode: 429, ...options });
     this.name = 'RateLimitError';
+    this.retryAfterMs = options.retryAfterMs ?? null;
   }
 }
 
-/**
- * Network error - thrown when network requests fail
- * Connection timeouts, DNS failures, etc.
- * May be retryable depending on the scenario
- *
- * @example
- * ```typescript
- * try {
- *   await evaluator.evaluate(text, grade);
- * } catch (error) {
- *   if (error instanceof NetworkError) {
- *     // Check network connection and retry
- *     console.error('Network error:', error.message);
- *   }
- * }
- * ```
- */
-export class NetworkError extends APIError {
-  constructor(message: string, retryable: boolean = true) {
-    super(message, undefined, retryable, 'NETWORK_ERROR');
+export class NetworkError extends DependencyError {
+  constructor(message: string, options: DependencyErrorOptions) {
+    super(message, true, options);
     this.name = 'NetworkError';
   }
 }
 
-/**
- * Knowledge Graph error - thrown when KG API calls fail
- */
-export class KnowledgeGraphError extends EvaluatorError {
-  constructor(message: string, public readonly statusCode?: number, code = 'KNOWLEDGE_GRAPH_ERROR') {
-    super(message, code);
+export class RequestTimeoutError extends DependencyError {
+  constructor(message: string, options: DependencyErrorOptions) {
+    super(message, true, options);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+/** Catch-all for LLM-provider failures not mapped above. Retryable iff 5xx. */
+export class LLMProviderError extends DependencyError {
+  constructor(message: string, options: DependencyErrorOptions) {
+    super(message, false, options);
+    this.name = 'LLMProviderError';
+  }
+}
+
+/** Catch-all for Knowledge Graph failures not mapped above. Retryable iff 5xx. */
+export class KnowledgeGraphError extends DependencyError {
+  constructor(message: string, options: Omit<DependencyErrorOptions, 'dependency'> = {}) {
+    super(message, false, { ...options, dependency: 'knowledge-graph' });
     this.name = 'KnowledgeGraphError';
   }
 }
 
 /**
- * Thrown when a statement code does not exist in the requested jurisdiction.
- * Distinct from other KG failures because it reflects the caller's input rather
- * than the service.
+ * Extract what the provider told us, preferring structured fields over the
+ * message. Message text is not a contract — it is carried through for
+ * diagnosis but never used to reclassify.
  */
-export class StandardNotFoundError extends KnowledgeGraphError {
-  constructor(message: string, public readonly statementCode: string) {
-    super(message, undefined, 'STANDARD_NOT_FOUND');
-    this.name = 'StandardNotFoundError';
+function readProviderError(error: unknown): {
+  message: string;
+  statusCode: number | null;
+  requestId: string | null;
+} {
+  if (!(error instanceof Error)) {
+    return { message: String(error), statusCode: null, requestId: null };
   }
-}
-
-/**
- * Timeout error - thrown when requests exceed timeout limits
- * Should be retried with caution
- *
- * @example
- * ```typescript
- * try {
- *   await evaluator.evaluate(text, grade);
- * } catch (error) {
- *   if (error instanceof TimeoutError) {
- *     // Retry with longer timeout or smaller text
- *     console.error('Request timed out');
- *   }
- * }
- * ```
- */
-export class TimeoutError extends APIError {
-  constructor(message: string = 'Request timed out') {
-    super(message, 408, true, 'TIMEOUT_ERROR');
-    this.name = 'TimeoutError';
-  }
-}
-
-/**
- * Parse structured output from LLM provider error
- */
-function parseProviderError(error: unknown): { message: string; statusCode?: number; code?: string } {
-  if (error instanceof Error) {
-    const message = error.message;
-    const err = error as Error & { statusCode?: number; status?: number };
-
-    // Prefer a statusCode/status property (Vercel AI SDK's APICallError sets these)
-    // then fall back to parsing from the message string
-    const statusMatch = message.match(/\b(4\d{2}|5\d{2})\b/);
-    const statusCode =
-      err.statusCode ??
-      err.status ??
-      (statusMatch ? parseInt(statusMatch[1]) : undefined);
-
-    return {
-      message,
-      statusCode,
-      code: error.name !== 'Error' ? error.name : undefined,
-    };
-  }
-
+  const err = error as Error & {
+    statusCode?: number;
+    status?: number;
+    requestId?: string;
+    request_id?: string;
+  };
   return {
-    message: String(error),
+    message: error.message,
+    statusCode: err.statusCode ?? err.status ?? null,
+    requestId: err.requestId ?? err.request_id ?? null,
   };
 }
 
 /**
- * Wrap a provider error into the appropriate error type.
+ * Map a dependency failure onto the taxonomy.
  *
- * Returns `ConfigurationError` for model-not-found responses (HTTP 404, or HTTP 400
- * with a model-related message), since those indicate a bad model ID in configuration.
- * Returns the appropriate `APIError` subclass for all other provider errors.
- *
- * @internal
+ * Classification uses status codes only. Free-text matching is deliberately
+ * absent: wording is not a contract, and the catch-all is safer than a wrong
+ * class. Text-only failures therefore land on `LLMProviderError`.
  */
-export function wrapProviderError(error: unknown, defaultMessage: string = 'API request failed'): EvaluatorError {
-  const { message, statusCode, code } = parseProviderError(error);
-
-  // Detect model-not-found errors (404, or 400 with model-related message)
-  if (
-    statusCode === 404 ||
-    (statusCode === 400 && /\bmodel\b.*(not found|does not exist|invalid)/i.test(message))
-  ) {
-    return new ConfigurationError(
-      `Model not found or invalid: ${message}. Check the model ID passed to the provider.`
-    );
-  }
-
-  // Detect authentication errors (401, 403)
-  if (statusCode === 401 || statusCode === 403) {
-    return new AuthenticationError(
-      message.includes('API key') ? message : 'Invalid API key',
-      statusCode
-    );
-  }
-
-  // Detect rate limit errors (429)
-  if (statusCode === 429) {
-    // Try to extract retry-after if present
-    const retryAfterMatch = message.match(/retry[- ]after[:\s]+(\d+)/i);
-    const retryAfter = retryAfterMatch ? parseInt(retryAfterMatch[1]) * 1000 : undefined;
-
-    return new RateLimitError(
-      message.includes('rate limit') ? message : 'Rate limit exceeded',
-      retryAfter
-    );
-  }
-
-  // Detect network errors
-  if (
-    message.includes('ECONNREFUSED') ||
-    message.includes('ENOTFOUND') ||
-    message.includes('ETIMEDOUT') ||
-    message.includes('network') ||
-    message.includes('Network')
-  ) {
-    return new NetworkError(message);
-  }
-
-  // Detect timeout errors
-  if (message.includes('timeout') || message.includes('timed out')) {
-    return new TimeoutError(message);
-  }
-
-  // Generic API error for everything else
-  return new APIError(
-    message || defaultMessage,
+export function wrapProviderError(
+  error: unknown,
+  context: { dependency: DependencyId; model?: string | null }
+): EvaluatorError {
+  const { message, statusCode, requestId } = readProviderError(error);
+  const options: DependencyErrorOptions = {
+    dependency: context.dependency,
     statusCode,
-    statusCode ? statusCode >= 500 : false, // 5xx errors are retryable
-    code
-  );
+    requestId,
+    model: context.model ?? null,
+    cause: error,
+  };
+
+  if (statusCode === 404) {
+    return new ConfigurationError(
+      `Model not found or invalid: ${message}. Check the model ID passed to the provider.`,
+      error
+    );
+  }
+  if (statusCode === 401 || statusCode === 403) {
+    return new AuthenticationError(message, options);
+  }
+  if (statusCode === 429) {
+    return new RateLimitError(message, options);
+  }
+  if (statusCode === 408) {
+    return new RequestTimeoutError(message, options);
+  }
+  return new LLMProviderError(message || 'API request failed', options);
 }

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -9,9 +9,36 @@
  * memorizing which classes retry. Strategy follows the category — dependency
  * failures back off, evaluation failures resample immediately.
  */
+import {
+  APICallError,
+  JSONParseError,
+  NoObjectGeneratedError,
+  TypeValidationError,
+} from 'ai';
 
-/** Canonical ID of an external system, for `DependencyError.dependency`. */
-export type DependencyId = 'openai' | 'google' | 'anthropic' | 'knowledge-graph';
+/**
+ * Canonical ID of an external system, for `DependencyError.dependency`.
+ *
+ * Closed on purpose: an integration we add must be named here rather than
+ * landing in a catch-all. `custom` is not that catch-all — it means the caller
+ * injected their own `llmProvider`, so the vendor is theirs to know, not ours.
+ * A `modelOverride` still reports its real vendor, since it is one of ours.
+ *
+ * The provider arm must stay in step with the `Provider` enum, which cannot be
+ * imported here without a cycle.
+ */
+export type DependencyId = 'openai' | 'google' | 'anthropic' | 'knowledge-graph' | 'custom';
+
+/**
+ * The subset of {@link DependencyId} that can appear as an LLM provider label's
+ * prefix. `knowledge-graph` never does — that client raises its own errors — and
+ * `custom` is the fallback for a label none of these match, not a match itself.
+ */
+export const PROVIDER_DEPENDENCIES: ReadonlySet<DependencyId> = new Set<DependencyId>([
+  'openai',
+  'google',
+  'anthropic',
+]);
 
 export interface DependencyErrorOptions {
   dependency: DependencyId;
@@ -111,7 +138,9 @@ export class RateLimitError extends DependencyError {
   readonly retryAfterMs: number | null;
 
   constructor(message: string, options: DependencyErrorOptions & { retryAfterMs?: number | null }) {
-    super(message, true, { statusCode: 429, ...options });
+    // Spread first, then default: a present-but-undefined statusCode must not
+    // clobber the 429 this class implies.
+    super(message, true, { ...options, statusCode: options.statusCode ?? 429 });
     this.name = 'RateLimitError';
     this.retryAfterMs = options.retryAfterMs ?? null;
   }
@@ -147,51 +176,137 @@ export class KnowledgeGraphError extends DependencyError {
   }
 }
 
-/**
- * Extract what the provider told us, preferring structured fields over the
- * message. Message text is not a contract — it is carried through for
- * diagnosis but never used to reclassify.
- */
-function readProviderError(error: unknown): {
+/** Connection-level failures, by Node errno rather than message text. */
+const NETWORK_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+/** Timeouts, by Node errno or the DOMException name `AbortSignal.timeout` raises. */
+const TIMEOUT_CODES = new Set(['ETIMEDOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT']);
+const TIMEOUT_NAMES = new Set(['TimeoutError', 'AbortError']);
+
+/** Header names providers use for the request ID, in preference order. */
+const REQUEST_ID_HEADERS = ['x-request-id', 'request-id', 'x-amzn-requestid'];
+
+interface ProviderSignals {
   message: string;
   statusCode: number | null;
   requestId: string | null;
-} {
-  if (!(error instanceof Error)) {
-    return { message: String(error), statusCode: null, requestId: null };
+  /** The provider's own retryability verdict, when it gave one. */
+  retryable?: boolean;
+  retryAfterMs: number | null;
+}
+
+/** Walk the cause chain so a wrapped provider error is still classifiable. */
+function* causeChain(error: unknown): Generator<unknown> {
+  let current = error;
+  for (let depth = 0; current != null && depth < 10; depth++) {
+    yield current;
+    current = (current as { cause?: unknown }).cause;
   }
-  const err = error as Error & {
-    statusCode?: number;
-    status?: number;
-    requestId?: string;
-    request_id?: string;
+}
+
+function readRetryAfterMs(headers: Record<string, string> | undefined): number | null {
+  const seconds = headers?.['retry-after'];
+  if (seconds !== undefined) {
+    const parsed = Number(seconds);
+    if (Number.isFinite(parsed)) return Math.round(parsed * 1000);
+  }
+  const ms = headers?.['retry-after-ms'];
+  if (ms !== undefined) {
+    const parsed = Number(ms);
+    if (Number.isFinite(parsed)) return Math.round(parsed);
+  }
+  return null;
+}
+
+/**
+ * Read structured fields off whatever was thrown. Message text is carried for
+ * diagnosis but never used to classify.
+ */
+function readProviderSignals(error: unknown): ProviderSignals {
+  const base: ProviderSignals = {
+    message: error instanceof Error ? error.message : String(error),
+    statusCode: null,
+    requestId: null,
+    retryAfterMs: null,
   };
-  return {
-    message: error.message,
-    statusCode: err.statusCode ?? err.status ?? null,
-    requestId: err.requestId ?? err.request_id ?? null,
-  };
+
+  for (const link of causeChain(error)) {
+    if (!APICallError.isInstance(link)) continue;
+    const headers = link.responseHeaders;
+    return {
+      ...base,
+      statusCode: link.statusCode ?? null,
+      requestId: REQUEST_ID_HEADERS.map((h) => headers?.[h]).find((v) => v != null) ?? null,
+      retryable: link.isRetryable,
+      retryAfterMs: readRetryAfterMs(headers),
+    };
+  }
+
+  // Not an AI SDK error: fall back to the loose properties other clients set.
+  const loose = error as { statusCode?: number; status?: number };
+  return { ...base, statusCode: loose?.statusCode ?? loose?.status ?? null };
+}
+
+/** Schema/parse failures are the model's fault, not the dependency's. */
+function isOutputProcessingFailure(error: unknown): boolean {
+  for (const link of causeChain(error)) {
+    if (
+      NoObjectGeneratedError.isInstance(link) ||
+      TypeValidationError.isInstance(link) ||
+      JSONParseError.isInstance(link)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function findTransportFailure(error: unknown): 'network' | 'timeout' | null {
+  for (const link of causeChain(error)) {
+    const { code, name } = (link ?? {}) as { code?: string; name?: string };
+    if (code !== undefined && TIMEOUT_CODES.has(code)) return 'timeout';
+    if (name !== undefined && TIMEOUT_NAMES.has(name)) return 'timeout';
+    if (code !== undefined && NETWORK_CODES.has(code)) return 'network';
+  }
+  return null;
 }
 
 /**
  * Map a dependency failure onto the taxonomy.
  *
- * Classification uses status codes only. Free-text matching is deliberately
- * absent: wording is not a contract, and the catch-all is safer than a wrong
- * class. Text-only failures therefore land on `LLMProviderError`.
+ * Classification uses structured signals only — status codes, typed AI SDK
+ * errors, and Node errnos, each searched along the cause chain. Message text is
+ * never matched: wording is not a contract, and the catch-all is safer than a
+ * wrong class.
  */
 export function wrapProviderError(
   error: unknown,
   context: { dependency: DependencyId; model?: string | null }
 ): EvaluatorError {
-  const { message, statusCode, requestId } = readProviderError(error);
+  const signals = readProviderSignals(error);
+  const { message, statusCode } = signals;
   const options: DependencyErrorOptions = {
     dependency: context.dependency,
     statusCode,
-    requestId,
+    requestId: signals.requestId,
     model: context.model ?? null,
+    retryable: signals.retryable,
     cause: error,
   };
+
+  // The model returned something unusable — our fault to re-sample, not the
+  // dependency's to fix, so this outranks any transport signal.
+  if (isOutputProcessingFailure(error)) {
+    return new LLMOutputProcessingError(message, null, error);
+  }
 
   if (statusCode === 404) {
     return new ConfigurationError(
@@ -203,10 +318,12 @@ export function wrapProviderError(
     return new AuthenticationError(message, options);
   }
   if (statusCode === 429) {
-    return new RateLimitError(message, options);
+    return new RateLimitError(message, { ...options, retryAfterMs: signals.retryAfterMs });
   }
-  if (statusCode === 408) {
-    return new RequestTimeoutError(message, options);
-  }
+
+  const transport = statusCode === 408 ? 'timeout' : findTransportFailure(error);
+  if (transport === 'timeout') return new RequestTimeoutError(message, options);
+  if (transport === 'network') return new NetworkError(message, options);
+
   return new LLMProviderError(message || 'API request failed', options);
 }

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -5,7 +5,7 @@ import {
   type TelemetryMetadata,
   type TokenUsage,
 } from '../telemetry/index.js';
-import { ConfigurationError, ValidationError } from '../errors.js';
+import { ConfigurationError, InputValidationError, type DependencyId } from '../errors.js';
 import { createLogger, LogLevel, type Logger } from '../logger.js';
 import { createProvider } from '../providers/index.js';
 import type { LLMProvider } from '../providers/index.js';
@@ -413,10 +413,27 @@ export abstract class BaseEvaluator {
   }
 
   /**
+   * Dependency attribution for errors raised while calling `provider`
+   * Derived from the provider label's `provider:model` form.
+   */
+  protected providerContext(provider: LLMProvider): {
+    dependency: DependencyId;
+    model: string | null;
+  } {
+    const separator = provider.label.indexOf(':');
+    return separator === -1
+      ? { dependency: provider.label as DependencyId, model: null }
+      : {
+          dependency: provider.label.slice(0, separator) as DependencyId,
+          model: provider.label.slice(separator + 1) || null,
+        };
+  }
+
+  /**
    * Validate text meets requirements
    * Default implementation - can be overridden by concrete evaluators
    *
-   * @throws {ValidationError} If text is invalid
+   * @throws {InputValidationError} If text is invalid
    */
   protected validateText(text: string): void {
     this.logger.debug('Validating text input', {
@@ -428,19 +445,19 @@ export abstract class BaseEvaluator {
     // Check if text is empty or only whitespace
     const trimmedText = text.trim();
     if (!trimmedText) {
-      throw new ValidationError('Text cannot be empty or contain only whitespace');
+      throw new InputValidationError('Text cannot be empty or contain only whitespace');
     }
 
     // Check minimum length
     if (trimmedText.length < VALIDATION_LIMITS.MIN_TEXT_LENGTH) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `Text is too short. Minimum length is ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters, received ${trimmedText.length} characters`
       );
     }
 
     // Check maximum length
     if (trimmedText.length > VALIDATION_LIMITS.MAX_TEXT_LENGTH) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `Text is too long. Maximum length is ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters, received ${trimmedText.length.toLocaleString()} characters`
       );
     }
@@ -452,7 +469,7 @@ export abstract class BaseEvaluator {
    *
    * @param grade - Grade level to validate
    * @param validGrades - Set of valid grades for this evaluator
-   * @throws {ValidationError} If grade is invalid
+   * @throws {InputValidationError} If grade is invalid
    */
   protected validateGrade(grade: string, validGrades: Set<string>): void {
     this.logger.debug('Validating grade input', {
@@ -470,7 +487,7 @@ export abstract class BaseEvaluator {
         return parseInt(a, 10) - parseInt(b, 10);
       }).join(', ');
 
-      throw new ValidationError(
+      throw new InputValidationError(
         `Invalid grade "${grade}". Supported grades for this evaluator: ${validList}`
       );
     }

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -430,15 +430,21 @@ export abstract class BaseEvaluator {
     dependency: DependencyId;
     model: string;
   } {
-    const separator = provider.label.indexOf(':');
-    const prefix = separator === -1 ? provider.label : provider.label.slice(0, separator);
+    const label = provider.label;
+    const separator = label.indexOf(':');
+    const prefix = separator === -1 ? label : label.slice(0, separator);
 
-    // A known prefix is already reported as `dependency`, so `model` carries just
-    // the model id. An unknown one keeps the whole label, which is the only
-    // identifier a caller-supplied provider gives us.
-    return PROVIDER_DEPENDENCIES.has(prefix as DependencyId)
-      ? { dependency: prefix as DependencyId, model: provider.label.slice(separator + 1) }
-      : { dependency: 'custom', model: provider.label };
+    // An unrecognised prefix means a caller-supplied provider, whose vendor is
+    // theirs to know; the label is the only identifier we have, so keep it whole.
+    if (!PROVIDER_DEPENDENCIES.has(prefix)) {
+      return { dependency: 'custom', model: label };
+    }
+
+    // The vendor is already reported as `dependency`, so `model` need only carry
+    // the model id. Slicing past a missing separator yields the whole label,
+    // which is also the right answer when there is no model id to strip.
+    const model = label.slice(separator + 1);
+    return { dependency: prefix as DependencyId, model: model === '' ? label : model };
   }
 
   /**

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -5,7 +5,12 @@ import {
   type TelemetryMetadata,
   type TokenUsage,
 } from '../telemetry/index.js';
-import { ConfigurationError, InputValidationError, type DependencyId } from '../errors.js';
+import {
+  ConfigurationError,
+  InputValidationError,
+  PROVIDER_DEPENDENCIES,
+  type DependencyId,
+} from '../errors.js';
 import { createLogger, LogLevel, type Logger } from '../logger.js';
 import { createProvider } from '../providers/index.js';
 import type { LLMProvider } from '../providers/index.js';
@@ -413,20 +418,27 @@ export abstract class BaseEvaluator {
   }
 
   /**
-   * Dependency attribution for errors raised while calling `provider`
-   * Derived from the provider label's `provider:model` form.
+   * Dependency attribution for errors raised while calling `provider`.
+   *
+   * The label is `provider:model`, and its prefix is a `Provider` value on both
+   * the default and `modelOverride` paths, so those report their real vendor. An
+   * injected `llmProvider` can label itself anything; that reports `custom`
+   * rather than guessing a vendor we never called. The label is always kept as
+   * `model`, so the caller's own identifier is never lost.
    */
   protected providerContext(provider: LLMProvider): {
     dependency: DependencyId;
-    model: string | null;
+    model: string;
   } {
     const separator = provider.label.indexOf(':');
-    return separator === -1
-      ? { dependency: provider.label as DependencyId, model: null }
-      : {
-          dependency: provider.label.slice(0, separator) as DependencyId,
-          model: provider.label.slice(separator + 1) || null,
-        };
+    const prefix = separator === -1 ? provider.label : provider.label.slice(0, separator);
+
+    // A known prefix is already reported as `dependency`, so `model` carries just
+    // the model id. An unknown one keeps the whole label, which is the only
+    // identifier a caller-supplied provider gives us.
+    return PROVIDER_DEPENDENCIES.has(prefix as DependencyId)
+      ? { dependency: prefix as DependencyId, model: provider.label.slice(separator + 1) }
+      : { dependency: 'custom', model: provider.label };
   }
 
   /**

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -57,7 +57,8 @@ export class ConventionalityEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -5,7 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/conventionality/index
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 
 /**
  * Conventionality Evaluator
@@ -55,7 +55,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -172,11 +172,11 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         // Ignore telemetry errors
       });
 
-      if (error instanceof ValidationError) {
+      if (error instanceof EvaluatorError) {
         throw error;
       }
 
-      throw wrapProviderError(error, 'Conventionality evaluation failed');
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -6,7 +6,7 @@ import {
 import { getSystemPrompt, getUserPrompt } from '../prompts/grade-level-appropriateness/index.js';
 import type { EvaluationResult, GradeBand } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 
 /**
  * Grade Level Appropriateness Evaluator
@@ -60,7 +60,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    *
    * @param text - The text to evaluate
    * @returns Evaluation result with grade recommendations and scaffolding suggestions
-   * @throws {ValidationError} If text is empty or too short/long
+   * @throws {InputValidationError} If text is empty or too short/long
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -155,12 +155,12 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       });
 
       // Re-throw validation errors as-is
-      if (error instanceof ValidationError) {
+      if (error instanceof EvaluatorError) {
         throw error;
       }
 
       // Wrap provider errors into appropriate error types
-      throw wrapProviderError(error, 'Grade level appropriateness evaluation failed');
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 }

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -62,7 +62,8 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @returns Evaluation result with grade recommendations and scaffolding suggestions
    * @throws {InputValidationError} If text is empty or too short/long
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(text: string): Promise<EvaluationResult<GradeBand, GradeLevelAppropriatenessInternal>> {
     this.logger.info('Starting grade level appropriateness evaluation', {

--- a/sdks/typescript/src/evaluators/intertextuality.ts
+++ b/sdks/typescript/src/evaluators/intertextuality.ts
@@ -63,7 +63,8 @@ export class IntertextualityEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(text: string, grade: string): Promise<EvaluationResult<TextComplexityLevel, IntertextualityInternal>> {
     this.logger.info('Starting Intertextuality evaluation', {

--- a/sdks/typescript/src/evaluators/intertextuality.ts
+++ b/sdks/typescript/src/evaluators/intertextuality.ts
@@ -5,7 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/intertextuality/index
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, InputValidationError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/literacy/qualitative-text-complexity/intertextuality/config.json';
 import INPUT_SCHEMA from '../../../../evals/literacy/qualitative-text-complexity/intertextuality/input_schema.json';
 
@@ -61,7 +61,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -163,15 +163,15 @@ export class IntertextualityEvaluator extends BaseEvaluator {
         inputText: text,
       }).catch(() => undefined);
 
-      if (error instanceof ValidationError) throw error;
-      throw wrapProviderError(error, 'Intertextuality evaluation failed');
+      if (error instanceof EvaluatorError) throw error;
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 
   private parseAndValidateGrade(grade: string): number {
     const num = Number(grade.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `Invalid grade "${grade}". Intertextuality evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -15,7 +15,7 @@ import {
   MAX_QUESTION_LENGTH,
 } from '../../prompts/math/standards-alignment/index.js';
 import { KnowledgeGraphClient, Jurisdiction } from '../../knowledge-graph/index.js';
-import { EvaluatorError, APIError, ConfigurationError, ValidationError, wrapProviderError } from '../../errors.js';
+import { EvaluatorError, DependencyError, ConfigurationError, InputValidationError, LLMOutputProcessingError, wrapProviderError } from '../../errors.js';
 import type { StageDetail } from '../../telemetry/index.js';
 
 export { Jurisdiction } from '../../knowledge-graph/index.js';
@@ -45,12 +45,10 @@ export interface StandardAlignmentResult {
    * Not evidence of non-alignment: alignedCount is 0 because nothing was
    * measured, not because nothing aligned.
    *
-   * `code` and `name` are both carried because subclasses can share a code, and a
-   * report grouping failures by kind needs the narrower one.
+   * `name` is the error class, which is what a report groups failures on.
    */
   error?: {
     message: string;
-    code?: string;
     name?: string;
     statusCode?: number;
     retryable?: boolean;
@@ -136,13 +134,14 @@ const BY_GRADE_WARN_PAIRS = 500;
 /** Flattens a thrown value into the reportable shape, keeping what a report can group on. */
 function describeFailure(err: unknown): NonNullable<StandardAlignmentResult['error']> {
   if (!(err instanceof Error)) return { message: String(err) };
-  const api = err as Partial<APIError>;
+  // `name` is the canonical error code, so there is no separate code field.
   return {
     message: err.message,
     name: err.name,
-    ...(err instanceof EvaluatorError && err.code ? { code: err.code } : {}),
-    ...(typeof api.statusCode === 'number' ? { statusCode: api.statusCode } : {}),
-    ...(typeof api.retryable === 'boolean' ? { retryable: api.retryable } : {}),
+    ...(err instanceof DependencyError && err.statusCode !== null
+      ? { statusCode: err.statusCode }
+      : {}),
+    ...(err instanceof EvaluatorError ? { retryable: err.retryable } : {}),
   };
 }
 
@@ -230,7 +229,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         this.validateQuestion(item.question);
       } catch (err) {
         // Only a domain error is a per-item validation failure. Anything else is a
-        // bug here, and turning it into a ValidationError would report it as bad
+        // bug here, and turning it into a InputValidationError would report it as bad
         // user input.
         if (!(err instanceof EvaluatorError)) throw err;
         validationError = err;
@@ -357,7 +356,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     jurisdiction: Jurisdiction,
     options?: QuestionBankOptions,
   ): Promise<QuestionBankResult> {
-    if (questions.length === 0) throw new ValidationError('questions array must not be empty');
+    if (questions.length === 0) throw new InputValidationError('questions array must not be empty');
     this.validateGrade(grade, new Set(SUPPORTED_GRADES));
 
     const academicStandards = await this.kgClient.getStandardsByGrade(grade, {
@@ -505,9 +504,10 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         .filter((id) => !evalById.has(id));
 
       if (missingIds.length > 0) {
-        throw new APIError(
+        throw new LLMOutputProcessingError(
           `LLM response missing verified evaluations for LC identifiers: ${missingIds.join(', ')}. ` +
           `Standard: ${statementCode}`,
+          missingIds.map((identifier) => ({ path: 'evaluations', identifier })),
         );
       }
 
@@ -570,7 +570,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       }).catch(() => undefined);
 
       if (error instanceof EvaluatorError) throw error;
-      throw wrapProviderError(error, 'Math standards alignment evaluation failed');
+      throw wrapProviderError(error, this.providerContext(this.detailProvider));
     }
   }
 
@@ -648,10 +648,10 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
   private validateQuestion(question: string): void {
     if (question.trim().length === 0) {
-      throw new ValidationError('question must not be empty');
+      throw new InputValidationError('question must not be empty');
     }
     if (question.length > MAX_QUESTION_LENGTH) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `question exceeds maximum length of ${MAX_QUESTION_LENGTH} characters (got ${question.length})`,
       );
     }
@@ -659,7 +659,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
   private validateStatementCode(code: string): void {
     if (code.trim().length === 0) {
-      throw new ValidationError('statementCode must not be empty');
+      throw new InputValidationError('statementCode must not be empty');
     }
   }
 }

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -8,7 +8,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/organizational-struct
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, InputValidationError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/literacy/qualitative-text-complexity/organizational-structure/config.json';
 import INPUT_SCHEMA from '../../../../evals/literacy/qualitative-text-complexity/organizational-structure/input_schema.json';
 
@@ -64,7 +64,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -166,15 +166,15 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         inputText: text,
       }).catch(() => undefined);
 
-      if (error instanceof ValidationError) throw error;
-      throw wrapProviderError(error, 'Organizational Structure evaluation failed');
+      if (error instanceof EvaluatorError) throw error;
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 
   private parseAndValidateGrade(grade: string): number {
     const num = Number(grade.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `Invalid grade "${grade}". Organizational Structure evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -66,7 +66,8 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(text: string, grade: string): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
     this.logger.info('Starting Organizational Structure evaluation', {

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -5,7 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/purpose/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, InputValidationError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/prompts/purpose/config.json';
 import INPUT_SCHEMA from '../../../../evals/prompts/purpose/input_schema.json';
 
@@ -64,7 +64,7 @@ export class PurposeEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -166,15 +166,15 @@ export class PurposeEvaluator extends BaseEvaluator {
         inputText: text,
       }).catch(() => undefined);
 
-      if (error instanceof ValidationError) throw error;
-      throw wrapProviderError(error, 'Purpose evaluation failed');
+      if (error instanceof EvaluatorError) throw error;
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 
   private parseAndValidateGrade(grade: string): number {
     const num = Number(grade.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
-      throw new ValidationError(
+      throw new InputValidationError(
         `Invalid grade "${grade}". Purpose evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -66,7 +66,8 @@ export class PurposeEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(text: string, grade: string): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
     this.logger.info('Starting Purpose evaluation', {

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -17,7 +17,7 @@ import {
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { EvaluatorError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, LLMOutputProcessingError, wrapProviderError } from '../errors.js';
 
 /**
  * Normalize complexity label to handle LLM output variations
@@ -91,7 +91,8 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
@@ -306,9 +307,10 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
     const normalizedAnswer = normalizeLabel(response.data.answer);
 
     if (!normalizedAnswer) {
-      throw new Error(
+      throw new LLMOutputProcessingError(
         `Failed to normalize complexity label. Received unexpected value: "${response.data.answer}". ` +
-        `Expected one of: Slightly Complex, Moderately Complex, Very Complex, Exceedingly Complex, Extremely Complex.`
+        `Expected one of: Slightly Complex, Moderately Complex, Very Complex, Exceedingly Complex, Extremely Complex.`,
+        [{ path: 'answer', received: response.data.answer }]
       );
     }
 

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -17,7 +17,7 @@ import {
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 
 /**
  * Normalize complexity label to handle LLM output variations
@@ -89,7 +89,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -232,12 +232,12 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
       });
 
       // Re-throw validation errors as-is
-      if (error instanceof ValidationError) {
+      if (error instanceof EvaluatorError) {
         throw error;
       }
 
       // Wrap provider errors into appropriate error types
-      throw wrapProviderError(error, 'Sentence structure evaluation failed');
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -57,7 +57,8 @@ export class SmkEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -5,7 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/subject-matter-knowle
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 
 /**
  * Subject Matter Knowledge (SMK) Evaluator
@@ -55,7 +55,7 @@ export class SmkEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -172,11 +172,11 @@ export class SmkEvaluator extends BaseEvaluator {
         // Ignore telemetry errors
       });
 
-      if (error instanceof ValidationError) {
+      if (error instanceof EvaluatorError) {
         throw error;
       }
 
-      throw wrapProviderError(error, 'SMK evaluation failed');
+      throw wrapProviderError(error, this.providerContext(this.provider));
     }
   }
 

--- a/sdks/typescript/src/evaluators/text-complexity.ts
+++ b/sdks/typescript/src/evaluators/text-complexity.ts
@@ -85,7 +85,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Map of sub-evaluator results
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {Error} If all sub-evaluators fail
    */

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -13,7 +13,7 @@ import {
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { ValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 
 /**
  * Vocabulary Evaluator
@@ -80,7 +80,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
    * @param text - The text to evaluate
    * @param grade - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {ValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
    */
@@ -97,9 +97,10 @@ export class VocabularyEvaluator extends BaseEvaluator {
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
-    const complexityProviderLabel = (grade === '3' || grade === '4')
-      ? this.grades34ComplexityProvider.label
-      : this.otherGradesComplexityProvider.label;
+    const complexityProvider = (grade === '3' || grade === '4')
+      ? this.grades34ComplexityProvider
+      : this.otherGradesComplexityProvider;
+    const complexityProviderLabel = complexityProvider.label;
     const backgroundProviderLabel = this.backgroundKnowledgeProvider.label;
     // When override is active all providers resolve to the same model — show a single label.
     const modelLabel = this.config.modelOverride
@@ -229,12 +230,16 @@ export class VocabularyEvaluator extends BaseEvaluator {
       });
 
       // Re-throw validation errors as-is
-      if (error instanceof ValidationError) {
+      if (error instanceof EvaluatorError) {
         throw error;
       }
 
-      // Wrap provider errors into appropriate error types
-      throw wrapProviderError(error, 'Vocabulary evaluation failed');
+      // Three providers can fail here and the catch cannot tell which did, so
+      // attribute to the grade's complexity provider and report both models.
+      throw wrapProviderError(error, {
+        dependency: this.providerContext(complexityProvider).dependency,
+        model: modelLabel,
+      });
     }
   }
 

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -82,7 +82,8 @@ export class VocabularyEvaluator extends BaseEvaluator {
    * @returns Evaluation result with complexity score and detailed analysis
    * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {APIError} If LLM API calls fail (includes AuthenticationError, RateLimitError, NetworkError, TimeoutError)
+   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
@@ -234,12 +235,12 @@ export class VocabularyEvaluator extends BaseEvaluator {
         throw error;
       }
 
-      // Three providers can fail here and the catch cannot tell which did, so
-      // attribute to the grade's complexity provider and report both models.
-      throw wrapProviderError(error, {
-        dependency: this.providerContext(complexityProvider).dependency,
-        model: modelLabel,
-      });
+      // An empty stageDetails means stage 1 (background knowledge) is what
+      // failed; otherwise it completed and stage 2 (complexity) did. Attribute
+      // to the provider that actually failed rather than a combined label.
+      const failed =
+        stageDetails.length === 0 ? this.backgroundKnowledgeProvider : complexityProvider;
+      throw wrapProviderError(error, this.providerContext(failed));
     }
   }
 

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -2,7 +2,7 @@
 export type {
   EvaluationResult,
   EvaluationMetadata,
-  EvaluationError,
+  EvaluationFailure,
 } from './schemas/index.js';
 
 export { TextComplexityLevel, GradeBand } from './schemas/index.js';
@@ -11,14 +11,18 @@ export { TextComplexityLevel, GradeBand } from './schemas/index.js';
 export {
   EvaluatorError,
   ConfigurationError,
-  ValidationError,
-  APIError,
+  InputValidationError,
+  StandardNotFoundError,
+  EvaluationError,
+  LLMOutputProcessingError,
+  DependencyError,
   AuthenticationError,
   RateLimitError,
   NetworkError,
-  TimeoutError,
+  RequestTimeoutError,
+  LLMProviderError,
   KnowledgeGraphError,
-  StandardNotFoundError,
+  type DependencyId,
 } from './errors.js';
 
 // Knowledge Graph

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -23,6 +23,7 @@ export {
   LLMProviderError,
   KnowledgeGraphError,
   type DependencyId,
+  type DependencyErrorOptions,
 } from './errors.js';
 
 // Knowledge Graph

--- a/sdks/typescript/src/knowledge-graph/client.ts
+++ b/sdks/typescript/src/knowledge-graph/client.ts
@@ -6,7 +6,12 @@ import {
   AuthenticationError,
   RateLimitError,
   NetworkError,
+  RequestTimeoutError,
+  type DependencyId,
 } from '../errors.js';
+
+/** Every error raised here attributes to the Knowledge Graph service. */
+const KG: DependencyId = 'knowledge-graph';
 import type { AcademicStandard, LearningComponent, LearningComponentSet, StandardInfo } from './types.js';
 import type { paths, components } from './kg-api.js';
 
@@ -35,15 +40,23 @@ async function kgFetchFn(input: Request, init?: Parameters<typeof fetch>[1]): Pr
     return await fetch(input, { ...init, signal: AbortSignal.timeout(KG_TIMEOUT_MS) });
   } catch (err) {
     if (err instanceof Error && err.name === 'TimeoutError') {
-      throw new NetworkError(`Knowledge Graph request timed out after ${KG_TIMEOUT_MS}ms`);
+      throw new RequestTimeoutError(
+        `Knowledge Graph request timed out after ${KG_TIMEOUT_MS}ms`,
+        { dependency: KG, cause: err },
+      );
     }
-    throw new NetworkError(`Knowledge Graph request failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new NetworkError(
+      `Knowledge Graph request failed: ${err instanceof Error ? err.message : String(err)}`,
+      { dependency: KG, cause: err },
+    );
   }
 }
 
 function wrapJsonError(err: unknown): never {
   if (err instanceof SyntaxError) {
-    throw new KnowledgeGraphError(`Knowledge Graph returned invalid JSON: ${err.message}`);
+    throw new KnowledgeGraphError(`Knowledge Graph returned invalid JSON: ${err.message}`, {
+      cause: err,
+    });
   }
   throw err;
 }
@@ -53,13 +66,18 @@ const httpErrorMiddleware: Middleware = {
   async onResponse({ response }) {
     if (!response.ok) {
       const body = await response.text().catch(() => '');
+      const requestId = response.headers.get('x-request-id');
+      const options = { dependency: KG, statusCode: response.status, requestId };
       if (response.status === 401 || response.status === 403) {
-        throw new AuthenticationError(`Knowledge Graph authentication failed: ${body}`, response.status);
+        throw new AuthenticationError(`Knowledge Graph authentication failed: ${body}`, options);
       }
       if (response.status === 429) {
-        throw new RateLimitError(`Knowledge Graph rate limit exceeded: ${body}`);
+        throw new RateLimitError(`Knowledge Graph rate limit exceeded: ${body}`, options);
       }
-      throw new KnowledgeGraphError(`Knowledge Graph request failed (${response.status}): ${body}`, response.status);
+      throw new KnowledgeGraphError(
+        `Knowledge Graph request failed (${response.status}): ${body}`,
+        { statusCode: response.status, requestId },
+      );
     }
   },
 };

--- a/sdks/typescript/src/knowledge-graph/standards-catalog.ts
+++ b/sdks/typescript/src/knowledge-graph/standards-catalog.ts
@@ -3,7 +3,7 @@ import {
   ConfigurationError,
   StandardNotFoundError,
   AuthenticationError,
-  ValidationError,
+  InputValidationError,
   KnowledgeGraphError,
 } from '../errors.js';
 import { KnowledgeGraphClient, normalizeStatementCode, STANDARD_SEARCH_LIMIT } from './client.js';
@@ -129,14 +129,14 @@ export class StandardsCatalog {
   }
 
   /**
-   * Resolve a single statement code. Throws `ValidationError` for a code the KG
+   * Resolve a single statement code. Throws `InputValidationError` for a code the KG
    * cannot answer for, and `StandardNotFoundError` when it does not exist.
    */
   // async so a rejected code rejects rather than throwing synchronously, which
   // would force callers into both try/catch and .catch().
   async getStandard(statementCode: string, opts?: StandardsLookupOptions): Promise<StandardInfo> {
     const problem = localCodeProblem(normalizeStatementCode(statementCode));
-    if (problem) throw new ValidationError(problem);
+    if (problem) throw new InputValidationError(problem);
 
     return this.kg.getStandardInfo(statementCode, {
       jurisdiction: opts?.jurisdiction ?? Jurisdiction.MultiState,

--- a/sdks/typescript/src/schemas/index.ts
+++ b/sdks/typescript/src/schemas/index.ts
@@ -2,7 +2,7 @@ export {
   TextComplexityLevel,
   type EvaluationResult,
   type EvaluationMetadata,
-  type EvaluationError,
+  type EvaluationFailure,
 } from './outputs.js';
 
 export {

--- a/sdks/typescript/src/schemas/outputs.ts
+++ b/sdks/typescript/src/schemas/outputs.ts
@@ -44,9 +44,10 @@ export interface BatchSummary {
 }
 
 /**
- * Error type for failed evaluations
+ * A failed slot in a batch result. Named to leave `EvaluationError` free for the
+ * canonical error class.
  */
-export interface EvaluationError {
+export interface EvaluationFailure {
   error: string;
   input: {
     text: string;
@@ -58,6 +59,6 @@ export interface EvaluationError {
  * Batch evaluation result
  */
 export interface BatchEvaluationResult<T = EvaluationResult> {
-  results: Array<T | EvaluationError>;
+  results: Array<T | EvaluationFailure>;
   summary: BatchSummary;
 }

--- a/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
+++ b/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
@@ -54,6 +54,29 @@ describe('wrapProviderError — status-code classification', () => {
     expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(RateLimitError);
   });
 
+  // The shape a bring-your-own llmProvider produces: it wraps its vendor SDK's
+  // error rather than re-raising it, so the status is one link down. Reading
+  // only the outermost error would turn a rate limit into a permanent failure.
+  it('finds a loose status nested in the cause chain', () => {
+    const vendor = Object.assign(new Error('429 Too Many Requests'), { status: 429 });
+    const wrapped = wrapProviderError(new Error('gateway call failed', { cause: vendor }), CONTEXT);
+    expect(wrapped).toBeInstanceOf(RateLimitError);
+    expect(wrapped.retryable).toBe(true);
+  });
+
+  it('prefers the outermost loose status over a deeper one', () => {
+    const inner = Object.assign(new Error('inner'), { status: 500 });
+    const outer = Object.assign(new Error('outer'), { statusCode: 401, cause: inner });
+    expect(wrapProviderError(outer, CONTEXT)).toBeInstanceOf(AuthenticationError);
+  });
+
+  it('ignores a non-numeric status rather than reading it as a code', () => {
+    const err = Object.assign(new Error('nope'), { status: '429' });
+    const wrapped = wrapProviderError(err, CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect((wrapped as LLMProviderError).statusCode).toBeNull();
+  });
+
   it('falls back to the catch-all when no status is available', () => {
     const wrapped = wrapProviderError(new Error('something opaque'), CONTEXT);
     expect(wrapped).toBeInstanceOf(LLMProviderError);
@@ -239,19 +262,6 @@ describe('wrapProviderError — retryability comes through end to end', () => {
     expect(wrapProviderError(makeAPICallError(401, 'nope'), CONTEXT).retryable).toBe(false);
   });
 
-  it("honours the provider's own isRetryable verdict over the status heuristic", () => {
-    const err = new APICallError({
-      message: 'permanent server-side rejection',
-      url: 'https://api.example.com/v1/chat',
-      requestBodyValues: {},
-      statusCode: 500,
-      responseHeaders: {},
-      responseBody: '',
-      isRetryable: false,
-    });
-
-    expect(wrapProviderError(err, CONTEXT).retryable).toBe(false);
-  });
 });
 
 describe('wrapProviderError — transport failures stay classified and retryable', () => {
@@ -313,14 +323,78 @@ describe('wrapProviderError — unusable model output is our fault, not the depe
     expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(LLMOutputProcessingError);
   });
 
-  it('outranks a status code carried alongside it', () => {
-    const parse = new JSONParseError({ text: 'nope', cause: new Error('bad') });
+  // A 5xx whose body is an HTML error page surfaces as a parse failure nested
+  // under the APICallError. That is the service failing, not the model, and
+  // resampling it immediately would hammer a server that is already down.
+  it('yields to an HTTP error status, so a 500 with an unparseable body backs off', () => {
+    const parse = new JSONParseError({ text: '<html>502</html>', cause: new Error('bad') });
     const wrapped = wrapProviderError(
       Object.assign(makeAPICallError(500, 'server'), { cause: parse }),
       CONTEXT,
     );
 
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect(wrapped).not.toBeInstanceOf(LLMOutputProcessingError);
+    expect(wrapped.retryable).toBe(true);
+  });
+
+  it('still claims a parse failure on a successful response', () => {
+    const parse = new JSONParseError({ text: '{"a":', cause: new Error('unexpected end') });
+    const wrapped = wrapProviderError(
+      Object.assign(makeAPICallError(200, 'ok'), { cause: parse }),
+      CONTEXT,
+    );
+
     expect(wrapped).toBeInstanceOf(LLMOutputProcessingError);
+  });
+
+  // 400 is the first failing status, and a 3xx is not a failure at all — the
+  // boundary decides whether the request or the response is blamed.
+  it.each([
+    [400, false],
+    [399, true],
+  ])('treats %i as a parse failure: %s', (status, isParseFailure) => {
+    const parse = new JSONParseError({ text: '<html>oops</html>', cause: new Error('bad') });
+    const wrapped = wrapProviderError(
+      Object.assign(makeAPICallError(status, 'upstream'), { cause: parse }),
+      CONTEXT,
+    );
+
+    expect(wrapped instanceof LLMOutputProcessingError).toBe(isParseFailure);
+  });
+});
+
+describe('wrapProviderError — the dependency verdict may widen, never narrow', () => {
+  const withVerdict = (statusCode: number, isRetryable: boolean) =>
+    new APICallError({
+      message: 'upstream',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode,
+      responseHeaders: {},
+      responseBody: '',
+      isRetryable,
+    });
+
+  it('honours an upstream true on a status our own rule would not retry', () => {
+    // 409 Conflict: the AI SDK retries it, "iff 5xx" alone would not.
+    expect(wrapProviderError(withVerdict(409, true), CONTEXT).retryable).toBe(true);
+  });
+
+  it('keeps the 5xx floor when the upstream verdict says otherwise', () => {
+    expect(wrapProviderError(withVerdict(500, false), CONTEXT).retryable).toBe(true);
+  });
+
+  it('never lets an upstream flag make an auth failure retryable', () => {
+    const wrapped = wrapProviderError(withVerdict(403, true), CONTEXT);
+    expect(wrapped).toBeInstanceOf(AuthenticationError);
+    expect(wrapped.retryable).toBe(false);
+  });
+
+  it('never lets an upstream flag stop a rate limit from retrying', () => {
+    const wrapped = wrapProviderError(withVerdict(429, false), CONTEXT);
+    expect(wrapped).toBeInstanceOf(RateLimitError);
+    expect(wrapped.retryable).toBe(true);
   });
 });
 
@@ -379,9 +453,13 @@ describe('wrapProviderError — classification boundaries', () => {
     );
   });
 
-  it('maps an AbortError name to RequestTimeoutError', () => {
+  // AbortError is deliberate caller cancellation, not a timeout — retrying it
+  // would re-issue a request the caller just called off.
+  it('does not treat an AbortError as a retryable timeout', () => {
     const aborted = Object.assign(new Error('aborted'), { name: 'AbortError' });
-    expect(wrapProviderError(aborted, CONTEXT)).toBeInstanceOf(RequestTimeoutError);
+    const wrapped = wrapProviderError(aborted, CONTEXT);
+    expect(wrapped).not.toBeInstanceOf(RequestTimeoutError);
+    expect(wrapped.retryable).toBe(false);
   });
 
   // An errno we do not recognise must fall to the catch-all, not be guessed at.
@@ -433,6 +511,26 @@ describe('wrapProviderError — retry-after parsing', () => {
     const wrapped = withHeader({ 'retry-after': '0.25' });
     expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBe(250);
   });
+
+  it('reads a mixed-case Retry-After', () => {
+    const wrapped = withHeader({ 'Retry-After': '3' });
+    expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBe(3000);
+  });
+
+  // A zero delay would read as "retry immediately", which is never what a rate
+  // limiter meant — and `Number('')` is also 0, so this guards the empty header.
+  it.each([['zero', '0'], ['empty', ''], ['negative', '-5']])(
+    'rejects a %s Retry-After',
+    (_why, value) => {
+      const wrapped = withHeader({ 'retry-after': value });
+      expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBeNull();
+    }
+  );
+
+  it('falls through to retry-after-ms when the seconds header is unusable', () => {
+    const wrapped = withHeader({ 'retry-after': '0', 'retry-after-ms': '1500' });
+    expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBe(1500);
+  });
 });
 
 describe('wrapProviderError — requestId header fallbacks', () => {
@@ -458,6 +556,21 @@ describe('wrapProviderError — requestId header fallbacks', () => {
   it('is null when no known header is present', () => {
     const wrapped = wrapProviderError(withHeaders({ 'x-other': 'nope' }), CONTEXT) as DependencyError;
     expect(wrapped.requestId).toBeNull();
+  });
+
+  // HTTP header names are case-insensitive, and a custom `fetch` need not
+  // lower-case them on the way in.
+  it('reads a header the transport left mixed-case', () => {
+    const wrapped = wrapProviderError(withHeaders({ 'X-Request-Id': 'req_mixed' }), CONTEXT) as DependencyError;
+    expect(wrapped.requestId).toBe('req_mixed');
+  });
+
+  it('prefers x-request-id over the later fallbacks', () => {
+    const wrapped = wrapProviderError(
+      withHeaders({ 'x-amzn-requestid': 'req_amzn', 'x-request-id': 'req_x' }),
+      CONTEXT
+    ) as DependencyError;
+    expect(wrapped.requestId).toBe('req_x');
   });
 });
 

--- a/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
+++ b/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { APICallError } from 'ai';
-import { wrapProviderError, ConfigurationError, AuthenticationError, RateLimitError, APIError } from '../../../src/errors.js';
+import {
+  wrapProviderError,
+  ConfigurationError,
+  AuthenticationError,
+  RateLimitError,
+  RequestTimeoutError,
+  LLMProviderError,
+  DependencyError,
+  EvaluatorError,
+  KnowledgeGraphError,
+  LLMOutputProcessingError,
+  NetworkError,
+  InputValidationError,
+  StandardNotFoundError,
+} from '../../../src/errors.js';
+
+const CONTEXT = { dependency: 'openai' as const, model: 'gpt-4o-2024-11-20' };
 
 const makeAPICallError = (statusCode: number, message: string) =>
   new APICallError({
@@ -13,48 +29,200 @@ const makeAPICallError = (statusCode: number, message: string) =>
     isRetryable: false,
   });
 
-describe('wrapProviderError — model-not-found detection', () => {
-  it('returns ConfigurationError for a 404 APICallError', () => {
-    const err = makeAPICallError(404, "The model 'gpt-fake' does not exist");
-    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+describe('wrapProviderError — status-code classification', () => {
+  it.each([
+    [404, ConfigurationError],
+    [401, AuthenticationError],
+    [403, AuthenticationError],
+    [429, RateLimitError],
+    [408, RequestTimeoutError],
+    [500, LLMProviderError],
+    [503, LLMProviderError],
+    [400, LLMProviderError],
+  ])('maps %i to %s', (status, expected) => {
+    expect(wrapProviderError(makeAPICallError(status, 'boom'), CONTEXT)).toBeInstanceOf(expected);
   });
 
-  it('returns ConfigurationError for a 400 APICallError with model-related message', () => {
-    const err = makeAPICallError(400, 'model gpt-fake-99 does not exist or you do not have access');
-    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+  it('reads statusCode from a plain Error property', () => {
+    const err = Object.assign(new Error('nope'), { statusCode: 401 });
+    expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(AuthenticationError);
   });
 
-  it('does NOT return ConfigurationError for a 400 without model-related message', () => {
-    const err = makeAPICallError(400, 'Invalid request: missing required field');
-    expect(wrapProviderError(err)).not.toBeInstanceOf(ConfigurationError);
-    expect(wrapProviderError(err)).toBeInstanceOf(APIError);
+  it('reads statusCode from the `status` alias', () => {
+    const err = Object.assign(new Error('nope'), { status: 429 });
+    expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(RateLimitError);
   });
 
-  it('returns ConfigurationError for a plain Error with statusCode: 404 property', () => {
-    const err = Object.assign(new Error("The model 'gpt-fake' does not exist"), { statusCode: 404 });
-    expect(wrapProviderError(err)).toBeInstanceOf(ConfigurationError);
+  it('falls back to the catch-all when no status is available', () => {
+    const wrapped = wrapProviderError(new Error('something opaque'), CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect((wrapped as LLMProviderError).statusCode).toBeNull();
+  });
+
+  it('handles a non-Error throw', () => {
+    const wrapped = wrapProviderError('just a string', CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect(wrapped.message).toBe('just a string');
+  });
+
+  it('substitutes a default message only when the provider gave none', () => {
+    expect(wrapProviderError(new Error(''), CONTEXT).message).toBe('API request failed');
+    expect(wrapProviderError(new Error('upstream detail'), CONTEXT).message).toBe('upstream detail');
   });
 });
 
-describe('wrapProviderError — existing error type detection (regression)', () => {
-  it('returns AuthenticationError for 401', () => {
-    const err = makeAPICallError(401, 'Invalid API key');
-    expect(wrapProviderError(err)).toBeInstanceOf(AuthenticationError);
+describe('wrapProviderError — message text never reclassifies', () => {
+  // Wording is not a contract. A 400 whose prose mentions a bad model stays the
+  // catch-all; only structured signals may narrow the class.
+  it('does not promote a 400 with model-not-found prose to ConfigurationError', () => {
+    const err = makeAPICallError(400, "model 'gpt-fake-99' does not exist or you do not have access");
+    expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(LLMProviderError);
+    expect(wrapProviderError(err, CONTEXT)).not.toBeInstanceOf(ConfigurationError);
   });
 
-  it('returns AuthenticationError for 403', () => {
-    const err = makeAPICallError(403, 'Forbidden');
-    expect(wrapProviderError(err)).toBeInstanceOf(AuthenticationError);
+  it.each([
+    'ECONNREFUSED connecting to api.example.com',
+    'ENOTFOUND api.example.com',
+    'socket hang up: network unreachable',
+    'the request timed out after 30s',
+  ])('does not classify %s by prose', (message) => {
+    const wrapped = wrapProviderError(new Error(message), CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect(wrapped).not.toBeInstanceOf(NetworkError);
+    expect(wrapped).not.toBeInstanceOf(RequestTimeoutError);
+  });
+});
+
+describe('wrapProviderError — diagnostic attribution', () => {
+  it('attaches dependency, status, model and the original cause', () => {
+    const original = makeAPICallError(500, 'upstream exploded');
+    const wrapped = wrapProviderError(original, CONTEXT) as DependencyError;
+
+    expect(wrapped.dependency).toBe('openai');
+    expect(wrapped.statusCode).toBe(500);
+    expect(wrapped.model).toBe('gpt-4o-2024-11-20');
+    expect(wrapped.cause).toBe(original);
   });
 
-  it('returns RateLimitError for 429', () => {
-    const err = makeAPICallError(429, 'Rate limit exceeded');
-    expect(wrapProviderError(err)).toBeInstanceOf(RateLimitError);
+  it('carries the upstream message rather than a generic substitute', () => {
+    const wrapped = wrapProviderError(makeAPICallError(401, 'key sk-abc revoked on 2026-01-01'), CONTEXT);
+    expect(wrapped.message).toBe('key sk-abc revoked on 2026-01-01');
   });
 
-  it('returns generic APIError for 500', () => {
-    const err = makeAPICallError(500, 'Internal server error');
-    expect(wrapProviderError(err)).toBeInstanceOf(APIError);
-    expect(wrapProviderError(err)).not.toBeInstanceOf(ConfigurationError);
+  it('extracts requestId from either casing', () => {
+    const camel = Object.assign(new Error('x'), { statusCode: 500, requestId: 'req_camel' });
+    const snake = Object.assign(new Error('x'), { statusCode: 500, request_id: 'req_snake' });
+
+    expect((wrapProviderError(camel, CONTEXT) as DependencyError).requestId).toBe('req_camel');
+    expect((wrapProviderError(snake, CONTEXT) as DependencyError).requestId).toBe('req_snake');
+  });
+
+  it('defaults model and requestId to null rather than undefined', () => {
+    const wrapped = wrapProviderError(new Error('x'), { dependency: 'google' }) as DependencyError;
+    expect(wrapped.model).toBeNull();
+    expect(wrapped.requestId).toBeNull();
+  });
+
+  it('preserves the cause and upstream detail on the ConfigurationError path', () => {
+    const original = makeAPICallError(404, 'no such model');
+    const wrapped = wrapProviderError(original, CONTEXT);
+
+    expect(wrapped.cause).toBe(original);
+    expect(wrapped.message).toContain('no such model');
+  });
+});
+
+describe('retryable is data', () => {
+  it('is false for caller faults', () => {
+    expect(new ConfigurationError('x').retryable).toBe(false);
+    expect(new InputValidationError('x').retryable).toBe(false);
+    expect(new StandardNotFoundError('x', '4.OA.A.1').retryable).toBe(false);
+  });
+
+  it('is true for output processing, which resamples rather than backs off', () => {
+    expect(new LLMOutputProcessingError('bad shape').retryable).toBe(true);
+  });
+
+  it('follows the class default for dependency failures', () => {
+    expect(new AuthenticationError('x', { dependency: 'openai' }).retryable).toBe(false);
+    expect(new RateLimitError('x', { dependency: 'openai' }).retryable).toBe(true);
+    expect(new NetworkError('x', { dependency: 'openai' }).retryable).toBe(true);
+    expect(new RequestTimeoutError('x', { dependency: 'openai' }).retryable).toBe(true);
+  });
+
+  it('makes catch-alls retryable only on 5xx', () => {
+    expect(new LLMProviderError('x', { dependency: 'openai', statusCode: 503 }).retryable).toBe(true);
+    expect(new LLMProviderError('x', { dependency: 'openai', statusCode: 400 }).retryable).toBe(false);
+    expect(new LLMProviderError('x', { dependency: 'openai' }).retryable).toBe(false);
+    expect(new KnowledgeGraphError('x', { statusCode: 500 }).retryable).toBe(true);
+    expect(new KnowledgeGraphError('x', { statusCode: 404 }).retryable).toBe(false);
+  });
+
+  it('lets an explicit override win over both the 5xx rule and the class default', () => {
+    expect(
+      new LLMProviderError('x', { dependency: 'openai', statusCode: 503, retryable: false }).retryable,
+    ).toBe(false);
+    expect(
+      new AuthenticationError('x', { dependency: 'openai', retryable: true }).retryable,
+    ).toBe(true);
+  });
+});
+
+describe('taxonomy shape', () => {
+  it('classifies by fault domain, so a bad standards code is the caller’s fault', () => {
+    const err = new StandardNotFoundError('unknown code', '9.ZZ.Z.9');
+    expect(err).toBeInstanceOf(InputValidationError);
+    expect(err).not.toBeInstanceOf(DependencyError);
+    expect(err.statementCode).toBe('9.ZZ.Z.9');
+  });
+
+  it('puts every external failure under DependencyError', () => {
+    for (const err of [
+      new AuthenticationError('x', { dependency: 'openai' }),
+      new RateLimitError('x', { dependency: 'google' }),
+      new NetworkError('x', { dependency: 'anthropic' }),
+      new RequestTimeoutError('x', { dependency: 'openai' }),
+      new LLMProviderError('x', { dependency: 'openai' }),
+      new KnowledgeGraphError('x'),
+    ]) {
+      expect(err).toBeInstanceOf(DependencyError);
+      expect(err).toBeInstanceOf(EvaluatorError);
+    }
+  });
+
+  it('defaults the Knowledge Graph dependency without the caller naming it', () => {
+    expect(new KnowledgeGraphError('x').dependency).toBe('knowledge-graph');
+  });
+
+  // `name` is the canonical error code that reports group failures on, so every
+  // class must carry its own.
+  it('names each class as its own canonical error code', () => {
+    const dep = { dependency: 'openai' as const };
+    expect(new ConfigurationError('x').name).toBe('ConfigurationError');
+    expect(new InputValidationError('x').name).toBe('InputValidationError');
+    expect(new StandardNotFoundError('x', 'c').name).toBe('StandardNotFoundError');
+    expect(new LLMOutputProcessingError('x').name).toBe('LLMOutputProcessingError');
+    expect(new AuthenticationError('x', dep).name).toBe('AuthenticationError');
+    expect(new RateLimitError('x', dep).name).toBe('RateLimitError');
+    expect(new NetworkError('x', dep).name).toBe('NetworkError');
+    expect(new RequestTimeoutError('x', dep).name).toBe('RequestTimeoutError');
+    expect(new LLMProviderError('x', dep).name).toBe('LLMProviderError');
+    expect(new KnowledgeGraphError('x').name).toBe('KnowledgeGraphError');
+  });
+
+  it('exposes retryAfterMs on rate limits, null when the provider omitted it', () => {
+    expect(new RateLimitError('x', { dependency: 'openai', retryAfterMs: 2500 }).retryAfterMs).toBe(2500);
+    expect(new RateLimitError('x', { dependency: 'openai' }).retryAfterMs).toBeNull();
+  });
+
+  it('defaults a rate limit to 429 but lets the provider’s status win', () => {
+    expect(new RateLimitError('x', { dependency: 'openai' }).statusCode).toBe(429);
+    expect(new RateLimitError('x', { dependency: 'openai', statusCode: 529 }).statusCode).toBe(529);
+  });
+
+  it('exposes validationErrors on output processing failures', () => {
+    const details = [{ path: 'evaluations', identifier: 'LC-1' }];
+    expect(new LLMOutputProcessingError('x', details).validationErrors).toEqual(details);
+    expect(new LLMOutputProcessingError('x').validationErrors).toBeNull();
   });
 });

--- a/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
+++ b/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { APICallError } from 'ai';
+import { APICallError, JSONParseError, TypeValidationError } from 'ai';
 import {
   wrapProviderError,
   ConfigurationError,
@@ -18,6 +18,8 @@ import {
 
 const CONTEXT = { dependency: 'openai' as const, model: 'gpt-4o-2024-11-20' };
 
+// isRetryable is deliberately left to the AI SDK's own default (408/409/429/5xx),
+// so these fixtures behave like errors the provider actually produces.
 const makeAPICallError = (statusCode: number, message: string) =>
   new APICallError({
     message,
@@ -26,7 +28,6 @@ const makeAPICallError = (statusCode: number, message: string) =>
     statusCode,
     responseHeaders: {},
     responseBody: message,
-    isRetryable: false,
   });
 
 describe('wrapProviderError — status-code classification', () => {
@@ -107,14 +108,6 @@ describe('wrapProviderError — diagnostic attribution', () => {
   it('carries the upstream message rather than a generic substitute', () => {
     const wrapped = wrapProviderError(makeAPICallError(401, 'key sk-abc revoked on 2026-01-01'), CONTEXT);
     expect(wrapped.message).toBe('key sk-abc revoked on 2026-01-01');
-  });
-
-  it('extracts requestId from either casing', () => {
-    const camel = Object.assign(new Error('x'), { statusCode: 500, requestId: 'req_camel' });
-    const snake = Object.assign(new Error('x'), { statusCode: 500, request_id: 'req_snake' });
-
-    expect((wrapProviderError(camel, CONTEXT) as DependencyError).requestId).toBe('req_camel');
-    expect((wrapProviderError(snake, CONTEXT) as DependencyError).requestId).toBe('req_snake');
   });
 
   it('defaults model and requestId to null rather than undefined', () => {
@@ -224,5 +217,281 @@ describe('taxonomy shape', () => {
     const details = [{ path: 'evaluations', identifier: 'LC-1' }];
     expect(new LLMOutputProcessingError('x', details).validationErrors).toEqual(details);
     expect(new LLMOutputProcessingError('x').validationErrors).toBeNull();
+  });
+});
+
+describe('wrapProviderError — retryability comes through end to end', () => {
+  // The gap that let a regression through: retryability was only ever tested by
+  // direct construction, never through the function every evaluator calls.
+  it('keeps a 5xx retryable', () => {
+    expect(wrapProviderError(makeAPICallError(503, 'unavailable'), CONTEXT).retryable).toBe(true);
+  });
+
+  it('keeps a 429 retryable', () => {
+    expect(wrapProviderError(makeAPICallError(429, 'slow down'), CONTEXT).retryable).toBe(true);
+  });
+
+  it('keeps a 400 non-retryable', () => {
+    expect(wrapProviderError(makeAPICallError(400, 'bad request'), CONTEXT).retryable).toBe(false);
+  });
+
+  it('keeps auth failures non-retryable', () => {
+    expect(wrapProviderError(makeAPICallError(401, 'nope'), CONTEXT).retryable).toBe(false);
+  });
+
+  it("honours the provider's own isRetryable verdict over the status heuristic", () => {
+    const err = new APICallError({
+      message: 'permanent server-side rejection',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode: 500,
+      responseHeaders: {},
+      responseBody: '',
+      isRetryable: false,
+    });
+
+    expect(wrapProviderError(err, CONTEXT).retryable).toBe(false);
+  });
+});
+
+describe('wrapProviderError — transport failures stay classified and retryable', () => {
+  const transport = (props: Record<string, unknown>) =>
+    Object.assign(new Error('boom'), props);
+
+  it.each(['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'EAI_AGAIN', 'EPIPE'])(
+    'maps errno %s to a retryable NetworkError',
+    (code) => {
+      const wrapped = wrapProviderError(transport({ code }), CONTEXT);
+      expect(wrapped).toBeInstanceOf(NetworkError);
+      expect(wrapped.retryable).toBe(true);
+    },
+  );
+
+  it.each(['ETIMEDOUT', 'UND_ERR_HEADERS_TIMEOUT'])(
+    'maps errno %s to a retryable RequestTimeoutError',
+    (code) => {
+      const wrapped = wrapProviderError(transport({ code }), CONTEXT);
+      expect(wrapped).toBeInstanceOf(RequestTimeoutError);
+      expect(wrapped.retryable).toBe(true);
+    },
+  );
+
+  it('maps an AbortSignal timeout by its DOMException name', () => {
+    const wrapped = wrapProviderError(new DOMException('aborted', 'TimeoutError'), CONTEXT);
+    expect(wrapped).toBeInstanceOf(RequestTimeoutError);
+    expect(wrapped.retryable).toBe(true);
+  });
+
+  it('maps a 408 to RequestTimeoutError', () => {
+    expect(wrapProviderError(makeAPICallError(408, 'too slow'), CONTEXT)).toBeInstanceOf(
+      RequestTimeoutError,
+    );
+  });
+
+  it('finds a transport failure nested in the cause chain', () => {
+    const nested = Object.assign(new Error('fetch failed'), {
+      cause: Object.assign(new Error('inner'), { code: 'ECONNREFUSED' }),
+    });
+
+    expect(wrapProviderError(nested, CONTEXT)).toBeInstanceOf(NetworkError);
+  });
+});
+
+describe('wrapProviderError — unusable model output is our fault, not the dependency’s', () => {
+  it('maps a schema type-validation failure to LLMOutputProcessingError', () => {
+    const err = new TypeValidationError({ value: { nope: true }, cause: new Error('bad shape') });
+    const wrapped = wrapProviderError(err, CONTEXT);
+
+    expect(wrapped).toBeInstanceOf(LLMOutputProcessingError);
+    expect(wrapped).not.toBeInstanceOf(DependencyError);
+    // Sampling variance, so it resamples immediately rather than backing off.
+    expect(wrapped.retryable).toBe(true);
+  });
+
+  it('maps unparseable JSON to LLMOutputProcessingError', () => {
+    const err = new JSONParseError({ text: '{"a":', cause: new Error('unexpected end') });
+    expect(wrapProviderError(err, CONTEXT)).toBeInstanceOf(LLMOutputProcessingError);
+  });
+
+  it('outranks a status code carried alongside it', () => {
+    const parse = new JSONParseError({ text: 'nope', cause: new Error('bad') });
+    const wrapped = wrapProviderError(
+      Object.assign(makeAPICallError(500, 'server'), { cause: parse }),
+      CONTEXT,
+    );
+
+    expect(wrapped).toBeInstanceOf(LLMOutputProcessingError);
+  });
+});
+
+describe('wrapProviderError — structured diagnostics from the provider', () => {
+  const withHeaders = (headers: Record<string, string>, status = 429) =>
+    new APICallError({
+      message: 'rate limited',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode: status,
+      responseHeaders: headers,
+      responseBody: '',
+      isRetryable: true,
+    });
+
+  it('reads retryAfterMs from the retry-after header, converting seconds', () => {
+    const wrapped = wrapProviderError(withHeaders({ 'retry-after': '3' }), CONTEXT) as RateLimitError;
+    expect(wrapped.retryAfterMs).toBe(3000);
+  });
+
+  it('reads retryAfterMs from retry-after-ms when present', () => {
+    const wrapped = wrapProviderError(
+      withHeaders({ 'retry-after-ms': '1500' }),
+      CONTEXT,
+    ) as RateLimitError;
+    expect(wrapped.retryAfterMs).toBe(1500);
+  });
+
+  it('leaves retryAfterMs null when the provider sent no hint', () => {
+    const wrapped = wrapProviderError(withHeaders({}), CONTEXT) as RateLimitError;
+    expect(wrapped.retryAfterMs).toBeNull();
+  });
+
+  it('reads requestId from the response headers, which is where providers put it', () => {
+    const wrapped = wrapProviderError(
+      withHeaders({ 'x-request-id': 'req_abc123' }, 500),
+      CONTEXT,
+    ) as DependencyError;
+    expect(wrapped.requestId).toBe('req_abc123');
+  });
+});
+
+describe('wrapProviderError — classification boundaries', () => {
+  const withCode = (code: string) => Object.assign(new Error('boom'), { code });
+
+  it.each(['EHOSTUNREACH', 'ENETUNREACH'])(
+    'maps host/net unreachable errno %s to NetworkError',
+    (code) => {
+      expect(wrapProviderError(withCode(code), CONTEXT)).toBeInstanceOf(NetworkError);
+    },
+  );
+
+  it('maps UND_ERR_BODY_TIMEOUT to RequestTimeoutError', () => {
+    expect(wrapProviderError(withCode('UND_ERR_BODY_TIMEOUT'), CONTEXT)).toBeInstanceOf(
+      RequestTimeoutError,
+    );
+  });
+
+  it('maps an AbortError name to RequestTimeoutError', () => {
+    const aborted = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    expect(wrapProviderError(aborted, CONTEXT)).toBeInstanceOf(RequestTimeoutError);
+  });
+
+  // An errno we do not recognise must fall to the catch-all, not be guessed at.
+  it.each(['EACCES', 'ENOENT', 'EWHATEVER'])('does not treat errno %s as transport', (code) => {
+    const wrapped = wrapProviderError(withCode(code), CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect(wrapped).not.toBeInstanceOf(NetworkError);
+    expect(wrapped).not.toBeInstanceOf(RequestTimeoutError);
+  });
+});
+
+describe('wrapProviderError — hostile inputs', () => {
+  it.each([null, undefined, 0, false])('survives a thrown %s', (thrown) => {
+    const wrapped = wrapProviderError(thrown, CONTEXT);
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+  });
+
+  it('terminates on a self-referencing cause chain', () => {
+    const loop = new Error('round and round') as Error & { cause?: unknown };
+    loop.cause = loop;
+
+    expect(wrapProviderError(loop, CONTEXT)).toBeInstanceOf(LLMProviderError);
+  });
+});
+
+describe('wrapProviderError — retry-after parsing', () => {
+  const withHeader = (headers: Record<string, string>) =>
+    new APICallError({
+      message: 'rate limited',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: headers,
+      responseBody: '',
+    });
+
+  // Retry-After may legally be an HTTP-date, which we cannot use as a delay.
+  it('ignores a non-numeric Retry-After rather than emitting NaN', () => {
+    const wrapped = withHeader({ 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' });
+    expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBeNull();
+  });
+
+  it('prefers retry-after seconds over retry-after-ms when both are present', () => {
+    const wrapped = withHeader({ 'retry-after': '2', 'retry-after-ms': '9999' });
+    expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBe(2000);
+  });
+
+  it('rounds fractional seconds to whole milliseconds', () => {
+    const wrapped = withHeader({ 'retry-after': '0.25' });
+    expect((wrapProviderError(wrapped, CONTEXT) as RateLimitError).retryAfterMs).toBe(250);
+  });
+});
+
+describe('wrapProviderError — requestId header fallbacks', () => {
+  const withHeaders = (headers: Record<string, string>) =>
+    new APICallError({
+      message: 'server error',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode: 500,
+      responseHeaders: headers,
+      responseBody: '',
+    });
+
+  it.each([
+    ['x-request-id', 'req_x'],
+    ['request-id', 'req_plain'],
+    ['x-amzn-requestid', 'req_amzn'],
+  ])('reads %s', (header, value) => {
+    const wrapped = wrapProviderError(withHeaders({ [header]: value }), CONTEXT) as DependencyError;
+    expect(wrapped.requestId).toBe(value);
+  });
+
+  it('is null when no known header is present', () => {
+    const wrapped = wrapProviderError(withHeaders({ 'x-other': 'nope' }), CONTEXT) as DependencyError;
+    expect(wrapped.requestId).toBeNull();
+  });
+});
+
+describe('wrapProviderError — provider errors without response headers', () => {
+  // responseHeaders is optional on APICallError, so every header read must
+  // tolerate its absence rather than throwing while classifying an error.
+  const headerless = new APICallError({
+    message: 'rate limited',
+    url: 'https://api.example.com/v1/chat',
+    requestBodyValues: {},
+    statusCode: 429,
+    responseBody: '',
+  });
+
+  it('classifies without crashing', () => {
+    expect(wrapProviderError(headerless, CONTEXT)).toBeInstanceOf(RateLimitError);
+  });
+
+  it('leaves retryAfterMs and requestId null', () => {
+    const wrapped = wrapProviderError(headerless, CONTEXT) as RateLimitError;
+    expect(wrapped.retryAfterMs).toBeNull();
+    expect(wrapped.requestId).toBeNull();
+  });
+
+  it('ignores a non-numeric retry-after-ms', () => {
+    const bad = new APICallError({
+      message: 'rate limited',
+      url: 'https://api.example.com/v1/chat',
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { 'retry-after-ms': 'soon' },
+      responseBody: '',
+    });
+
+    expect((wrapProviderError(bad, CONTEXT) as RateLimitError).retryAfterMs).toBeNull();
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GradeLevelAppropriatenessEvaluator } from '../../../src/evaluators/grade-level-appropriateness.js';
-import { ConfigurationError, ValidationError } from '../../../src/errors.js';
+import { ConfigurationError, InputValidationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
 /**
@@ -109,14 +109,14 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
   });
 
   describe('Input Validation', () => {
-    it('should throw ValidationError for empty text', async () => {
+    it('should throw InputValidationError for empty text', async () => {
       await expect(evaluator.evaluate(''))
-        .rejects.toThrow(ValidationError);
+        .rejects.toThrow(InputValidationError);
     });
 
-    it('should throw ValidationError for text that is too short', async () => {
+    it('should throw InputValidationError for text that is too short', async () => {
       await expect(evaluator.evaluate('Hi'))
-        .rejects.toThrow(ValidationError);
+        .rejects.toThrow(InputValidationError);
     });
   });
 

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -4,7 +4,7 @@ import {
   Jurisdiction,
   type MathStandardsAlignmentEvaluatorConfig,
 } from '../../../../src/evaluators/math/standards-alignment.js';
-import { ConfigurationError, ValidationError, APIError, KnowledgeGraphError, RateLimitError } from '../../../../src/errors.js';
+import { ConfigurationError, InputValidationError, LLMOutputProcessingError, KnowledgeGraphError, RateLimitError } from '../../../../src/errors.js';
 import type { LLMProvider } from '../../../../src/providers/base.js';
 import type { KnowledgeGraphClient } from '../../../../src/knowledge-graph/client.js';
 
@@ -191,29 +191,31 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
-  it('throws APIError when LLM returns fewer evaluations than LCs', async () => {
+  it('throws LLMOutputProcessingError when LLM returns fewer evaluations than LCs', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue({
       ...MOCK_BATCH_RESPONSE,
       data: { evaluations: [MOCK_BATCH_RESPONSE.data.evaluations[0]] }, // only lc-001, missing lc-002
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow(APIError);
+    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow(
+      LLMOutputProcessingError,
+    );
     await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow('missing verified evaluations for LC identifiers');
   });
 
-  it('throws ValidationError for empty question', async () => {
+  it('throws InputValidationError for empty question', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate('', STATEMENT_CODE, JURISDICTION)).rejects.toThrow(ValidationError);
+    await expect(evaluator.evaluate('', STATEMENT_CODE, JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
-  it('throws ValidationError for question exceeding max length', async () => {
+  it('throws InputValidationError for question exceeding max length', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate('x'.repeat(10_001), STATEMENT_CODE, JURISDICTION)).rejects.toThrow(ValidationError);
+    await expect(evaluator.evaluate('x'.repeat(10_001), STATEMENT_CODE, JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
-  it('throws ValidationError for empty statementCode', async () => {
+  it('throws InputValidationError for empty statementCode', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate(QUESTION, '', JURISDICTION)).rejects.toThrow(ValidationError);
+    await expect(evaluator.evaluate(QUESTION, '', JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
   it('correctly handles kindergarten standard', async () => {
@@ -323,7 +325,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (per-question codes)',
 // ---------------------------------------------------------------------------
 
 describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () => {
-  it('throws ValidationError for empty items list', async () => {
+  it('throws InputValidationError for empty items list', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
     expect(await evaluator.evaluateItems([], JURISDICTION)).toEqual([]);
   });
@@ -428,7 +430,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
         data: { standards: [{ standard: STATEMENT_CODE, relevant: true }] },
         model: 'anthropic:claude-haiku-4-5-20251001', usage: { inputTokens: 50, outputTokens: 20 }, latencyMs: 200,
       })
-      .mockRejectedValue(new APIError('rate limited', 429));
+      .mockRejectedValue(new RateLimitError('rate limited', { dependency: 'anthropic' }));
 
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
     const results = await evaluator.evaluateItems(
@@ -509,14 +511,14 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
 // ---------------------------------------------------------------------------
 
 describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
-  it('throws ValidationError for empty questions array', async () => {
+  it('throws InputValidationError for empty questions array', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluateByGrade([], '3', JURISDICTION)).rejects.toThrow(ValidationError);
+    await expect(evaluator.evaluateByGrade([], '3', JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
-  it('throws ValidationError for invalid grade', async () => {
+  it('throws InputValidationError for invalid grade', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluateByGrade([QUESTION], '13', JURISDICTION)).rejects.toThrow(ValidationError);
+    await expect(evaluator.evaluateByGrade([QUESTION], '13', JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
   it('fetches standards for grade and jurisdiction, deduping codes reused across courses', async () => {
@@ -644,12 +646,11 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     expect(errored).toHaveLength(1);
     expect(errored[0].statementCode).toBe('BAD.CODE');
     // A report needs to group failures by kind, not by message text.
-    expect(errored[0].error?.code).toBe('KNOWLEDGE_GRAPH_ERROR');
     expect(errored[0].error?.name).toBe('KnowledgeGraphError');
   });
 
   it('carries statusCode and retryable through so a report can separate transient failures', async () => {
-    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(new RateLimitError('slow down'));
+    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(new RateLimitError('slow down', { dependency: 'anthropic' }));
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
 
     const results = await evaluator.evaluateItems(
@@ -659,7 +660,6 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
 
     expect(results[0].standards[0].error).toMatchObject({
       name: 'RateLimitError',
-      code: 'RATE_LIMIT_ERROR',
       statusCode: 429,
       retryable: true,
     });
@@ -683,7 +683,9 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
   });
 
   it('surfaces an LLM failure as a per-pair error rather than rejecting', async () => {
-    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(new APIError('rate limited', 429));
+    vi.mocked(mockProvider.generateStructured).mockRejectedValueOnce(
+      new RateLimitError('rate limited', { dependency: 'anthropic' }),
+    );
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
 
     const results = await evaluator.evaluateItems(
@@ -751,9 +753,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     );
 
     expect(results).toHaveLength(2);
-    expect(results[0].standards[0].error?.code).toBe('VALIDATION_ERROR');
     // Same shape as every other failure, so grouping by name does not miss these.
-    expect(results[0].standards[0].error?.name).toBe('ValidationError');
+    expect(results[0].standards[0].error?.name).toBe('InputValidationError');
     expect(results[0].standards[0].statementCode).toBe(STATEMENT_CODE);
     expect(results[1].standards[0].error).toBeUndefined();
     expect(results[1].standards[0].alignedCount).toBe(2);
@@ -770,7 +771,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
 
     expect(results).toHaveLength(1);
     expect(results[0].standards).toEqual([]);
-    expect(results[0].error).toMatchObject({ code: 'VALIDATION_ERROR', name: 'ValidationError' });
+    expect(results[0].error).toMatchObject({ name: 'InputValidationError' });
   });
 
   it('excludes an invalid item from the progress denominator', async () => {

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TextComplexityEvaluator } from '../../../src/evaluators/text-complexity.js';
-import { ConfigurationError, ValidationError } from '../../../src/errors.js';
+import { ConfigurationError, InputValidationError } from '../../../src/errors.js';
 
 // Mock telemetry to avoid real HTTP calls
 vi.mock('../../../src/telemetry/client.js', () => ({
@@ -178,7 +178,7 @@ describe('TextComplexityEvaluator', () => {
     });
 
     it('should validate text input', async () => {
-      await expect(evaluator.evaluate('', '5')).rejects.toThrow(ValidationError);
+      await expect(evaluator.evaluate('', '5')).rejects.toThrow(InputValidationError);
       await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(
         'Text cannot be empty or contain only whitespace'
       );
@@ -191,16 +191,16 @@ describe('TextComplexityEvaluator', () => {
       const text = 'The cat sat on the mat.';
 
       await expect(evaluator.evaluate(text, 'invalid')).rejects.toThrow(
-        ValidationError
+        InputValidationError
       );
       await expect(evaluator.evaluate(text, 'invalid')).rejects.toThrow(
         'Invalid grade "invalid"'
       );
 
       // Grades outside supported range (K, 1, 2 not supported)
-      await expect(evaluator.evaluate(text, 'K')).rejects.toThrow(ValidationError);
-      await expect(evaluator.evaluate(text, '1')).rejects.toThrow(ValidationError);
-      await expect(evaluator.evaluate(text, '2')).rejects.toThrow(ValidationError);
+      await expect(evaluator.evaluate(text, 'K')).rejects.toThrow(InputValidationError);
+      await expect(evaluator.evaluate(text, '1')).rejects.toThrow(InputValidationError);
+      await expect(evaluator.evaluate(text, '2')).rejects.toThrow(InputValidationError);
     });
 
     it('should accept all supported grades', async () => {

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -309,4 +309,37 @@ describe('providerContext — dependency attribution', () => {
       model: 'gateway:openai-compatible',
     });
   });
+
+  // A label carrying no model id still names the vendor where it can, and never
+  // reports an empty model — a blank attribution is worse than a redundant one.
+  it.each([
+    ['openai', 'openai', 'openai'],
+    ['openai:', 'openai', 'openai:'],
+  ])('keeps %s whole as model when it carries no model id', (label, dependency, model) => {
+    expect(probe().contextFor(label)).toEqual({ dependency, model });
+  });
+
+  it.each([
+    ['the empty label', ''],
+    ['a label with no prefix', ':gpt-4o'],
+    // Prefix matching is exact: a differently-cased vendor is not our vendor.
+    ['a differently-cased vendor', 'OpenAI:gpt-4o'],
+  ])('reports custom for %s', (_why, label) => {
+    expect(probe().contextFor(label)).toEqual({ dependency: 'custom', model: label });
+  });
+
+  // Binds attribution to the label VercelAIProvider actually emits. Without it
+  // every case here is hand-written, so a label-format change would reroute all
+  // real traffic to `custom` with the suite still green.
+  it('names the vendor for a label a real provider emits', () => {
+    const provider = createProvider({
+      type: 'openai',
+      model: 'gpt-4o-2024-11-20',
+      apiKey: 'k',
+    });
+    expect(probe().contextFor(provider.label)).toEqual({
+      dependency: 'openai',
+      model: 'gpt-4o-2024-11-20',
+    });
+  });
 });

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
 import { SmkEvaluator } from '../../../src/evaluators/smk.js';
-import { VALIDATION_LIMITS, Provider } from '../../../src/evaluators/base.js';
+import { VALIDATION_LIMITS, Provider, BaseEvaluator } from '../../../src/evaluators/base.js';
 import { ConfigurationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 import { createProvider } from '../../../src/providers/index.js';
@@ -250,6 +250,63 @@ describe('Input Validation - Grade Validation', () => {
 
       await expect(evaluator.evaluate(validText, grade))
         .rejects.toThrow(`Invalid grade "${grade}". Supported grades for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+    });
+  });
+});
+
+describe('providerContext — dependency attribution', () => {
+  // Exposed via a minimal subclass because providerContext is protected.
+  class Probe extends BaseEvaluator {
+    static readonly metadata = {
+      id: 'probe',
+      name: 'Probe',
+      description: 'test seam',
+      supportedGrades: ['3'] as const,
+      defaultProviders: [Provider.Google] as const,
+    };
+    contextFor(label: string) {
+      return this.providerContext({
+        label,
+        generateStructured: vi.fn(),
+        generateText: vi.fn(),
+      });
+    }
+  }
+
+  const probe = () =>
+    new Probe({ googleApiKey: 'k', telemetry: false });
+
+  it.each([
+    ['openai:gpt-4o-2024-11-20', 'openai', 'gpt-4o-2024-11-20'],
+    ['google:gemini-3-flash-preview', 'google', 'gemini-3-flash-preview'],
+    ['anthropic:claude-opus-5', 'anthropic', 'claude-opus-5'],
+  ])('names the vendor for %s and strips it from model', (label, dependency, model) => {
+    expect(probe().contextFor(label)).toEqual({ dependency, model });
+  });
+
+  // A modelOverride resolves to one of our vendors, so it is still nameable —
+  // overriding does not make a call "custom".
+  it('reports the overridden vendor, not custom', () => {
+    expect(probe().contextFor('anthropic:claude-haiku-4-5-20251001')).toEqual({
+      dependency: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+    });
+  });
+
+  // An injected llmProvider labels itself; the vendor is the caller's to know.
+  it.each([
+    ['azure:gpt-4o', 'azure:gpt-4o'],
+    ['bedrock:anthropic.claude-v2', 'bedrock:anthropic.claude-v2'],
+    ['my-gateway', 'my-gateway'],
+  ])('reports custom for the unrecognised label %s, keeping it as model', (label, model) => {
+    expect(probe().contextFor(label)).toEqual({ dependency: 'custom', model });
+  });
+
+  it('does not let a vendor name appear anywhere in the label pass as that vendor', () => {
+    // Only the prefix counts — a model id mentioning a vendor must not win.
+    expect(probe().contextFor('gateway:openai-compatible')).toEqual({
+      dependency: 'custom',
+      model: 'gateway:openai-compatible',
     });
   });
 });

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { KnowledgeGraphClient } from '../../../src/knowledge-graph/client.js';
-import { KnowledgeGraphError, AuthenticationError, RateLimitError, NetworkError } from '../../../src/errors.js';
+import {
+  KnowledgeGraphError,
+  AuthenticationError,
+  RateLimitError,
+  NetworkError,
+  RequestTimeoutError,
+  StandardNotFoundError,
+  InputValidationError,
+} from '../../../src/errors.js';
 
 // openapi-fetch calls response.text() when there is no Content-Length header,
 // then JSON.parse()s the result. Both text and json must reflect the same body.
@@ -45,9 +53,11 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
     expect(info.description).toBeUndefined();
   });
 
-  it('throws KnowledgeGraphError when no standard found', async () => {
+  it('throws StandardNotFoundError when no standard found', async () => {
     mockFetch(200, []);
-    await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('X.YZ.A.1')).rejects.toThrow(KnowledgeGraphError);
+    const call = new KnowledgeGraphClient(API_KEY).getStandardInfo('X.YZ.A.1');
+    await expect(call).rejects.toThrow(StandardNotFoundError);
+    await expect(call).rejects.toBeInstanceOf(InputValidationError);
   });
 
   it('returns the first match and flags ambiguity when a code matches multiple standards', async () => {
@@ -238,11 +248,14 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
     await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d')).rejects.toThrow(NetworkError);
   });
 
-  it('throws NetworkError with timeout message when AbortSignal fires', async () => {
+  it('throws RequestTimeoutError, not NetworkError, when AbortSignal fires', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('aborted', 'TimeoutError')));
     const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
-    expect(err).toBeInstanceOf(NetworkError);
+    expect(err).toBeInstanceOf(RequestTimeoutError);
+    expect(err).not.toBeInstanceOf(NetworkError);
     expect(err.message).toContain('timed out');
+    expect(err.dependency).toBe('knowledge-graph');
+    expect(err.retryable).toBe(true);
   });
 
   it('sends x-api-key header', async () => {

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -226,14 +226,60 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('throws AuthenticationError on 401', async () => {
-    mockFetch(401, 'Unauthorized');
-    await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d')).rejects.toThrow(AuthenticationError);
+  it.each([401, 403])('throws AuthenticationError on %i', async (status) => {
+    mockFetch(status, 'Unauthorized');
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toContain('Unauthorized');
+  });
+
+  // Reading the body is best-effort: a failure there must not mask the status
+  // we already know, nor leak "undefined" into the message.
+  it('classifies by status when the error body cannot be read', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      headers: new Headers(),
+      json: () => Promise.reject(new Error('stream closed')),
+      text: () => Promise.reject(new Error('stream closed')),
+    }));
+
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(KnowledgeGraphError);
+    expect(err.statusCode).toBe(503);
+    // An unreadable body contributes nothing — not "undefined", not a placeholder.
+    expect(err.message).toBe('Knowledge Graph request failed (503): ');
   });
 
   it('throws RateLimitError on 429', async () => {
     mockFetch(429, 'Too Many Requests');
     await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d')).rejects.toThrow(RateLimitError);
+  });
+
+  // Attribution and diagnostics are what let a caller tell a KG outage from an
+  // LLM one, so they must survive the trip out of the middleware.
+  it('attributes an HTTP failure to the knowledge graph, with status, request id and body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Headers({ 'content-type': 'text/plain', 'x-request-id': 'req_kg' }),
+      json: () => Promise.resolve('slow down'),
+      text: () => Promise.resolve('slow down'),
+    }));
+
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.dependency).toBe('knowledge-graph');
+    expect(err.statusCode).toBe(429);
+    expect(err.requestId).toBe('req_kg');
+    expect(err.message).toContain('slow down');
+  });
+
+  it('leaves requestId null when the response carries no request id', async () => {
+    mockFetch(500, 'Server Error');
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err.requestId).toBeNull();
+    expect(err.message).toContain('Server Error');
   });
 
   it('throws KnowledgeGraphError with statusCode on 500', async () => {
@@ -244,8 +290,46 @@ describe('KnowledgeGraphClient - getStandardInfo', () => {
   });
 
   it('throws NetworkError when fetch throws', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
-    await expect(new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d')).rejects.toThrow(NetworkError);
+    const cause = new Error('ECONNREFUSED');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(cause));
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.dependency).toBe('knowledge-graph');
+    expect(err.cause).toBe(cause);
+    expect(err.message).toContain('ECONNREFUSED');
+  });
+
+  it('bounds the request with a timeout signal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse([{ caseIdentifierUUID: 'u1' }]));
+    vi.stubGlobal('fetch', fetchMock);
+    await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d');
+
+    // Without this the client would hang indefinitely on an unresponsive KG.
+    expect(fetchMock.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('reports a non-Error rejection rather than losing it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue('socket hang up'));
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(NetworkError);
+    expect(err.message).toContain('socket hang up');
+  });
+
+  // openapi-fetch parses the body itself, so a KG that answers 200 with
+  // non-JSON surfaces as a SyntaxError from deep inside the client.
+  it('wraps a malformed JSON body as a KnowledgeGraphError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve('<html>gateway</html>'),
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    }));
+
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardInfo('3.MD.C.7.d').catch((e) => e);
+    expect(err).toBeInstanceOf(KnowledgeGraphError);
+    expect(err.message).toContain('invalid JSON');
+    expect(err.cause).toBeInstanceOf(SyntaxError);
   });
 
   it('throws RequestTimeoutError, not NetworkError, when AbortSignal fires', async () => {

--- a/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StandardsCatalog } from '../../../src/knowledge-graph/standards-catalog.js';
 import { Jurisdiction } from '../../../src/knowledge-graph/types.js';
-import { ConfigurationError, AuthenticationError, ValidationError } from '../../../src/errors.js';
+import { ConfigurationError, AuthenticationError, InputValidationError } from '../../../src/errors.js';
 
 function okResponse(body: unknown) {
   const text = JSON.stringify(body);
@@ -71,7 +71,7 @@ describe('StandardsCatalog - construction', () => {
     async (code) => {
       const fetchMock = vi.fn();
       vi.stubGlobal('fetch', fetchMock);
-      await expect(catalog().getStandard(code)).rejects.toThrow(ValidationError);
+      await expect(catalog().getStandard(code)).rejects.toThrow(InputValidationError);
       expect(fetchMock).not.toHaveBeenCalled();
     },
   );

--- a/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
+++ b/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
@@ -337,6 +337,54 @@ describe('VercelAIProvider - request assembly', () => {
     await new mod.VercelAIProvider({ ...CONFIG, maxRetries: 3 }).generateStructured({ messages, schema });
     expect(generateText.mock.calls[1][0].maxRetries).toBe(3);
   });
+
+  it('passes the request schema through as the structured output', async () => {
+    const { mod, generateText } = await loadProvider();
+    const messages = [{ role: 'user' as const, content: 'hi' }];
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema });
+
+    // `Output.object` is stubbed as an identity, so its argument is observable.
+    expect(generateText.mock.calls[0][0].output).toEqual({ schema });
+  });
+
+  it('applies the same maxRetries policy to generateText', async () => {
+    const { mod, generateText } = await loadProvider();
+    const messages = [{ role: 'user' as const, content: 'hi' }];
+
+    await new mod.VercelAIProvider(CONFIG).generateText(messages);
+    expect(generateText.mock.calls[0][0].maxRetries).toBe(0);
+
+    await new mod.VercelAIProvider({ ...CONFIG, maxRetries: 3 }).generateText(messages);
+    expect(generateText.mock.calls[1][0].maxRetries).toBe(3);
+  });
+
+  // Only a system-role message may be hoisted: promoting a user turn to `system`
+  // would silently rewrite the prompt the caller asked us to send.
+  it('omits system in generateText when the conversation has no system message', async () => {
+    const { mod, generateText } = await loadProvider();
+    const messages = [{ role: 'user' as const, content: 'rate this' }];
+    await new mod.VercelAIProvider(CONFIG).generateText(messages);
+
+    const call = generateText.mock.calls[0][0];
+    expect(call).not.toHaveProperty('system');
+    expect(call.messages).toEqual(messages);
+  });
+
+  // latencyMs is reported as telemetry, so a sign or operand slip would ship
+  // epoch-scale garbage rather than an obviously wrong number.
+  it.each([
+    ['generateStructured', (p: { generateStructured: (r: unknown) => Promise<{ latencyMs: number }> }) =>
+      p.generateStructured({ messages: [{ role: 'user', content: 'hi' }], schema })],
+    ['generateText', (p: { generateText: (m: unknown) => Promise<{ latencyMs: number }> }) =>
+      p.generateText([{ role: 'user', content: 'hi' }])],
+  ])('reports an elapsed-time latency from %s', async (_name, call) => {
+    const { mod } = await loadProvider();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await call(new mod.VercelAIProvider(CONFIG) as any);
+
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.latencyMs).toBeLessThan(60_000);
+  });
 });
 
 describe('createProvider - custom provider dispatch', () => {


### PR DESCRIPTION
Three commits, reviewable in order:

1. **`cb22de09`** — the taxonomy: renames, new classes, new fields. No classification change.
2. **`6c7518bf`** — the classifier: how a thrown value becomes one of those classes.
3. **`a62c526e`** — hardening from review: classification precedence, header handling, attribution edge cases.

The first two ship together because splitting them across PRs leaves a window where transient failures are non-retryable.

### Taxonomy

```
EvaluatorError (abstract)
├── ConfigurationError            caller
├── InputValidationError          caller
│   └── StandardNotFoundError
├── EvaluationError (abstract)    our logic, after the call succeeded
│   └── LLMOutputProcessingError  retry immediately
└── DependencyError (abstract)    external system
    ├── AuthenticationError · RateLimitError · NetworkError · RequestTimeoutError
    ├── LLMProviderError          catch-all, retryable iff 5xx
    └── KnowledgeGraphError       catch-all, retryable iff 5xx
```

`APIError` is removed — its two roles split into `DependencyError` (base) and `LLMProviderError` (catch-all). Renames: `ValidationError` → `InputValidationError`, `TimeoutError` → `RequestTimeoutError`, `retryAfter` → `retryAfterMs`.

New fields: `retryable` on every error; `dependency`, `statusCode`, `requestId`, `model` on dependency failures; `validationErrors` on output failures; `cause` preserved throughout, which nothing did before.

`DependencyId` is a closed union — `'openai' | 'google' | 'anthropic' | 'knowledge-graph' | 'custom'`. A bring-your-own provider labelled `azure:gpt-4o` reports `custom` and carries the whole label in `model`; adding a named dependency is a deliberate edit, not a typo that compiles.

### Classification

Structured signals only — status codes, typed AI SDK errors, and Node errnos, each searched along the cause chain. Message text is never matched: wording is not a contract, and the catch-all is safer than a wrong class.

- `NoObjectGeneratedError` / `TypeValidationError` / `JSONParseError` → `LLMOutputProcessingError`. These are what `Output.object({ schema })` throws, so they are the highest-volume real failure; none carries a status code, so a status-only classifier sent all of them to a non-retryable dependency error.
- Node errnos (`ECONNREFUSED`, `ENOTFOUND`, …) → `NetworkError`; `ETIMEDOUT`/`UND_ERR_*` and the `TimeoutError` DOMException name → `RequestTimeoutError`. `AbortError` deliberately does **not** map to a timeout — it is caller cancellation, and retrying it re-issues a request the caller just called off.
- `retryAfterMs` comes from `retry-after` / `retry-after-ms`, and `requestId` from the response headers, since `APICallError` has no such field — it was permanently null before. Header lookup is case-insensitive, because a custom `fetch` need not normalise names.
- `APICallError.isRetryable` reaches only the catch-all, whose class rule is "retryable iff 5xx" and so genuinely benefits from a vendor verdict. It can widen but never narrow: an upstream `true` cannot make an auth failure retryable, and an upstream `false` cannot defeat the 5xx floor.

**HTTP status outranks output processing.** A `JSONParseError` under a 5xx is an error page, not a malformed completion — the server is failing, not the model, and resampling immediately would hammer a service that is already down. Only unparseable *successful* responses count as our own output failure.

### Bugs fixed

- **Transient failures were becoming non-retryable.** With text matching removed and nothing replacing it, `NetworkError` and `RequestTimeoutError` were unreachable from `wrapProviderError` — a connection reset became a non-retryable catch-all. This was the reason to fold classification in rather than defer it.
- **Knowledge Graph timeouts were classified as `NetworkError`** — the branch matched the timeout but had no timeout class to map to.
- **`LLMOutputProcessingError` was unreachable for its own purpose.** Sentence Structure threw a bare `Error` on label-normalization failure, which became a non-retryable provider error.
- **Vocabulary attributed an OpenAI failure to Google.** Stage 1 runs on OpenAI, stage 2 on Google for grades 3–4. It now uses `stageDetails.length` to name the provider that actually failed instead of guessing.
- **Nine evaluators re-wrapped already-classified errors** at eleven call sites, guarding only `InputValidationError`. Widened to `EvaluatorError`.
- **`RateLimitError` let a present-but-undefined `statusCode` clobber the 429 default.**
- **A rate limit wrapped by a caller's provider became a permanent failure.** A bring-your-own `llmProvider` wraps its vendor's error rather than re-raising it, and the loose `statusCode`/`status` fallback read only the outermost error. It now walks the chain.
- **A malformed `Retry-After` read as "retry now."** `Number('')` is `0`, so an empty or non-positive header produced a zero delay — worse than no hint. Non-positive, non-finite, and implausibly large values are now discarded.
- **19 `@throws` blocks** still named `APIError`, `TimeoutError` or `ValidationError`.

### Deliberate breaks

- **`code` is removed** — the class name is the canonical error code. Nothing read the field, but telemetry's `error_code` is `error.name`, so the renames change its values (`ValidationError` → `InputValidationError`, `TimeoutError` → `RequestTimeoutError`, `APIError` → one of the new dependency classes).
- **`StandardNotFoundError` moved** to `InputValidationError`: a bad standards code is the caller's fault whichever system reports it. Consumers catching `KnowledgeGraphError` for it stop matching.
- **`EvaluationError` the result interface** is renamed `EvaluationFailure`, freeing the name for the error class.
- **A 400 whose prose says "model does not exist"** is now the catch-all rather than `ConfigurationError`. Tests are inverted to pin this.

### Not in this PR

No retry loop reads `retryable` yet — `maxRetries` still goes to the vendor SDK. Correct data, no behaviour behind it.

### Tests

Mutation testing (StrykerJS, ad-hoc — nothing committed):

| file | score | killed | survived |
|---|---|---|---|
| `src/errors.ts` | 93.06% | 226 (+2 timeout) | 17 |
| `src/knowledge-graph/client.ts` | 83.67% | 198 (+7 timeout) | 25 |
| `src/providers/ai-sdk-provider.ts` | 100% | 111 | 0 |

Gaps it found and I closed, beyond the bugs listed above: the `Retry-After` boundary (`0`, empty, negative) and the fall-through to `retry-after-ms`; the 400 boundary that decides whether the request or the response is blamed; mixed-case and preference-ordered request-id headers; degenerate provider labels (`openai`, `openai:`, `:gpt-4o`, `OpenAI:gpt-4o`); dependency, `statusCode`, `requestId` and body on Knowledge Graph HTTP failures; KG 403, an unreadable error body, a non-`Error` rejection, the timeout signal, and the malformed-JSON wrapper, which had no coverage at all; `maxRetries` and system-message hoisting on `generateText`; and `latencyMs` on both provider methods.

One test now binds attribution to a label `VercelAIProvider` actually emits — without it every label in the suite is hand-written, so a label-format change would reroute all real traffic to `custom` with the suite still green.

Every surviving mutant in `errors.ts` is equivalent or stack-shape: `Error.captureStackTrace` is V8-only, the `!== null` guards are redundant at runtime and exist for the type checker, `code !== undefined &&` is redundant because `Set.has(undefined)` is already false, optional chaining on a value the cause-chain generator guarantees non-null, and one off-by-one on an arbitrary depth limit. `client.ts`'s 25 survivors are all in code this PR does not touch — its changed region (the fetch wrapper, JSON wrapper and HTTP middleware) has none.

656/656 unit tests pass · `tsc --noEmit` clean · lint 0 errors · `package-lock.json` unchanged.

