### PR TITLE
fix(ts-sdk)!: scope the Learning Commons key by purpose

### DIFF
--- a/sdks/typescript/.env.test.example
+++ b/sdks/typescript/.env.test.example
@@ -19,5 +19,5 @@
 # Anthropic API Key — https://console.anthropic.com/
 # ANTHROPIC_API_KEY=
 
-# Platform API Key - https://platform.learningcommons.org
-# PLATFORM_API_KEY=
+# Learning Commons API Key - https://platform.learningcommons.org
+# LEARNING_COMMONS_API_KEY=

--- a/sdks/typescript/src/batch/README.md
+++ b/sdks/typescript/src/batch/README.md
@@ -22,7 +22,7 @@ evaluators-batch
 # Non-interactive (CI): every input supplied up front, never prompts
 evaluators-batch corpus.csv \
   --family math-standards-alignment \
-  --platform-api-key "$PLATFORM_API_KEY" \
+  --learning-commons-api-key "$LEARNING_COMMONS_API_KEY" \
   --anthropic-api-key "$ANTHROPIC_API_KEY" \
   --output-dir ./out --yes
 

--- a/sdks/typescript/src/batch/cli-args.ts
+++ b/sdks/typescript/src/batch/cli-args.ts
@@ -14,7 +14,7 @@ export interface CliArgs {
   googleApiKey?: string;
   openaiApiKey?: string;
   anthropicApiKey?: string;
-  platformApiKey?: string;
+  learningCommonsApiKey?: string;
   outputDir?: string;
   /** --model: a shortcode (e.g. "haiku") or "provider:model". */
   model?: string;
@@ -58,8 +58,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     } else if (arg === '--evaluator' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
       const values = args[++i].split(',').map((s) => s.trim()).filter(Boolean);
       result.evaluators = [...(result.evaluators ?? []), ...values];
-    } else if (arg === '--platform-api-key' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
-      result.platformApiKey = args[++i];
+    } else if (arg === '--learning-commons-api-key' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      result.learningCommonsApiKey = args[++i];
     } else if (arg === '--model' && i + 1 < args.length && !args[i + 1].startsWith('-')) {
       result.model = args[++i];
     } else if (arg === '--concurrency' && i + 1 < args.length && !args[i + 1].startsWith('-')) {

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -58,7 +58,7 @@ const KEY_CONFIG: Record<KeyKind, { envVar: string; label: string; flag: string 
   [Provider.Google]: { envVar: 'GOOGLE_API_KEY', label: 'Google API Key', flag: '--google-api-key' },
   [Provider.OpenAI]: { envVar: 'OPENAI_API_KEY', label: 'OpenAI API Key', flag: '--openai-api-key' },
   [Provider.Anthropic]: { envVar: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key', flag: '--anthropic-api-key' },
-  platform: { envVar: 'PLATFORM_API_KEY', label: 'Learning Commons Platform Key', flag: '--platform-api-key' },
+  'learning-commons': { envVar: 'LEARNING_COMMONS_API_KEY', label: 'Learning Commons API Key', flag: '--learning-commons-api-key' },
 };
 
 // ---- Help / version ----
@@ -87,7 +87,7 @@ API Keys (flag > env var; prompted when interactive, required otherwise):
   --google-api-key <key>     (env: GOOGLE_API_KEY)
   --openai-api-key <key>     (env: OPENAI_API_KEY)
   --anthropic-api-key <key>  (env: ANTHROPIC_API_KEY)
-  --platform-api-key <key>   (env: PLATFORM_API_KEY) — required by math-standards-alignment
+  --learning-commons-api-key <key> (env: LEARNING_COMMONS_API_KEY) — required by math-standards-alignment
 
 Output:
   --output-dir <path>        Write results here (default: ./batch-results-<timestamp>)
@@ -277,7 +277,7 @@ async function main() {
       [Provider.Google]: cliArgs.googleApiKey,
       [Provider.OpenAI]: cliArgs.openaiApiKey,
       [Provider.Anthropic]: cliArgs.anthropicApiKey,
-      platform: cliArgs.platformApiKey,
+      'learning-commons': cliArgs.learningCommonsApiKey,
     };
     const keys: Partial<Record<KeyKind, string>> = {};
     for (const kind of requiredKeys) {
@@ -330,7 +330,7 @@ async function main() {
       googleApiKey: keys[Provider.Google],
       openaiApiKey: keys[Provider.OpenAI],
       anthropicApiKey: keys[Provider.Anthropic],
-      platformApiKey: keys.platform,
+      learningCommonsApiKey: keys['learning-commons'],
       concurrency: cliArgs.concurrency ?? 3,
       maxRetries: cliArgs.maxRetries ?? 2,
       telemetry: !cliArgs.noTelemetry,

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -105,7 +105,7 @@ export class BatchEvaluator {
       googleApiKey: this.config.googleApiKey,
       openaiApiKey: this.config.openaiApiKey,
       anthropicApiKey: this.config.anthropicApiKey,
-      platformApiKey: this.config.platformApiKey,
+      learningCommonsApiKey: this.config.learningCommonsApiKey,
       maxRetries: this.config.maxRetries,
       telemetry: this.config.telemetry,
       modelOverride: this.config.modelOverride,

--- a/sdks/typescript/src/batch/families/family.ts
+++ b/sdks/typescript/src/batch/families/family.ts
@@ -4,8 +4,11 @@ import type { LLMProvider } from '../../providers/index.js';
 
 /**
  * A credential an evaluator family needs to run. Provider values match
- * {@link Provider}; `'learning-commons'` is the Learning Commons API key used for
- * Knowledge Graph access (distinct from any LLM provider key).
+ * {@link Provider}; `'learning-commons'` is the Learning Commons API key, which
+ * authorizes every Learning Commons service (currently the Knowledge Graph).
+ *
+ * Keyed by issuer, not by service — one key covers all of them. Failures are
+ * attributed per service instead, via `DependencyId`.
  */
 export type KeyKind = Provider | 'learning-commons';
 

--- a/sdks/typescript/src/batch/families/family.ts
+++ b/sdks/typescript/src/batch/families/family.ts
@@ -4,7 +4,7 @@ import type { LLMProvider } from '../../providers/index.js';
 
 /**
  * A credential an evaluator family needs to run. Provider values match
- * {@link Provider}; `'learning-commons'` is the Learning Commons platform key used for
+ * {@link Provider}; `'learning-commons'` is the Learning Commons API key used for
  * Knowledge Graph access (distinct from any LLM provider key).
  */
 export type KeyKind = Provider | 'learning-commons';

--- a/sdks/typescript/src/batch/families/family.ts
+++ b/sdks/typescript/src/batch/families/family.ts
@@ -4,10 +4,10 @@ import type { LLMProvider } from '../../providers/index.js';
 
 /**
  * A credential an evaluator family needs to run. Provider values match
- * {@link Provider}; `'platform'` is the Learning Commons platform key used for
+ * {@link Provider}; `'learning-commons'` is the Learning Commons platform key used for
  * Knowledge Graph access (distinct from any LLM provider key).
  */
-export type KeyKind = Provider | 'platform';
+export type KeyKind = Provider | 'learning-commons';
 
 /**
  * Declares one canonical input column a family consumes. `aliases` are
@@ -43,7 +43,7 @@ export interface FamilyRunContext {
   googleApiKey?: string;
   openaiApiKey?: string;
   anthropicApiKey?: string;
-  platformApiKey?: string;
+  learningCommonsApiKey?: string;
   maxRetries?: number;
   telemetry?: boolean | TelemetryOptions;
   modelOverride?: ModelOverride;

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -95,7 +95,7 @@ export const STANDARDS_FAMILY: EvaluatorFamily = {
   columns: STANDARDS_COLUMNS,
   maxInputRows: 5000,
   requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
-    // The platform key (Knowledge Graph) is always required; the LLM provider
+    // The Learning Commons key (Knowledge Graph) is always required; the LLM provider
     // is Anthropic unless a model override redirects it.
     return [modelOverride?.provider ?? Provider.Anthropic, 'learning-commons'];
   },

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -56,7 +56,7 @@ class StandardsRunner implements FamilyRunner {
   constructor(ctx: FamilyRunContext, selectedMemberIds?: string[]) {
     this.members = resolveMembers(STANDARDS_FAMILY, selectedMemberIds);
     this.evaluator = new MathStandardsAlignmentEvaluator({
-      platformApiKey: ctx.platformApiKey,
+      learningCommonsApiKey: ctx.learningCommonsApiKey,
       anthropicApiKey: ctx.anthropicApiKey,
       // Forwarded so a `--model google:…`/`openai:…` override has its key.
       googleApiKey: ctx.googleApiKey,
@@ -97,7 +97,7 @@ export const STANDARDS_FAMILY: EvaluatorFamily = {
   requiredKeys(_selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
     // The platform key (Knowledge Graph) is always required; the LLM provider
     // is Anthropic unless a model override redirects it.
-    return [modelOverride?.provider ?? Provider.Anthropic, 'platform'];
+    return [modelOverride?.provider ?? Provider.Anthropic, 'learning-commons'];
   },
   createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner {
     return new StandardsRunner(ctx, selectedMemberIds);

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -90,7 +90,7 @@ export interface BatchConfig {
   openaiApiKey?: string;
   anthropicApiKey?: string;
   /** Learning Commons platform key — required for families that hit the Knowledge Graph. */
-  platformApiKey?: string;
+  learningCommonsApiKey?: string;
   concurrency?: number;
   maxRetries?: number;
   /** Max concurrent Knowledge Graph HTTP calls, for families that use it. */

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -89,7 +89,7 @@ export interface BatchConfig {
   googleApiKey?: string;
   openaiApiKey?: string;
   anthropicApiKey?: string;
-  /** Learning Commons platform key — required for families that hit the Knowledge Graph. */
+  /** Learning Commons API key — required for families that hit the Knowledge Graph. */
   learningCommonsApiKey?: string;
   concurrency?: number;
   maxRetries?: number;

--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -24,6 +24,10 @@ import {
  * injected their own `llmProvider`, so the vendor is theirs to know, not ours.
  * A `modelOverride` still reports its real vendor, since it is one of ours.
  *
+ * Named per service, so `knowledge-graph` rather than `learning-commons`: the
+ * one Learning Commons key authorizes several services, and a failure needs to
+ * name the one that failed. Further Learning Commons services get their own IDs.
+ *
  * The provider arm must stay in step with the `Provider` enum, which cannot be
  * imported here without a cycle.
  */

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -45,20 +45,14 @@ export interface TelemetryOptions {
   recordInputs?: boolean;
 
   /**
-   * Opt in to **identified** telemetry by declaring the Learning Commons key
-   * here as well: events are then attributed to your Learning Commons user
-   * rather than being anonymous.
-   *
-   * Deliberately separate from the top-level `learningCommonsApiKey`. The same
-   * value may be passed to both, but each use is opted into explicitly — the
-   * SDK never repurposes a key given for API access as an identity.
+   * Learning Commons key authorizing identified telemetry: events are attributed
+   * to your Learning Commons user. Unset → events are anonymous.
    */
   learningCommonsApiKey?: string;
 }
 
 /**
- * Telemetry options after defaults are applied. The key stays optional: absent
- * means anonymous events, which is the default, not a missing value to fill in.
+ * Telemetry options after defaults are applied. The key remains optional.
  */
 type NormalizedTelemetryOptions = Required<Pick<TelemetryOptions, 'enabled' | 'recordInputs'>> &
   Pick<TelemetryOptions, 'learningCommonsApiKey'>;
@@ -105,11 +99,8 @@ export interface BaseEvaluatorConfig {
   anthropicApiKey?: string;
 
   /**
-   * Learning Commons–issued key authorizing Learning Commons API calls, such as
-   * the Knowledge Graph.
-   *
-   * Scoped to that purpose only. To also attribute telemetry to your Learning
-   * Commons user, declare it again under
+   * Learning Commons key authorizing Learning Commons API calls, such as the
+   * Knowledge Graph. For identified telemetry, see
    * {@link TelemetryOptions.learningCommonsApiKey}.
    */
   learningCommonsApiKey?: string;

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -43,7 +43,25 @@ export interface TelemetryOptions {
 
   /** Record input text in telemetry (default: false) */
   recordInputs?: boolean;
+
+  /**
+   * Opt in to **identified** telemetry by declaring the Learning Commons key
+   * here as well: events are then attributed to your Learning Commons user
+   * rather than being anonymous.
+   *
+   * Deliberately separate from the top-level `learningCommonsApiKey`. The same
+   * value may be passed to both, but each use is opted into explicitly — the
+   * SDK never repurposes a key given for API access as an identity.
+   */
+  learningCommonsApiKey?: string;
 }
+
+/**
+ * Telemetry options after defaults are applied. The key stays optional: absent
+ * means anonymous events, which is the default, not a missing value to fill in.
+ */
+type NormalizedTelemetryOptions = Required<Pick<TelemetryOptions, 'enabled' | 'recordInputs'>> &
+  Pick<TelemetryOptions, 'learningCommonsApiKey'>;
 
 /**
  * Override the provider and model used by an evaluator.
@@ -86,11 +104,15 @@ export interface BaseEvaluatorConfig {
   /** Anthropic API key (for evaluators using Claude) */
   anthropicApiKey?: string;
 
-  /** Learning Commons partner key for authenticated telemetry (optional) */
-  partnerKey?: string;
-
-  /** Learning Commons platform API key — used for Knowledge Graph API access */
-  platformApiKey?: string;
+  /**
+   * Learning Commons–issued key authorizing Learning Commons API calls, such as
+   * the Knowledge Graph.
+   *
+   * Scoped to that purpose only. To also attribute telemetry to your Learning
+   * Commons user, declare it again under
+   * {@link TelemetryOptions.learningCommonsApiKey}.
+   */
+  learningCommonsApiKey?: string;
 
   /**
    * Override the provider and model used by this evaluator.
@@ -186,7 +208,7 @@ export abstract class BaseEvaluator {
   protected telemetryClient?: TelemetryClient;
   protected logger: Logger;
   protected config: Required<Pick<BaseEvaluatorConfig, 'maxRetries'>> & {
-    telemetry: Required<TelemetryOptions>;
+    telemetry: NormalizedTelemetryOptions;
     modelOverride?: ModelOverride;
     googleApiKey?: string;
     openaiApiKey?: string;
@@ -272,7 +294,7 @@ export abstract class BaseEvaluator {
     if (this.config.telemetry.enabled) {
       this.telemetryClient = new TelemetryClient({
         endpoint: 'https://api.learningcommons.org/evaluators-telemetry/v1/events',
-        partnerKey: config.partnerKey,
+        learningCommonsApiKey: this.config.telemetry.learningCommonsApiKey,
         clientId: generateClientId(),
         enabled: true,
         logger: this.logger,
@@ -386,7 +408,7 @@ export abstract class BaseEvaluator {
    */
   private normalizeTelemetryConfig(
     telemetry: boolean | TelemetryOptions | undefined
-  ): Required<TelemetryOptions> {
+  ): NormalizedTelemetryOptions {
     // Handle boolean shortcuts
     if (telemetry === false) {
       return {
@@ -406,6 +428,7 @@ export abstract class BaseEvaluator {
     return {
       enabled: telemetry.enabled ?? true,
       recordInputs: telemetry.recordInputs ?? false,
+      learningCommonsApiKey: telemetry.learningCommonsApiKey,
     };
   }
 

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -102,8 +102,8 @@ export interface QuestionBankOptions {
 }
 
 export interface MathStandardsAlignmentEvaluatorConfig extends BaseEvaluatorConfig {
-  /** Learning Commons platform API key — required for Knowledge Graph access */
-  platformApiKey?: string;
+  /** Learning Commons API key — required by this evaluator, for Knowledge Graph access */
+  learningCommonsApiKey?: string;
   /** Max concurrent LLM calls (default: 10) */
   concurrency?: number;
   /** Max concurrent KG HTTP calls (default: 20) */
@@ -165,17 +165,17 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   private readonly llmLimit: ReturnType<typeof pLimit>;
 
   constructor(config: MathStandardsAlignmentEvaluatorConfig) {
-    // If partnerKey isn't set, fall back to platformApiKey — same LC platform key,
-    // different API surfaces (KG vs telemetry).
-    super({ ...config, partnerKey: config.partnerKey ?? config.platformApiKey });
+    super(config);
 
-    if (!config.platformApiKey && !config._kgClient) {
+    if (!config.learningCommonsApiKey && !config._kgClient) {
       throw new ConfigurationError(
-        'MathStandardsAlignmentEvaluator requires a platformApiKey to access the Learning Commons Knowledge Graph.',
+        'MathStandardsAlignmentEvaluator requires a learningCommonsApiKey to access the Learning Commons Knowledge Graph.',
       );
     }
 
-    this.kgClient = config._kgClient ?? new KnowledgeGraphClient(config.platformApiKey!, config.kgConcurrency ?? 20);
+    this.kgClient =
+      config._kgClient ??
+      new KnowledgeGraphClient(config.learningCommonsApiKey!, config.kgConcurrency ?? 20);
     this.llmLimit = pLimit(config.concurrency ?? 10);
 
     this.detailProvider = this.createConfiguredProvider(

--- a/sdks/typescript/src/knowledge-graph/standards-catalog.ts
+++ b/sdks/typescript/src/knowledge-graph/standards-catalog.ts
@@ -22,7 +22,7 @@ function localCodeProblem(normalizedCode: string): string | null {
 }
 
 export interface StandardsCatalogConfig {
-  /** Learning Commons platform API key, used for Knowledge Graph access. */
+  /** Learning Commons API key, used for Knowledge Graph access. */
   learningCommonsApiKey: string;
   /**
    * Default subject filter for all lookups (e.g. 'Mathematics'). No default,

--- a/sdks/typescript/src/knowledge-graph/standards-catalog.ts
+++ b/sdks/typescript/src/knowledge-graph/standards-catalog.ts
@@ -23,7 +23,7 @@ function localCodeProblem(normalizedCode: string): string | null {
 
 export interface StandardsCatalogConfig {
   /** Learning Commons platform API key, used for Knowledge Graph access. */
-  platformApiKey: string;
+  learningCommonsApiKey: string;
   /**
    * Default subject filter for all lookups (e.g. 'Mathematics'). No default,
    * because omitting it makes the result subject-dependent rather than wrong in a
@@ -105,8 +105,8 @@ export class StandardsCatalog {
   private readonly concurrency: number;
 
   constructor(config: StandardsCatalogConfig) {
-    if (!config.platformApiKey?.trim()) {
-      throw new ConfigurationError('platformApiKey is required to access the standards catalog.');
+    if (!config.learningCommonsApiKey?.trim()) {
+      throw new ConfigurationError('learningCommonsApiKey is required to access the standards catalog.');
     }
     const concurrency = config.concurrency ?? 20;
     if (!Number.isInteger(concurrency) || concurrency < 1) {
@@ -116,7 +116,7 @@ export class StandardsCatalog {
     const academicSubject = config.academicSubject?.trim();
 
     this.concurrency = concurrency;
-    this.kg = new KnowledgeGraphClient(config.platformApiKey, concurrency);
+    this.kg = new KnowledgeGraphClient(config.learningCommonsApiKey, concurrency);
     this.academicSubject = academicSubject || undefined;
   }
 

--- a/sdks/typescript/src/telemetry/client.ts
+++ b/sdks/typescript/src/telemetry/client.ts
@@ -33,9 +33,9 @@ export class TelemetryClient {
         'X-Client-ID': this.config.clientId,
       };
 
-      // Add partner key if provided
-      if (this.config.partnerKey) {
-        headers['X-API-Key'] = this.config.partnerKey;
+      // Identified telemetry is opt-in; absent key means anonymous events.
+      if (this.config.learningCommonsApiKey) {
+        headers['X-API-Key'] = this.config.learningCommonsApiKey;
       }
 
       const response = await fetch(this.config.endpoint, {

--- a/sdks/typescript/src/telemetry/types.ts
+++ b/sdks/typescript/src/telemetry/types.ts
@@ -79,8 +79,8 @@ export interface TelemetryConfig {
   /** Analytics service endpoint URL */
   endpoint: string;
 
-  /** Learning Commons partner key (optional, sent as X-API-Key header) */
-  partnerKey?: string;
+  /** Learning Commons key for identified telemetry (sent as X-API-Key). Absent → anonymous. */
+  learningCommonsApiKey?: string;
 
   /** Client ID for anonymous tracking (persistent UUID from ~/.config/learning-commons/config.json) */
   clientId: string;

--- a/sdks/typescript/tests/README.md
+++ b/sdks/typescript/tests/README.md
@@ -124,9 +124,6 @@ describeIntegration.concurrent('My Evaluator - Test Suite', () => {
     }
 
     evaluator = new MyEvaluator({
-      // Attributes telemetry to your Learning Commons user. The top-level
-      // `learningCommonsApiKey` authorizes API calls instead — declaring it
-      // there does not identify telemetry, and vice versa.
       telemetry: { learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY! },
       retry: false,  // We handle retries in test logic
     });

--- a/sdks/typescript/tests/README.md
+++ b/sdks/typescript/tests/README.md
@@ -124,7 +124,10 @@ describeIntegration.concurrent('My Evaluator - Test Suite', () => {
     }
 
     evaluator = new MyEvaluator({
-      learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY!,
+      // Attributes telemetry to your Learning Commons user. The top-level
+      // `learningCommonsApiKey` authorizes API calls instead — declaring it
+      // there does not identify telemetry, and vice versa.
+      telemetry: { learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY! },
       retry: false,  // We handle retries in test logic
     });
   });

--- a/sdks/typescript/tests/README.md
+++ b/sdks/typescript/tests/README.md
@@ -124,7 +124,7 @@ describeIntegration.concurrent('My Evaluator - Test Suite', () => {
     }
 
     evaluator = new MyEvaluator({
-      partnerKey: process.env.MY_PARTNER_KEY!,
+      learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY!,
       retry: false,  // We handle retries in test logic
     });
   });

--- a/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
+++ b/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
@@ -4,7 +4,7 @@ import { KnowledgeGraphClient } from '../../src/knowledge-graph/client.js';
 
 const RUN = process.env['RUN_INTEGRATION_TESTS'] === 'true';
 const ANTHROPIC_KEY = process.env['ANTHROPIC_API_KEY'];
-const PLATFORM_KEY = process.env['PLATFORM_API_KEY'];
+const LEARNING_COMMONS_KEY = process.env['LEARNING_COMMONS_API_KEY'];
 
 const itIf = (cond: boolean) => (cond ? it : it.skip);
 
@@ -26,7 +26,7 @@ const MD_C_7_FAMILY = ['3.MD.C.7', '3.MD.C.7.a', '3.MD.C.7.b', '3.MD.C.7.c', '3.
 // Instrumented evaluator wraps KnowledgeGraphClient methods to count calls.
 function makeInstrumentedEvaluator() {
   const counters = { uuidFetches: 0, lcFetches: 0, llmCalls: 0 };
-  const baseClient = new KnowledgeGraphClient(PLATFORM_KEY!);
+  const baseClient = new KnowledgeGraphClient(LEARNING_COMMONS_KEY!);
 
   // Wrap individual methods to count KG API calls
   const origInfo = baseClient.getStandardInfo.bind(baseClient);
@@ -36,7 +36,7 @@ function makeInstrumentedEvaluator() {
 
   const evaluator = new MathStandardsAlignmentEvaluator({
     anthropicApiKey: ANTHROPIC_KEY!,
-    platformApiKey: PLATFORM_KEY!,
+    learningCommonsApiKey: LEARNING_COMMONS_KEY!,
     _kgClient: baseClient,
   });
 
@@ -54,7 +54,7 @@ function makeInstrumentedEvaluator() {
 // ---------------------------------------------------------------------------
 
 describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, () => {
-  itIf(RUN && !!ANTHROPIC_KEY && !!PLATFORM_KEY)(
+  itIf(RUN && !!ANTHROPIC_KEY && !!LEARNING_COMMONS_KEY)(
     '3.MD.C.7 family: area L-shape question vs parent + all sub-standards',
     async () => {
       const questionItems = [

--- a/sdks/typescript/tests/unit/batch/cli-args.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli-args.test.ts
@@ -231,9 +231,9 @@ describe('parseArgs — family selection flags', () => {
     expect(parseArgs(['--evaluator', 'vocabulary', '--evaluator', 'purpose']).evaluators).toEqual(['vocabulary', 'purpose']);
   });
 
-  it('parses --platform-api-key (space and = form)', () => {
-    expect(parseArgs(['--platform-api-key', 'pk']).platformApiKey).toBe('pk');
-    expect(parseArgs(['--platform-api-key=pk']).platformApiKey).toBe('pk');
+  it('parses --learning-commons-api-key (space and = form)', () => {
+    expect(parseArgs(['--learning-commons-api-key', 'pk']).learningCommonsApiKey).toBe('pk');
+    expect(parseArgs(['--learning-commons-api-key=pk']).learningCommonsApiKey).toBe('pk');
   });
 
   it('parses --model and --yes/-y', () => {

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -8,11 +8,11 @@ import type { FamilyRow } from '../../../src/batch/families/family.js';
 const MEMBER = 'math.standards-alignment';
 
 describe('STANDARDS_FAMILY.requiredKeys', () => {
-  it('requires the platform key plus Anthropic by default', () => {
+  it('requires the Learning Commons key plus Anthropic by default', () => {
     expect(STANDARDS_FAMILY.requiredKeys([MEMBER])).toEqual([Provider.Anthropic, 'learning-commons']);
   });
 
-  it('swaps in the override provider (platform key still required)', () => {
+  it('swaps in the override provider (Learning Commons key still required)', () => {
     expect(
       STANDARDS_FAMILY.requiredKeys([MEMBER], { provider: Provider.Google, model: 'gemini-x' }),
     ).toEqual([Provider.Google, 'learning-commons']);

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -9,13 +9,13 @@ const MEMBER = 'math.standards-alignment';
 
 describe('STANDARDS_FAMILY.requiredKeys', () => {
   it('requires the platform key plus Anthropic by default', () => {
-    expect(STANDARDS_FAMILY.requiredKeys([MEMBER])).toEqual([Provider.Anthropic, 'platform']);
+    expect(STANDARDS_FAMILY.requiredKeys([MEMBER])).toEqual([Provider.Anthropic, 'learning-commons']);
   });
 
   it('swaps in the override provider (platform key still required)', () => {
     expect(
       STANDARDS_FAMILY.requiredKeys([MEMBER], { provider: Provider.Google, model: 'gemini-x' }),
-    ).toEqual([Provider.Google, 'platform']);
+    ).toEqual([Provider.Google, 'learning-commons']);
   });
 });
 
@@ -47,7 +47,7 @@ describe('QTC_FAMILY.requiredKeys — member selection', () => {
 });
 
 describe('STANDARDS_FAMILY.createRunner — provider-key forwarding', () => {
-  const base = { platformApiKey: 'p' };
+  const base = { learningCommonsApiKey: 'p' };
 
   it('constructs with a Google model override when the Google key is forwarded', () => {
     expect(() =>
@@ -84,7 +84,7 @@ describe('STANDARDS_FAMILY.runTask', () => {
 
   /** The runner builds a real evaluator; swap it for a stub so no network is needed. */
   function runnerWithStub(evaluate: ReturnType<typeof vi.fn>) {
-    const runner = STANDARDS_FAMILY.createRunner({ platformApiKey: 'p', anthropicApiKey: 'a', telemetry: false });
+    const runner = STANDARDS_FAMILY.createRunner({ learningCommonsApiKey: 'p', anthropicApiKey: 'a', telemetry: false });
     (runner as unknown as { evaluator: { evaluate: unknown } }).evaluator = { evaluate };
     return runner;
   }

--- a/sdks/typescript/tests/unit/evaluators/key-scoping.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/key-scoping.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MathStandardsAlignmentEvaluator } from '../../../src/evaluators/math/standards-alignment.js';
+import { ConventionalityEvaluator } from '../../../src/evaluators/conventionality.js';
+import { ConfigurationError } from '../../../src/errors.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+
+const mockProvider: LLMProvider = {
+  label: 'google:gemini-3-flash-preview',
+  generateStructured: vi.fn(),
+  generateText: vi.fn(),
+};
+
+vi.mock('../../../src/providers/index.js', () => ({
+  createProvider: vi.fn(() => mockProvider),
+}));
+
+// The real client, so header assembly is exercised rather than mocked away.
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('') });
+  vi.mocked(mockProvider.generateStructured).mockResolvedValue({
+    data: { complexity_level: 'Very complex', reasoning: 'why' },
+    model: 'gemini-3-flash-preview',
+    usage: { inputTokens: 1, outputTokens: 1 },
+    latencyMs: 1,
+  });
+});
+
+const TEXT = 'The author sustains irony throughout to critique civilized society.';
+
+async function telemetryHeaders(
+  telemetry: ConstructorParameters<typeof ConventionalityEvaluator>[0]['telemetry']
+) {
+  await new ConventionalityEvaluator({
+    googleApiKey: 'k',
+    learningCommonsApiKey: 'lc-key',
+    telemetry,
+  }).evaluate(TEXT, '10');
+
+  // Telemetry is fire-and-forget, so let the microtask queue drain.
+  await new Promise((resolve) => setImmediate(resolve));
+  return (fetchMock.mock.calls[0]?.[1]?.headers ?? {}) as Record<string, string>;
+}
+
+describe('credentials are purpose-scoped', () => {
+  // The core of the change: a key given for API access must not become an
+  // identity. Previously the KG key silently authenticated telemetry too.
+  it('does not authenticate telemetry with the top-level API key', async () => {
+    const headers = await telemetryHeaders(true);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(headers).not.toHaveProperty('X-API-Key');
+    expect(Object.values(headers)).not.toContain('lc-key');
+  });
+
+  it('authenticates telemetry only when the key is declared under telemetry', async () => {
+    const headers = await telemetryHeaders({ learningCommonsApiKey: 'lc-key' });
+
+    expect(headers['X-API-Key']).toBe('lc-key');
+  });
+
+  // Anonymous events still identify the install, just not the partner.
+  it('sends the client id either way', async () => {
+    expect(await telemetryHeaders(true)).toHaveProperty('X-Client-ID');
+  });
+
+  it('sends nothing at all when telemetry is off', async () => {
+    await telemetryHeaders(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('MathStandardsAlignmentEvaluator key requirement', () => {
+  it('requires the Learning Commons key by name', () => {
+    expect(() => new MathStandardsAlignmentEvaluator({ anthropicApiKey: 'sk-ant' })).toThrow(
+      ConfigurationError
+    );
+    expect(() => new MathStandardsAlignmentEvaluator({ anthropicApiKey: 'sk-ant' })).toThrow(
+      /learningCommonsApiKey/
+    );
+  });
+
+  // A telemetry-scoped key authorizes telemetry, not the Knowledge Graph — the
+  // fallback used to run the other way and made this construction succeed.
+  it('is not satisfied by a telemetry-scoped key', () => {
+    expect(
+      () =>
+        new MathStandardsAlignmentEvaluator({
+          anthropicApiKey: 'sk-ant',
+          telemetry: { learningCommonsApiKey: 'lc-key' },
+        })
+    ).toThrow(ConfigurationError);
+  });
+
+  it('constructs with the top-level key', () => {
+    expect(
+      () =>
+        new MathStandardsAlignmentEvaluator({
+          anthropicApiKey: 'sk-ant',
+          learningCommonsApiKey: 'lc-key',
+        })
+    ).not.toThrow();
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -89,7 +89,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('MathStandardsAlignmentEvaluator - constructor', () => {
-  it('throws ConfigurationError when neither platformApiKey nor _kgClient provided', () => {
+  it('throws ConfigurationError when neither learningCommonsApiKey nor _kgClient provided', () => {
     expect(() => new MathStandardsAlignmentEvaluator({ anthropicApiKey: 'sk-ant-test' })).toThrow(ConfigurationError);
   });
 
@@ -101,8 +101,8 @@ describe('MathStandardsAlignmentEvaluator - constructor', () => {
     expect(() => new MathStandardsAlignmentEvaluator(makeConfig())).not.toThrow();
   });
 
-  it('constructs successfully with platformApiKey instead of repository', () => {
-    expect(() => new MathStandardsAlignmentEvaluator({ anthropicApiKey: 'sk-ant-test', platformApiKey: 'pk-test' })).not.toThrow();
+  it('constructs successfully with learningCommonsApiKey instead of repository', () => {
+    expect(() => new MathStandardsAlignmentEvaluator({ anthropicApiKey: 'sk-ant-test', learningCommonsApiKey: 'pk-test' })).not.toThrow();
   });
 });
 

--- a/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
@@ -56,7 +56,7 @@ function stubResolution(candidates: unknown[], lcsByUuid: Record<string, string[
 }
 
 describe('StandardsCatalog - construction', () => {
-  it.each(['', '   '])('throws ConfigurationError for a blank platform API key (%j)', (learningCommonsApiKey) => {
+  it.each(['', '   '])('throws ConfigurationError for a blank Learning Commons API key (%j)', (learningCommonsApiKey) => {
     expect(() => new StandardsCatalog({ learningCommonsApiKey })).toThrow(ConfigurationError);
   });
 

--- a/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/standards-catalog.test.ts
@@ -27,7 +27,7 @@ function errorResponse(status: number, body = 'error') {
 beforeEach(() => { vi.unstubAllGlobals(); });
 
 const API_KEY = 'test-key';
-const catalog = () => new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: 'Mathematics' });
+const catalog = () => new StandardsCatalog({ learningCommonsApiKey: API_KEY, academicSubject: 'Mathematics' });
 
 /** One learning component per identifier, in the paginated shape the LC endpoint returns. */
 function lcPage(...identifiers: string[]) {
@@ -56,12 +56,12 @@ function stubResolution(candidates: unknown[], lcsByUuid: Record<string, string[
 }
 
 describe('StandardsCatalog - construction', () => {
-  it.each(['', '   '])('throws ConfigurationError for a blank platform API key (%j)', (platformApiKey) => {
-    expect(() => new StandardsCatalog({ platformApiKey })).toThrow(ConfigurationError);
+  it.each(['', '   '])('throws ConfigurationError for a blank platform API key (%j)', (learningCommonsApiKey) => {
+    expect(() => new StandardsCatalog({ learningCommonsApiKey })).toThrow(ConfigurationError);
   });
 
   it.each([0, -1, 2.5])('rejects concurrency %s with a clear error rather than a p-limit crash', (concurrency) => {
-    expect(() => new StandardsCatalog({ platformApiKey: API_KEY, concurrency })).toThrow(
+    expect(() => new StandardsCatalog({ learningCommonsApiKey: API_KEY, concurrency })).toThrow(
       /concurrency must be a positive integer/,
     );
   });
@@ -79,7 +79,7 @@ describe('StandardsCatalog - construction', () => {
   it('treats a whitespace-only academicSubject as absent rather than filtering on it', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [], pagination: { hasMore: false } }));
     vi.stubGlobal('fetch', fetchMock);
-    await new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: '   ' }).listStandards('3');
+    await new StandardsCatalog({ learningCommonsApiKey: API_KEY, academicSubject: '   ' }).listStandards('3');
     expect((fetchMock.mock.calls[0][0] as Request).url).not.toContain('academicSubject');
   });
 });
@@ -273,7 +273,7 @@ describe('StandardsCatalog - validateCodes', () => {
     const codes = Array.from({ length: 40 }, (_, i) => `CODE.${i}`);
 
     await expect(
-      new StandardsCatalog({ platformApiKey: API_KEY, concurrency: 2 }).validateCodes(codes),
+      new StandardsCatalog({ learningCommonsApiKey: API_KEY, concurrency: 2 }).validateCodes(codes),
     ).rejects.toThrow(AuthenticationError);
 
     // Without the early abort every one of the 40 codes would have been requested.
@@ -302,7 +302,7 @@ describe('StandardsCatalog - validateCodes', () => {
     // The realistic cause is an unrecognised academicSubject, which fails for every
     // code — so "we could not check this" alone would send the user hunting the code.
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(400, 'Bad Request')));
-    const [result] = await new StandardsCatalog({ platformApiKey: API_KEY, academicSubject: 'Maths' })
+    const [result] = await new StandardsCatalog({ learningCommonsApiKey: API_KEY, academicSubject: 'Maths' })
       .validateCodes(['3.MD.C.7.d']);
     expect(result.status).toBe('unchecked');
     expect(result.error).toContain('academicSubject');


### PR DESCRIPTION
Closes SPEC gap 11: credentials are purpose-scoped, and the SDK must not repurpose a key across scopes.

Before, `MathStandardsAlignmentEvaluator` did `partnerKey: config.partnerKey ?? config.platformApiKey` — so a key you supplied for Knowledge Graph access silently became your telemetry identity.

- One top-level **`learningCommonsApiKey`** authorizes Learning Commons API calls, replacing `platformApiKey`.
- **`telemetry.learningCommonsApiKey`** is a separate, explicit opt-in to identified telemetry, replacing `partnerKey`. Same value may be passed to both; each use is opted into.
- The `??` fallback is gone.

### Breaking

- `platformApiKey` → `learningCommonsApiKey`; `partnerKey` → `telemetry.learningCommonsApiKey`.
- The rename follows through the batch layer, the test env example, and the surrounding comments/JSDoc/test names rather than leaving two names for one key: `StandardsCatalog`, `BatchEvaluator`, the `KeyKind` union (`'platform'` → `'learning-commons'`), the CLI flag `--platform-api-key` → `--learning-commons-api-key`, and its env var `PLATFORM_API_KEY` → `LEARNING_COMMONS_API_KEY`.
- Telemetry stops being identified for anyone who was relying on the fallback. That is the fix, not a regression, but it is a behaviour change worth naming.

### Tests

7 new, exercising the real `TelemetryClient` header assembly rather than a mock. The load-bearing one asserts the top-level key never reaches an `X-API-Key` header; re-verified by reintroducing the fallback, which fails it.

Also corrected in `tests/README.md`: its example configured telemetry identity via `partnerKey`, so renaming it to a top-level `learningCommonsApiKey` had silently inverted its meaning under this PR's own rule. It now uses `telemetry.learningCommonsApiKey`.

675/675 pass · `tsc --noEmit` clean · lint 0 errors.


