### PR TITLE
fix(ts-sdk)!: bound text at 1-10,000 chars measured as the caller sent it

### DIFF
--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -20,9 +20,9 @@ import type { LLMProvider } from '../providers/index.js';
  */
 export const VALIDATION_LIMITS = {
   /** Minimum text length in characters */
-  MIN_TEXT_LENGTH: 10,
-  /** Maximum text length in characters (100K chars ≈ 25K tokens) */
-  MAX_TEXT_LENGTH: 100_000,
+  MIN_TEXT_LENGTH: 1,
+  /** Maximum text length in characters */
+  MAX_TEXT_LENGTH: 10_000,
 } as const;
 
 /**
@@ -460,23 +460,20 @@ export abstract class BaseEvaluator {
       textLength: text.length,
     });
 
-    // Check if text is empty or only whitespace
-    const trimmedText = text.trim();
-    if (!trimmedText) {
+    // Rejected, not repaired — the bounds below measure the text as sent.
+    if (!text.trim()) {
       throw new InputValidationError('Text cannot be empty or contain only whitespace');
     }
 
-    // Check minimum length
-    if (trimmedText.length < VALIDATION_LIMITS.MIN_TEXT_LENGTH) {
+    if (text.length < VALIDATION_LIMITS.MIN_TEXT_LENGTH) {
       throw new InputValidationError(
-        `Text is too short. Minimum length is ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters, received ${trimmedText.length} characters`
+        `Text is too short. Minimum length is ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters, received ${text.length} characters`
       );
     }
 
-    // Check maximum length
-    if (trimmedText.length > VALIDATION_LIMITS.MAX_TEXT_LENGTH) {
+    if (text.length > VALIDATION_LIMITS.MAX_TEXT_LENGTH) {
       throw new InputValidationError(
-        `Text is too long. Maximum length is ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters, received ${trimmedText.length.toLocaleString()} characters`
+        `Text is too long. Maximum length is ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters, received ${text.length.toLocaleString()} characters`
       );
     }
   }

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -114,8 +114,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
         .rejects.toThrow(InputValidationError);
     });
 
-    it('should throw InputValidationError for text that is too short', async () => {
-      await expect(evaluator.evaluate('Hi'))
+    it('should throw InputValidationError for whitespace-only text', async () => {
+      await expect(evaluator.evaluate('   '))
         .rejects.toThrow(InputValidationError);
     });
   });

--- a/sdks/typescript/tests/unit/evaluators/intertextuality.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/intertextuality.test.ts
@@ -268,8 +268,8 @@ describe('IntertextualityEvaluator - Validation', () => {
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
-  it('rejects text below minimum length', async () => {
-    await expect(evaluator.evaluate('Short', '5')).rejects.toThrow();
+  it('rejects whitespace-only text', async () => {
+    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -268,8 +268,8 @@ describe('OrganizationalStructureEvaluator - Validation', () => {
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
-  it('rejects text below minimum length', async () => {
-    await expect(evaluator.evaluate('Short', '5')).rejects.toThrow();
+  it('rejects whitespace-only text', async () => {
+    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/purpose.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose.test.ts
@@ -268,8 +268,8 @@ describe('PurposeEvaluator - Validation', () => {
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
-  it('rejects text below minimum length', async () => {
-    await expect(evaluator.evaluate('Short', '5')).rejects.toThrow();
+  it('rejects whitespace-only text', async () => {
+    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -182,9 +182,6 @@ describe('TextComplexityEvaluator', () => {
       await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(
         'Text cannot be empty or contain only whitespace'
       );
-      await expect(evaluator.evaluate('abc', '5')).rejects.toThrow(
-        'Text is too short'
-      );
     });
 
     it('should validate grade input', async () => {

--- a/sdks/typescript/tests/unit/evaluators/text-length-reporting.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-length-reporting.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConventionalityEvaluator } from '../../../src/evaluators/conventionality.js';
+import { VALIDATION_LIMITS } from '../../../src/evaluators/base.js';
+import { InputValidationError } from '../../../src/errors.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+
+/**
+ * One length, measured on the caller's text, used for the bounds, the log line,
+ * the telemetry event and the prompt. The SDK does not normalize input: padding
+ * is the caller's to remove, not ours to repair behind their back.
+ */
+
+const mockProvider: LLMProvider = {
+  label: 'google:gemini-3-flash-preview',
+  generateStructured: vi.fn(),
+  generateText: vi.fn(),
+};
+
+vi.mock('../../../src/providers/index.js', () => ({
+  createProvider: vi.fn(() => mockProvider),
+}));
+
+// Captures what would go on the wire, rather than the argument passed in.
+const sent: Array<Record<string, unknown>> = [];
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class MockTelemetryClient {
+    send = vi.fn(async (event: Record<string, unknown>) => {
+      sent.push(event);
+    });
+  },
+}));
+
+const CORE = 'The author sustains irony throughout to critique civilized society.';
+const evaluator = () => new ConventionalityEvaluator({ googleApiKey: 'k' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sent.length = 0;
+  vi.mocked(mockProvider.generateStructured).mockResolvedValue({
+    data: { complexity_level: 'Very complex', reasoning: 'irony' },
+    model: 'gemini-3-flash-preview',
+    usage: { inputTokens: 10, outputTokens: 5 },
+    latencyMs: 1,
+  });
+});
+
+describe('text_length_chars is the length of what the caller sent', () => {
+  it('counts padding, because the model receives it too', async () => {
+    const padded = `\n\n   ${CORE}   \n\n`;
+    await evaluator().evaluate(padded, '10');
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text_length_chars).toBe(padded.length);
+    expect(sent[0].text_length_chars).not.toBe(CORE.length);
+  });
+
+  it('reports the same length on the failure path', async () => {
+    vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('upstream'));
+    const padded = `   ${CORE}   `;
+
+    await evaluator().evaluate(padded, '10').catch(() => undefined);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].status).toBe('error');
+    expect(sent[0].text_length_chars).toBe(padded.length);
+  });
+
+  // The reported number has to describe the payload, so it must agree with what
+  // the prompt actually carried.
+  it('agrees with the text sent to the model', async () => {
+    const padded = `   ${CORE}   `;
+    await evaluator().evaluate(padded, '10');
+
+    const prompt = vi.mocked(mockProvider.generateStructured).mock.calls[0][0].messages
+      .map((m) => m.content)
+      .join('');
+    expect(prompt).toContain(padded);
+    expect(sent[0].text_length_chars).toBe(padded.length);
+  });
+});
+
+describe('validation measures the caller\'s text, unmodified', () => {
+  it('is 10,000 characters', () => {
+    expect(VALIDATION_LIMITS.MAX_TEXT_LENGTH).toBe(10_000);
+  });
+
+  it('accepts text exactly at the bound', async () => {
+    const atBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH);
+    await expect(evaluator().evaluate(atBound, '10')).resolves.toBeDefined();
+  });
+
+  it('rejects one character past the bound', async () => {
+    const overBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH + 1);
+    await expect(evaluator().evaluate(overBound, '10')).rejects.toThrow(InputValidationError);
+  });
+
+  // The deliberate consequence: padding is not silently absorbed. Text that
+  // only fits once trimmed is rejected, and the caller is told the real length.
+  it('rejects text pushed past the bound by padding alone', async () => {
+    const atBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH);
+    await expect(evaluator().evaluate(`  ${atBound}  `, '10')).rejects.toThrow(
+      /Maximum length is 10,000 characters, received 10,004 characters/
+    );
+  });
+
+  // The minimum carries no product opinion: it excludes empty input and nothing
+  // else, so padding has nothing to sneak past. Meaningful minimums belong to
+  // each evaluator's input schema.
+  it('has a minimum of 1', () => {
+    expect(VALIDATION_LIMITS.MIN_TEXT_LENGTH).toBe(1);
+  });
+
+  it('accepts a single character', async () => {
+    await expect(evaluator().evaluate('a', '10')).resolves.toBeDefined();
+  });
+
+  // Trim survives as a validity test only: whitespace-only is rejected outright
+  // rather than being measured as content.
+  it.each(['   ', '\n\t\n', ' '.repeat(VALIDATION_LIMITS.MIN_TEXT_LENGTH + 5)])(
+    'rejects whitespace-only input (%j)',
+    async (blank) => {
+      await expect(evaluator().evaluate(blank, '10')).rejects.toThrow(
+        'Text cannot be empty or contain only whitespace'
+      );
+    }
+  );
+});

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VocabularyEvaluator } from '../../../src/evaluators/vocabulary.js';
 import { SmkEvaluator } from '../../../src/evaluators/smk.js';
 import { VALIDATION_LIMITS, Provider, BaseEvaluator } from '../../../src/evaluators/base.js';
