### PR TITLE
fix(ts-sdk): send maxTokens as maxOutputTokens so the vendor SDK reads it

### DIFF
--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -47,7 +47,8 @@ export class VercelAIProvider implements LLMProvider {
       output: Output.object({ schema: request.schema }),
       temperature: request.temperature ?? 0,
       maxRetries: this.config.maxRetries ?? 0,
-      ...(request.maxTokens !== undefined ? { maxTokens: request.maxTokens } : {}),
+      // maxOutputTokens is the vendor option; `maxTokens` is silently discarded.
+      ...(request.maxTokens !== undefined ? { maxOutputTokens: request.maxTokens } : {}),
     });
 
     return {

--- a/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
+++ b/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
@@ -182,3 +182,25 @@ describe('createProvider', () => {
     expect(provider).toBeInstanceOf(mod.VercelAIProvider);
   });
 });
+
+describe('VercelAIProvider - maxTokens', () => {
+  const CONFIG: ProviderConfig = { type: 'openai', model: 'gpt-4o-mini', apiKey: 'k' };
+  const schema = z.object({ ok: z.boolean() });
+  const messages = [{ role: 'user' as const, content: 'hi' }];
+
+  it('forwards maxTokens under the vendor name the SDK actually reads', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema, maxTokens: 4096 });
+
+    const call = generateText.mock.calls[0][0];
+    expect(call.maxOutputTokens).toBe(4096);
+    expect(call).not.toHaveProperty('maxTokens');
+  });
+
+  it('omits it entirely when unset', async () => {
+    const { mod, generateText } = await loadProvider();
+    await new mod.VercelAIProvider(CONFIG).generateStructured({ messages, schema });
+
+    expect(generateText.mock.calls[0][0]).not.toHaveProperty('maxOutputTokens');
+  });
+});


### PR DESCRIPTION
`LLMRequest.maxTokens` never reached the model. The provider passed it as `maxTokens`, but the option is `maxOutputTokens` in `ai` v7 — `grep -c "maxTokens\b"` against `ai@7.0.74`'s type definitions returns **0**, against 10 for `maxOutputTokens`.

Nothing caught it because the key sits inside a conditional spread, which defeats excess-property checking, so `tsc --noEmit` stays clean while the option silently does nothing.

No in-repo caller sets `maxTokens` today, so this changes no current behaviour — it makes a public option work rather than no-op.

### Tests

Two cases: the value is forwarded under the name the SDK actually reads (and the discarded name is absent), and it is omitted entirely when unset.

529/529 unit tests pass · `tsc --noEmit` clean · lint 0 errors.