-import { ConfigurationError } from '../../../src/errors.js';
+import { ConfigurationError, InputValidationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 import { createProvider } from '../../../src/providers/index.js';
 
@@ -189,10 +189,12 @@ describe('Input Validation - Text Validation', () => {
   });
 
   describe('Minimum length validation', () => {
-    it(`should reject text shorter than ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters`, async () => {
-      const shortText = 'Hello wo'; // 8 chars after trim
-      await expect(evaluator.evaluate(shortText, '5'))
-        .rejects.toThrow(`Text is too short. Minimum length is ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters, received 8 characters`);
+    // The SDK minimum excludes empty input only, so short-but-real text is no
+    // longer a validation failure. Meaningful minimums are declared in each
+    // evaluator's input schema.
+    it('does not reject short text as invalid input', async () => {
+      const error = await evaluator.evaluate('Hello wo', '5').catch((e) => e);
+      expect(error).not.toBeInstanceOf(InputValidationError);
     });
   });
 


### PR DESCRIPTION
Brings §4.1 bounds to their spec defaults and removes input normalization.

### Limits

`min` 10 → **1**, `max` 100,000 → **10,000**. The SDK defaults carry no product opinion: the minimum excludes empty input and nothing else. Meaningful minimums belong to each evaluator's input schema — which `math-question-alignment` already does, reading `maxLength` straight from its `input_schema.json`.

### One length, measured on the caller's text

The SDK previously validated the **trimmed** length while sending the **original** text to the model, so the bound enforced described a string the model never saw. Telemetry reported a third thing, agreeing with neither.

| | Before | After |
|---|---|---|
| Validation bounds | trimmed | as sent |
| `text_length_chars` | as sent | as sent |
| Sent to model | as sent | as sent |

`trim` survives only as a validity test — whitespace-only input is rejected outright, never repaired. Padding is the caller's to remove; absorbing it silently means never telling them their data is malformed, and billing them for characters we pretended weren't there.

### Breaking

- Text over 10,000 characters now raises `InputValidationError`, down from 100,000.
- **Text that only fits once trimmed is rejected**, with the real length reported (`received 10,004 characters`). A trailing newline on an otherwise-maximal text is enough — deliberately, since that text is what reaches the model.
- Short text is no longer rejected. `min: 1` means anything non-empty passes; evaluators that need a real floor must declare it.

Nothing in the repo is affected: the largest fixture input is 2,910 characters.

### Known dead branch

With `min: 1` the minimum check is **unreachable** — `text.length < 1` implies the empty string, which the whitespace-only check rejects first. Mutation testing confirms it: `if (false)` survives and the block reports as uncovered.

Left in place because it goes live the moment an evaluator declares a higher minimum, and because deleting it would mean re-deriving the bound later. Flagged here so the permanent coverage gap is not mistaken for a missing test — it should not be papered over with one.

### Spec follow-up

§4.1 in #162 says "Trim … then validate", "Trimmed length < min", "Trimmed length > max", and "`text_length_chars` … is the **trimmed** length". This PR contradicts all four. §4.1 also never says whether the trimmed text is the *input* or only the *measurement* — the ambiguity that let the SDK validate one string and send another. Both need fixing before #162 merges.

### Tests

12 in a new file, plus 6 existing suites updated where they asserted the old `min: 10`.

Verified load-bearing by mutation, not just by passing: reintroducing the trim in `validateText` fails 1 test, and in an evaluator's telemetry call fails 3 — so the validation and reporting paths are pinned independently. One test asserts the reported length equals the text the prompt actually carried, which is the invariant that was broken.

668/668 pass · `tsc --noEmit` clean · lint 0 errors.
