### PR TITLE
fix(ts-sdk)!: rename grade to gradeLevel on the evaluator API

### DIFF
--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -74,7 +74,7 @@ type NormalizedTelemetryOptions = Required<Pick<TelemetryOptions, 'enabled' | 'r
  * Two things to know before overriding:
  *
  * - The override is evaluator-wide, not per call site. `VocabularyEvaluator`
- *   deliberately uses three models (Gemini 2.5 Pro for grades 3-4, GPT-4.1 for
+ *   deliberately uses three models (Gemini 2.5 Pro for grade levels 3-4, GPT-4.1 for
  *   5-12, GPT-4o for background knowledge); an override collapses all three.
  * - `PurposeEvaluator` takes its model from the shared cross-language eval config
  *   (`evals/prompts/purpose/config.json`), so overriding it diverges from that
@@ -493,23 +493,23 @@ export abstract class BaseEvaluator {
   }
 
   /**
-   * Validate grade is in supported range
+   * Validate gradeLevel is in supported range
    * Default implementation - can be overridden by concrete evaluators
    *
-   * @param grade - Grade level to validate
-   * @param validGrades - Set of valid grades for this evaluator
-   * @throws {InputValidationError} If grade is invalid
+   * @param gradeLevel - Grade level to validate
+   * @param validGradeLevels - Set of valid grade levels for this evaluator
+   * @throws {InputValidationError} If gradeLevel is invalid
    */
-  protected validateGrade(grade: string, validGrades: Set<string>): void {
-    this.logger.debug('Validating grade input', {
+  protected validateGradeLevel(gradeLevel: string, validGradeLevels: Set<string>): void {
+    this.logger.debug('Validating grade level input', {
       evaluator: this.getEvaluatorType(),
-      operation: 'validateGrade',
-      grade,
+      operation: 'validateGradeLevel',
+      gradeLevel,
     });
 
-    // Check if grade is in valid set
-    if (!validGrades.has(grade)) {
-      const validList = Array.from(validGrades).sort((a, b) => {
+    // Check if gradeLevel is in valid set
+    if (!validGradeLevels.has(gradeLevel)) {
+      const validList = Array.from(validGradeLevels).sort((a, b) => {
         // Sort K first, then numerically
         if (a === 'K') return -1;
         if (b === 'K') return 1;
@@ -517,7 +517,7 @@ export abstract class BaseEvaluator {
       }).join(', ');
 
       throw new InputValidationError(
-        `Invalid grade "${grade}". Supported grades for this evaluator: ${validList}`
+        `Invalid grade level "${gradeLevel}". Supported grade levels for this evaluator: ${validList}`
       );
     }
   }
@@ -566,7 +566,7 @@ export abstract class BaseEvaluator {
     status: 'success' | 'error';
     latencyMs: number;
     textLength: number;
-    grade?: string;
+    gradeLevel?: string;
     provider: string;
     errorCode?: string;
     tokenUsage?: TokenUsage;
@@ -581,7 +581,9 @@ export abstract class BaseEvaluator {
       timestamp: new Date().toISOString(),
       sdk_version: getSDKVersion(),
       evaluator_type: this.getEvaluatorType(),
-      grade: params.grade,
+      // Wire field stays `grade` until the telemetry schema is renamed with the
+      // rest of the event fields; the collector reads this name today.
+      grade: params.gradeLevel,
       status: params.status,
       error_code: params.errorCode,
       latency_ms: params.latencyMs,

--- a/sdks/typescript/src/evaluators/conventionality.ts
+++ b/sdks/typescript/src/evaluators/conventionality.ts
@@ -53,21 +53,21 @@ export class ConventionalityEvaluator extends BaseEvaluator {
    * Evaluate conventionality complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<EvaluationResult<TextComplexityLevel, ConventionalityInternal>> {
     this.logger.info('Starting Conventionality evaluation', {
       evaluator: 'conventionality',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -77,7 +77,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
     try {
       // Validate inputs — inside try so validation errors are telemetered.
       this.validateText(text);
-      this.validateGrade(grade, new Set(ConventionalityEvaluator.metadata.supportedGrades));
+      this.validateGradeLevel(gradeLevel, new Set(ConventionalityEvaluator.metadata.supportedGrades));
 
       this.logger.debug('Evaluating conventionality complexity', {
         evaluator: 'conventionality',
@@ -85,7 +85,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
       });
 
       const fkScore = calculateFleschKincaidGrade(text);
-      const response = await this.evaluateConventionality(text, grade, fkScore);
+      const response = await this.evaluateConventionality(text, gradeLevel, fkScore);
 
       stageDetails.push({
         stage: 'conventionality_evaluation',
@@ -122,7 +122,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
@@ -136,7 +136,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
       this.logger.info('Conventionality evaluation completed successfully', {
         evaluator: 'conventionality',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -148,7 +148,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
       this.logger.error('Conventionality evaluation failed', {
         evaluator: 'conventionality',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
         completedStages: stageDetails.length,
@@ -163,7 +163,7 @@ export class ConventionalityEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -186,13 +186,13 @@ export class ConventionalityEvaluator extends BaseEvaluator {
    */
   private async evaluateConventionality(
     text: string,
-    grade: string,
+    gradeLevel: string,
     fkScore: number
   ): Promise<{ data: ConventionalityInternal; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
     const response = await this.provider.generateStructured({
       messages: [
         { role: 'system', content: getSystemPrompt() },
-        { role: 'user', content: getUserPrompt(text, grade, fkScore) },
+        { role: 'user', content: getUserPrompt(text, gradeLevel, fkScore) },
       ],
       schema: ConventionalityOutputSchema,
       temperature: 0,
@@ -220,9 +220,9 @@ export class ConventionalityEvaluator extends BaseEvaluator {
  */
 export async function evaluateConventionality(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<TextComplexityLevel, ConventionalityInternal>> {
   const evaluator = new ConventionalityEvaluator(config);
-  return evaluator.evaluate(text, grade);
+  return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -40,7 +40,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
     id: 'grade-level-appropriateness',
     name: 'Grade Level Appropriateness',
     description: 'Determines appropriate grade level for text with scaffolding recommendations',
-    supportedGrades: [] as const, // No grade parameter required - evaluates what grade the text is appropriate for
+    supportedGrades: [] as const, // No gradeLevel parameter required - evaluates what grade level the text is appropriate for
     defaultProviders: [Provider.Google] as const,
   };
 
@@ -59,7 +59,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * Evaluate grade level appropriateness for a given text
    *
    * @param text - The text to evaluate
-   * @returns Evaluation result with grade recommendations and scaffolding suggestions
+   * @returns Evaluation result with grade level recommendations and scaffolding suggestions
    * @throws {InputValidationError} If text is empty or too short/long
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
@@ -100,6 +100,8 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       };
 
       const result = {
+        // `grade` is the model's output field, declared in the eval's schema —
+        // not the SDK's parameter name.
         score: response.data.grade,
         reasoning: response.data.reasoning,
         metadata: {
@@ -127,7 +129,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       this.logger.info('Grade level appropriateness evaluation completed successfully', {
         evaluator: 'grade-level-appropriateness',
         operation: 'evaluate',
-        grade: result.score,
+        gradeLevel: result.score,
         processingTimeMs: latencyMs,
       });
 

--- a/sdks/typescript/src/evaluators/intertextuality.ts
+++ b/sdks/typescript/src/evaluators/intertextuality.ts
@@ -59,18 +59,18 @@ export class IntertextualityEvaluator extends BaseEvaluator {
    * Evaluate intertextuality complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, grade: string): Promise<EvaluationResult<TextComplexityLevel, IntertextualityInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<TextComplexityLevel, IntertextualityInternal>> {
     this.logger.info('Starting Intertextuality evaluation', {
       evaluator: IntertextualityEvaluator.metadata.id,
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -79,7 +79,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
 
     try {
       this.validateText(text);
-      const gradeNum = this.parseAndValidateGrade(grade);
+      const gradeNum = this.parseAndValidateGrade(gradeLevel);
 
       const fkScore = IntertextualityEvaluator.computeFkScore(text);
       const inputs: Record<string, string> = {
@@ -118,7 +118,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade: String(gradeNum),
+        gradeLevel: String(gradeNum),
         provider: this.provider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
@@ -128,7 +128,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
       this.logger.info('Intertextuality evaluation completed successfully', {
         evaluator: IntertextualityEvaluator.metadata.id,
         operation: 'evaluate',
-        grade: gradeNum,
+        gradeLevel: gradeNum,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -140,7 +140,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
       this.logger.error('Intertextuality evaluation failed', {
         evaluator: IntertextualityEvaluator.metadata.id,
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
       });
@@ -156,7 +156,7 @@ export class IntertextualityEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade: String(grade),
+        gradeLevel: String(gradeLevel),
         provider: this.provider.label,
         tokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -169,11 +169,11 @@ export class IntertextualityEvaluator extends BaseEvaluator {
     }
   }
 
-  private parseAndValidateGrade(grade: string): number {
-    const num = Number(grade.trim());
+  private parseAndValidateGrade(gradeLevel: string): number {
+    const num = Number(gradeLevel.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
       throw new InputValidationError(
-        `Invalid grade "${grade}". Intertextuality evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
+        `Invalid grade level "${gradeLevel}". Intertextuality evaluator supports integer grade levels ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }
     return num;
@@ -197,8 +197,8 @@ export class IntertextualityEvaluator extends BaseEvaluator {
 
 export async function evaluateIntertextuality(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<TextComplexityLevel, IntertextualityInternal>> {
-  return new IntertextualityEvaluator(config).evaluate(text, grade);
+  return new IntertextualityEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -125,7 +125,7 @@ const DETAIL_MODEL: string = STEP.model.name;
 const TEMPERATURE: number | null = STEP.generation.temperature;
 const KG_SUBJECT = 'Mathematics';
 /**
- * Above this many question/standard pairs, evaluateByGrade warns. A grade can carry
+ * Above this many question/standard pairs, evaluateByGrade warns. A grade level can carry
  * over a thousand standards in some jurisdictions, so a handful of questions is
  * enough to run into five figures of LLM calls.
  */
@@ -343,7 +343,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   }
 
   // -------------------------------------------------------------------------
-  // evaluateByGrade — fetches all math standards for a grade, then evaluates
+  // evaluateByGrade — fetches all math standards for a grade level, then evaluates
   //
   // Use when you don't have a predetermined standards list. Jurisdiction
   // determines which state's adopted standards are fetched from the KG.
@@ -352,14 +352,14 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
   async evaluateByGrade(
     questions: string[],
-    grade: string,
+    gradeLevel: string,
     jurisdiction: Jurisdiction,
     options?: QuestionBankOptions,
   ): Promise<QuestionBankResult> {
     if (questions.length === 0) throw new InputValidationError('questions array must not be empty');
-    this.validateGrade(grade, new Set(SUPPORTED_GRADES));
+    this.validateGradeLevel(gradeLevel, new Set(SUPPORTED_GRADES));
 
-    const academicStandards = await this.kgClient.getStandardsByGrade(grade, {
+    const academicStandards = await this.kgClient.getStandardsByGrade(gradeLevel, {
       jurisdiction,
       academicSubject: KG_SUBJECT,
     });
@@ -376,7 +376,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     if (pairs > BY_GRADE_WARN_PAIRS) {
       this.logger.warn('Large grade-wide evaluation; each pair costs an LLM call', {
         evaluator: EVALUATOR_ID,
-        grade,
+        gradeLevel,
         jurisdiction,
         questions: questions.length,
         standards: codes.length,

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -62,18 +62,18 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * Evaluate organizational structure complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, grade: string): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
     this.logger.info('Starting Organizational Structure evaluation', {
       evaluator: OrganizationalStructureEvaluator.metadata.id,
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -82,7 +82,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
 
     try {
       this.validateText(text);
-      const gradeNum = this.parseAndValidateGrade(grade);
+      const gradeNum = this.parseAndValidateGrade(gradeLevel);
 
       const fkScore = OrganizationalStructureEvaluator.computeFkScore(text);
       const inputs: Record<string, string> = {
@@ -121,7 +121,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade: String(gradeNum),
+        gradeLevel: String(gradeNum),
         provider: this.provider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
@@ -131,7 +131,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
       this.logger.info('Organizational Structure evaluation completed successfully', {
         evaluator: OrganizationalStructureEvaluator.metadata.id,
         operation: 'evaluate',
-        grade: gradeNum,
+        gradeLevel: gradeNum,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -143,7 +143,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
       this.logger.error('Organizational Structure evaluation failed', {
         evaluator: OrganizationalStructureEvaluator.metadata.id,
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
       });
@@ -159,7 +159,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade: String(grade),
+        gradeLevel: String(gradeLevel),
         provider: this.provider.label,
         tokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -172,11 +172,11 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
     }
   }
 
-  private parseAndValidateGrade(grade: string): number {
-    const num = Number(grade.trim());
+  private parseAndValidateGrade(gradeLevel: string): number {
+    const num = Number(gradeLevel.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
       throw new InputValidationError(
-        `Invalid grade "${grade}". Organizational Structure evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
+        `Invalid grade level "${gradeLevel}". Organizational Structure evaluator supports integer grade levels ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }
     return num;
@@ -200,8 +200,8 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
 
 export async function evaluateOrganizationalStructure(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
-  return new OrganizationalStructureEvaluator(config).evaluate(text, grade);
+  return new OrganizationalStructureEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/purpose.ts
+++ b/sdks/typescript/src/evaluators/purpose.ts
@@ -62,18 +62,18 @@ export class PurposeEvaluator extends BaseEvaluator {
    * Evaluate purpose complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, grade: string): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
     this.logger.info('Starting Purpose evaluation', {
       evaluator: PurposeEvaluator.metadata.id,
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -82,7 +82,7 @@ export class PurposeEvaluator extends BaseEvaluator {
 
     try {
       this.validateText(text);
-      const gradeNum = this.parseAndValidateGrade(grade);
+      const gradeNum = this.parseAndValidateGrade(gradeLevel);
 
       const fkScore = PurposeEvaluator.computeFkScore(text);
       const inputs: Record<string, string> = {
@@ -121,7 +121,7 @@ export class PurposeEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade: String(gradeNum),
+        gradeLevel: String(gradeNum),
         provider: this.provider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
@@ -131,7 +131,7 @@ export class PurposeEvaluator extends BaseEvaluator {
       this.logger.info('Purpose evaluation completed successfully', {
         evaluator: PurposeEvaluator.metadata.id,
         operation: 'evaluate',
-        grade: gradeNum,
+        gradeLevel: gradeNum,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -143,7 +143,7 @@ export class PurposeEvaluator extends BaseEvaluator {
       this.logger.error('Purpose evaluation failed', {
         evaluator: PurposeEvaluator.metadata.id,
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
       });
@@ -159,7 +159,7 @@ export class PurposeEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade: String(grade),
+        gradeLevel: String(gradeLevel),
         provider: this.provider.label,
         tokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -172,11 +172,11 @@ export class PurposeEvaluator extends BaseEvaluator {
     }
   }
 
-  private parseAndValidateGrade(grade: string): number {
-    const num = Number(grade.trim());
+  private parseAndValidateGrade(gradeLevel: string): number {
+    const num = Number(gradeLevel.trim());
     if (!Number.isInteger(num) || num < GRADE_MIN || num > GRADE_MAX) {
       throw new InputValidationError(
-        `Invalid grade "${grade}". Purpose evaluator supports integer grades ${GRADE_MIN}–${GRADE_MAX}.`,
+        `Invalid grade level "${gradeLevel}". Purpose evaluator supports integer grade levels ${GRADE_MIN}–${GRADE_MAX}.`,
       );
     }
     return num;
@@ -200,8 +200,8 @@ export class PurposeEvaluator extends BaseEvaluator {
 
 export async function evaluatePurpose(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<PurposeComplexityLevel, PurposeInternal>> {
-  return new PurposeEvaluator(config).evaluate(text, grade);
+  return new PurposeEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -45,7 +45,7 @@ function normalizeLabel(label: string | null | undefined): TextComplexityLevel |
  * Evaluates sentence structure complexity of educational texts relative to grade level.
  * Uses a 2-stage process:
  * 1. Analyze grammatical structure (sentence types, clauses, phrases, etc.)
- * 2. Classify complexity using features and grade-specific rubric
+ * 2. Classify complexity using features and grade-level-specific rubric
  *
  * Based on Qualitative Text Complexity rubric with 4 levels:
  * - Slightly complex
@@ -87,21 +87,21 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * Evaluate sentence structure complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<EvaluationResult<TextComplexityLevel, SentenceStructureInternal>> {
     this.logger.info('Starting sentence structure evaluation', {
       evaluator: 'sentence-structure',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -111,7 +111,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
     try {
       // Validate inputs — inside try so validation errors are telemetered.
       this.validateText(text);
-      this.validateGrade(grade, new Set(SentenceStructureEvaluator.metadata.supportedGrades));
+      this.validateGradeLevel(gradeLevel, new Set(SentenceStructureEvaluator.metadata.supportedGrades));
       this.logger.debug('Stage 1: Analyzing sentence structure', {
         evaluator: 'sentence-structure',
         operation: 'sentence_analysis',
@@ -137,7 +137,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         operation: 'complexity_classification',
       });
       // Stage 2: Classify complexity
-      const complexityResponse = await this.classifyComplexity(features, grade, text);
+      const complexityResponse = await this.classifyComplexity(features, gradeLevel, text);
 
       stageDetails.push({
         stage: 'complexity_classification',
@@ -178,7 +178,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
@@ -192,7 +192,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
       this.logger.info('Sentence structure evaluation completed successfully', {
         evaluator: 'sentence-structure',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -205,7 +205,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
       this.logger.error('Sentence structure evaluation failed', {
         evaluator: 'sentence-structure',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
         completedStages: stageDetails.length,
@@ -222,7 +222,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -282,17 +282,17 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
   /**
    * Stage 2: Classify sentence structure complexity
    *
-   * Uses engineered features and grade-specific rubric to classify complexity level
+   * Uses engineered features and grade-level-specific rubric to classify complexity level
    */
   private async classifyComplexity(
     features: SentenceFeatures,
-    grade: string,
+    gradeLevel: string,
     excerpt: string
   ): Promise<{ data: ComplexityClassification; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
     // Convert features to JSON string (cast to int by default, matching Python)
     const featuresJSON = featuresToJSON(features, 1, true);
 
-    const userPrompt = getUserPromptComplexity(featuresJSON, grade, excerpt);
+    const userPrompt = getUserPromptComplexity(featuresJSON, gradeLevel, excerpt);
 
     const response = await this.provider.generateStructured({
       messages: [
@@ -341,9 +341,9 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
  */
 export async function evaluateSentenceStructure(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<TextComplexityLevel, SentenceStructureInternal>> {
   const evaluator = new SentenceStructureEvaluator(config);
-  return evaluator.evaluate(text, grade);
+  return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/smk.ts
+++ b/sdks/typescript/src/evaluators/smk.ts
@@ -53,21 +53,21 @@ export class SmkEvaluator extends BaseEvaluator {
    * Evaluate subject matter knowledge complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<EvaluationResult<TextComplexityLevel, SmkInternal>> {
     this.logger.info('Starting SMK evaluation', {
       evaluator: 'subject-matter-knowledge',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
@@ -77,7 +77,7 @@ export class SmkEvaluator extends BaseEvaluator {
     try {
       // Validate inputs — inside try so validation errors are telemetered.
       this.validateText(text);
-      this.validateGrade(grade, new Set(SmkEvaluator.metadata.supportedGrades));
+      this.validateGradeLevel(gradeLevel, new Set(SmkEvaluator.metadata.supportedGrades));
 
       this.logger.debug('Evaluating subject matter knowledge complexity', {
         evaluator: 'subject-matter-knowledge',
@@ -85,7 +85,7 @@ export class SmkEvaluator extends BaseEvaluator {
       });
 
       const fkScore = calculateFleschKincaidGrade(text);
-      const response = await this.evaluateSmk(text, grade, fkScore);
+      const response = await this.evaluateSmk(text, gradeLevel, fkScore);
 
       stageDetails.push({
         stage: 'smk_evaluation',
@@ -122,7 +122,7 @@ export class SmkEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         metadata: {
@@ -136,7 +136,7 @@ export class SmkEvaluator extends BaseEvaluator {
       this.logger.info('SMK evaluation completed successfully', {
         evaluator: 'subject-matter-knowledge',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -148,7 +148,7 @@ export class SmkEvaluator extends BaseEvaluator {
       this.logger.error('SMK evaluation failed', {
         evaluator: 'subject-matter-knowledge',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
         completedStages: stageDetails.length,
@@ -163,7 +163,7 @@ export class SmkEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -186,13 +186,13 @@ export class SmkEvaluator extends BaseEvaluator {
    */
   private async evaluateSmk(
     text: string,
-    grade: string,
+    gradeLevel: string,
     fkScore: number
   ): Promise<{ data: SmkInternal; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
     const response = await this.provider.generateStructured({
       messages: [
         { role: 'system', content: getSystemPrompt() },
-        { role: 'user', content: getUserPrompt(text, grade, fkScore) },
+        { role: 'user', content: getUserPrompt(text, gradeLevel, fkScore) },
       ],
       schema: SmkOutputSchema,
       temperature: 0,
@@ -220,9 +220,9 @@ export class SmkEvaluator extends BaseEvaluator {
  */
 export async function evaluateSmk(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<TextComplexityLevel, SmkInternal>> {
   const evaluator = new SmkEvaluator(config);
-  return evaluator.evaluate(text, grade);
+  return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/text-complexity.ts
+++ b/sdks/typescript/src/evaluators/text-complexity.ts
@@ -83,23 +83,23 @@ export class TextComplexityEvaluator extends BaseEvaluator {
    * failed sub-evaluators are represented as `{ error: Error }`.
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Map of sub-evaluator results
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {Error} If all sub-evaluators fail
    */
-  async evaluate(text: string, grade: string): Promise<TextComplexityResult> {
+  async evaluate(text: string, gradeLevel: string): Promise<TextComplexityResult> {
     this.logger.info('Starting text complexity evaluation', {
       evaluator: 'text-complexity',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
     // Use inherited validation methods
     this.validateText(text);
-    this.validateGrade(grade, new Set(TextComplexityEvaluator.metadata.supportedGrades));
+    this.validateGradeLevel(gradeLevel, new Set(TextComplexityEvaluator.metadata.supportedGrades));
 
     const startTime = Date.now();
 
@@ -110,10 +110,10 @@ export class TextComplexityEvaluator extends BaseEvaluator {
       EvaluationResult<TextComplexityLevel, SmkInternal> | { error: Error },
       EvaluationResult<TextComplexityLevel, ConventionalityInternal> | { error: Error },
     ] = await Promise.all([
-      this.limit(() => this.runSubEvaluator(this.vocabularyEvaluator, text, grade)),
-      this.limit(() => this.runSubEvaluator(this.sentenceStructureEvaluator, text, grade)),
-      this.limit(() => this.runSubEvaluator(this.smkEvaluator, text, grade)),
-      this.limit(() => this.runSubEvaluator(this.conventionalityEvaluator, text, grade)),
+      this.limit(() => this.runSubEvaluator(this.vocabularyEvaluator, text, gradeLevel)),
+      this.limit(() => this.runSubEvaluator(this.sentenceStructureEvaluator, text, gradeLevel)),
+      this.limit(() => this.runSubEvaluator(this.smkEvaluator, text, gradeLevel)),
+      this.limit(() => this.runSubEvaluator(this.conventionalityEvaluator, text, gradeLevel)),
     ]);
 
     const latencyMs = Date.now() - startTime;
@@ -133,7 +133,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
       this.logger.error('Text complexity evaluation completed with errors', {
         evaluator: 'text-complexity',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         errors,
         processingTimeMs: latencyMs,
       });
@@ -148,7 +148,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
       status: hasFailures ? 'error' : 'success',
       latencyMs,
       textLength: text.length,
-      grade,
+      gradeLevel,
       provider: this.config.modelOverride
         ? `${this.config.modelOverride.provider}:${this.config.modelOverride.model}`
         : 'composite:google+openai',
@@ -161,7 +161,7 @@ export class TextComplexityEvaluator extends BaseEvaluator {
     this.logger.info('Text complexity evaluation completed', {
       evaluator: 'text-complexity',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       processingTimeMs: latencyMs,
       hasFailures,
     });
@@ -174,12 +174,12 @@ export class TextComplexityEvaluator extends BaseEvaluator {
    * Returns the evaluation result or `{ error: Error }` if the evaluator throws.
    */
   private async runSubEvaluator<TScore, TInternal>(
-    evaluator: { evaluate(text: string, grade: string): Promise<EvaluationResult<TScore, TInternal>> },
+    evaluator: { evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<TScore, TInternal>> },
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<EvaluationResult<TScore, TInternal> | { error: Error }> {
     try {
-      return await evaluator.evaluate(text, grade);
+      return await evaluator.evaluate(text, gradeLevel);
     } catch (error) {
       return { error: error instanceof Error ? error : new Error(String(error)) };
     }
@@ -203,9 +203,9 @@ export class TextComplexityEvaluator extends BaseEvaluator {
  */
 export async function evaluateTextComplexity(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig
 ): Promise<TextComplexityResult> {
   const evaluator = new TextComplexityEvaluator(config);
-  return evaluator.evaluate(text, grade);
+  return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/vocabulary.ts
+++ b/sdks/typescript/src/evaluators/vocabulary.ts
@@ -58,12 +58,12 @@ export class VocabularyEvaluator extends BaseEvaluator {
     // Call base constructor for common setup (telemetry, API key validation, etc.)
     super(config);
 
-    // Create Google Gemini provider for complexity evaluation (grades 3-4)
+    // Create Google Gemini provider for complexity evaluation (grade levels 3-4)
     this.grades34ComplexityProvider = this.createConfiguredProvider(
       Provider.Google, 'gemini-2.5-pro', config.googleApiKey
     );
 
-    // Create OpenAI GPT-4.1 provider for complexity evaluation (grades 5-12)
+    // Create OpenAI GPT-4.1 provider for complexity evaluation (grade levels 5-12)
     this.otherGradesComplexityProvider = this.createConfiguredProvider(
       Provider.OpenAI, 'gpt-4.1-2025-04-14', config.openaiApiKey
     );
@@ -78,27 +78,27 @@ export class VocabularyEvaluator extends BaseEvaluator {
    * Evaluate vocabulary complexity for a given text and grade level
    *
    * @param text - The text to evaluate
-   * @param grade - The target grade level (3-12)
+   * @param gradeLevel - The target grade level (3-12)
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or grade is invalid
+   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<EvaluationResult<TextComplexityLevel, VocabularyInternal>> {
     this.logger.info('Starting vocabulary evaluation', {
       evaluator: 'vocabulary',
       operation: 'evaluate',
-      grade,
+      gradeLevel,
       textLength: text.length,
     });
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
-    const complexityProvider = (grade === '3' || grade === '4')
+    const complexityProvider = (gradeLevel === '3' || gradeLevel === '4')
       ? this.grades34ComplexityProvider
       : this.otherGradesComplexityProvider;
     const complexityProviderLabel = complexityProvider.label;
@@ -110,15 +110,15 @@ export class VocabularyEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      // If partners consistently pass invalid grades/text, telemetry will surface documentation gaps.
+      // If partners consistently pass invalid grade levels/text, telemetry will surface documentation gaps.
       this.validateText(text);
-      this.validateGrade(grade, new Set(VocabularyEvaluator.metadata.supportedGrades));
+      this.validateGradeLevel(gradeLevel, new Set(VocabularyEvaluator.metadata.supportedGrades));
       this.logger.debug('Stage 1: Generating background knowledge', {
         evaluator: 'vocabulary',
         operation: 'background_knowledge',
       });
       // Stage 1: Generate background knowledge assumption
-      const bgResponse = await this.getBackgroundKnowledgeAssumption(text, grade);
+      const bgResponse = await this.getBackgroundKnowledgeAssumption(text, gradeLevel);
 
       stageDetails.push({
         stage: 'background_knowledge',
@@ -136,7 +136,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
       // Stage 2: Evaluate vocabulary complexity
       const complexityResponse = await this.evaluateComplexity(
         text,
-        grade,
+        gradeLevel,
         bgResponse.knowledge.assumption,
         fkLevel
       );
@@ -176,7 +176,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: modelLabel,
         tokenUsage: totalTokenUsage,
         metadata: {
@@ -190,7 +190,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
       this.logger.info('Vocabulary evaluation completed successfully', {
         evaluator: 'vocabulary',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         score: result.score,
         processingTimeMs: latencyMs,
       });
@@ -203,7 +203,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
       this.logger.error('Vocabulary evaluation failed', {
         evaluator: 'vocabulary',
         operation: 'evaluate',
-        grade,
+        gradeLevel,
         error: error instanceof Error ? error : undefined,
         processingTimeMs: latencyMs,
         completedStages: stageDetails.length,
@@ -220,7 +220,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
         status: 'error',
         latencyMs,
         textLength: text.length,
-        grade,
+        gradeLevel,
         provider: modelLabel,
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
@@ -252,9 +252,9 @@ export class VocabularyEvaluator extends BaseEvaluator {
    */
   private async getBackgroundKnowledgeAssumption(
     text: string,
-    grade: string
+    gradeLevel: string
   ): Promise<{ knowledge: BackgroundKnowledge; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const prompt = getBackgroundKnowledgePrompt(text, grade);
+    const prompt = getBackgroundKnowledgePrompt(text, gradeLevel);
 
     const response = await this.backgroundKnowledgeProvider.generateText(
       [{ role: 'user', content: prompt }],
@@ -264,7 +264,7 @@ export class VocabularyEvaluator extends BaseEvaluator {
     return {
       knowledge: {
         assumption: response.text.trim(),
-        grade,
+        gradeLevel,
       },
       usage: response.usage,
       latencyMs: response.latencyMs,
@@ -275,18 +275,18 @@ export class VocabularyEvaluator extends BaseEvaluator {
    * Stage 2: Evaluate vocabulary complexity
    *
    * Uses the Qual Text Complexity rubric (SAP) and background knowledge to evaluate vocabulary complexity.
-   * Grades 3-4 use Gemini 2.5 Pro; grades 5-12 use GPT-4.1.
+   * Grades 3-4 use Gemini 2.5 Pro; grade levels 5-12 use GPT-4.1.
    */
   private async evaluateComplexity(
     text: string,
-    grade: string,
+    gradeLevel: string,
     backgroundKnowledge: string,
     fkLevel: number
   ): Promise<{ data: VocabularyInternal; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const systemPrompt = getSystemPrompt(grade);
-    const userPrompt = getUserPrompt(text, grade, backgroundKnowledge, fkLevel);
+    const systemPrompt = getSystemPrompt(gradeLevel);
+    const userPrompt = getUserPrompt(text, gradeLevel, backgroundKnowledge, fkLevel);
 
-    const provider = (grade === '3' || grade === '4')
+    const provider = (gradeLevel === '3' || gradeLevel === '4')
       ? this.grades34ComplexityProvider
       : this.otherGradesComplexityProvider;
 
@@ -325,9 +325,9 @@ export class VocabularyEvaluator extends BaseEvaluator {
  */
 export async function evaluateVocabulary(
   text: string,
-  grade: string,
+  gradeLevel: string,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<TextComplexityLevel, VocabularyInternal>> {
   const evaluator = new VocabularyEvaluator(config);
-  return evaluator.evaluate(text, grade);
+  return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/schemas/outputs.ts
+++ b/sdks/typescript/src/schemas/outputs.ts
@@ -51,7 +51,7 @@ export interface EvaluationFailure {
   error: string;
   input: {
     text: string;
-    grade?: string;
+    gradeLevel?: string;
   };
 }
 

--- a/sdks/typescript/src/schemas/vocabulary.ts
+++ b/sdks/typescript/src/schemas/vocabulary.ts
@@ -23,5 +23,5 @@ export type VocabularyInternal = z.infer<typeof VocabularyComplexitySchema>;
  */
 export interface BackgroundKnowledge {
   assumption: string;
-  grade: string;
+  gradeLevel: string;
 }

--- a/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  evaluateConventionality,
+  evaluateGradeLevelAppropriateness,
+  evaluateIntertextuality,
+  evaluateOrganizationalStructure,
+  evaluatePurpose,
+  evaluateSentenceStructure,
+  evaluateSmk,
+  evaluateVocabulary,
+} from '../../../src/evaluators/index.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+
+/**
+ * The functional wrappers are public API — every one is re-exported from the
+ * package root — but nothing exercised them, so a wrapper passing the wrong
+ * argument through to its evaluator would have shipped unnoticed.
+ */
+
+const mockProvider: LLMProvider = {
+  label: 'google:gemini-3-flash-preview',
+  generateStructured: vi.fn(),
+  generateText: vi.fn(),
+};
+
+vi.mock('../../../src/providers/index.js', () => ({
+  createProvider: vi.fn(() => mockProvider),
+}));
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class MockTelemetryClient {
+    send = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+// Superset of every evaluator's output shape, so one stub serves all of them.
+const RESPONSE = {
+  data: {
+    complexity_level: 'Very complex',
+    complexity_score: 'very_complex',
+    grade: '6-8',
+    alternative_grade: '9-10',
+    scaffolding_needed: 'none',
+    reasoning: 'because',
+    grade_context: 'above grade',
+    details: { detailed_summary: [], adjustment_and_scaffolding: [], recommended_use_cases: [] },
+    assumption: 'students know this',
+    // Sentence Structure's second stage reports its verdict as `answer`.
+    answer: 'Very Complex',
+    // Sentence Structure computes engineered features from its first-stage
+    // output, so every count it divides by has to be present and non-zero.
+    num_sentences: 2,
+    num_words: 20,
+    flesch_kincaid_grade: 9.1,
+    sentence_word_counts: [12, 8],
+    num_simple_sentences: 1,
+    num_compound_sentences: 1,
+    num_complex_sentences: 0,
+    num_compound_complex_sentences: 0,
+    num_other_sentences: 0,
+    num_independent_clauses: 2,
+    num_subordinate_clauses: 1,
+    num_total_clauses: 3,
+    num_sentences_with_subordinate: 1,
+    num_sentences_with_multiple_subordinates: 0,
+    num_sentences_with_embedded_clauses: 0,
+    num_prepositional_phrases: 2,
+    num_participle_phrases: 0,
+    num_appositive_phrases: 0,
+    num_simple_transitions: 1,
+    num_sophisticated_transitions: 0,
+    words_in_simple_sentences: 12,
+    words_in_compound_sentences: 8,
+    words_in_complex_sentences: 0,
+    words_in_compound_complex_sentences: 0,
+    words_in_other_sentences: 0,
+    num_one_concept_sentences: 1,
+    num_multi_concept_sentences: 1,
+    num_cleft_sentences: 0,
+    max_clauses_in_any_sentence: 2,
+  },
+  model: 'gemini-3-flash-preview',
+  usage: { inputTokens: 10, outputTokens: 5 },
+  latencyMs: 1,
+};
+
+const TEXT =
+  'The author sustains irony throughout the passage to critique the hypocrisy of civilized society.';
+const GRADE_LEVEL = '10';
+const CONFIG = {
+  googleApiKey: 'k',
+  openaiApiKey: 'k',
+  anthropicApiKey: 'k',
+  telemetry: false as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(mockProvider.generateStructured).mockResolvedValue(RESPONSE);
+  vi.mocked(mockProvider.generateText).mockResolvedValue({
+    text: 'plain text answer',
+    usage: { inputTokens: 3, outputTokens: 2 },
+    latencyMs: 1,
+  });
+});
+
+describe('functional API wrappers', () => {
+  // Each takes (text, gradeLevel, config) and must reach the LLM with both.
+  it.each([
+    ['evaluateConventionality', evaluateConventionality],
+    ['evaluateIntertextuality', evaluateIntertextuality],
+    ['evaluateOrganizationalStructure', evaluateOrganizationalStructure],
+    ['evaluatePurpose', evaluatePurpose],
+    ['evaluateSentenceStructure', evaluateSentenceStructure],
+    ['evaluateSmk', evaluateSmk],
+    ['evaluateVocabulary', evaluateVocabulary],
+  ])('%s forwards text and gradeLevel and returns a result', async (_name, fn) => {
+    const result = await (fn as (t: string, g: string, c: typeof CONFIG) => Promise<unknown>)(
+      TEXT,
+      GRADE_LEVEL,
+      CONFIG
+    );
+
+    expect(result).toBeDefined();
+    expect(mockProvider.generateStructured).toHaveBeenCalled();
+
+    // The prompt is where a swapped or dropped argument would actually show up.
+    const prompts = vi
+      .mocked(mockProvider.generateStructured)
+      .mock.calls.flatMap((call) => call[0].messages.map((m) => m.content))
+      .join('\n');
+    expect(prompts).toContain(GRADE_LEVEL);
+  });
+
+  // Grade-free by design: it decides the grade level rather than being told one.
+  it('evaluateGradeLevelAppropriateness takes no gradeLevel', async () => {
+    const result = await evaluateGradeLevelAppropriateness(TEXT, CONFIG);
+
+    expect(result.score).toBe('6-8');
+    expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a validation failure rather than swallowing it', async () => {
+    await expect(evaluateConventionality('', GRADE_LEVEL, CONFIG)).rejects.toThrow(
+      /empty|whitespace/i
+    );
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/intertextuality.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/intertextuality.test.ts
@@ -86,7 +86,7 @@ describe('IntertextualityEvaluator - Metadata', () => {
     expect(IntertextualityEvaluator.metadata.defaultProviders).not.toContain(Provider.OpenAI);
   });
 
-  it('supports integer grades 3–12', () => {
+  it('supports integer grade levels 3–12', () => {
     expect(IntertextualityEvaluator.metadata.supportedGrades).toEqual(
       ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     );

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -86,7 +86,7 @@ describe('OrganizationalStructureEvaluator - Metadata', () => {
     expect(OrganizationalStructureEvaluator.metadata.defaultProviders).not.toContain(Provider.OpenAI);
   });
 
-  it('supports integer grades 3–12', () => {
+  it('supports integer grade levels 3–12', () => {
     expect(OrganizationalStructureEvaluator.metadata.supportedGrades).toEqual(
       ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     );

--- a/sdks/typescript/tests/unit/evaluators/purpose.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose.test.ts
@@ -86,7 +86,7 @@ describe('PurposeEvaluator - Metadata', () => {
     expect(PurposeEvaluator.metadata.defaultProviders).not.toContain(Provider.OpenAI);
   });
 
-  it('supports integer grades 3–12', () => {
+  it('supports integer grade levels 3–12', () => {
     expect(PurposeEvaluator.metadata.supportedGrades).toEqual(
       ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
     );

--- a/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-complexity.test.ts
@@ -191,7 +191,7 @@ describe('TextComplexityEvaluator', () => {
         InputValidationError
       );
       await expect(evaluator.evaluate(text, 'invalid')).rejects.toThrow(
-        'Invalid grade "invalid"'
+        'Invalid grade level "invalid"'
       );
 
       // Grades outside supported range (K, 1, 2 not supported)

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -230,7 +230,7 @@ describe('Input Validation - Grade Validation', () => {
       const validText = 'This is a sample text for testing.';
 
       await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade "${grade}". Supported grades for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
     });
 
     it.each([
@@ -240,7 +240,7 @@ describe('Input Validation - Grade Validation', () => {
       const validText = 'This is a sample text for testing.';
 
       await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade "${grade}". Supported grades for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
     });
 
     it.each([
@@ -251,7 +251,7 @@ describe('Input Validation - Grade Validation', () => {
       const validText = 'This is a sample text for testing.';
 
       await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade "${grade}". Supported grades for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
     });
   });
 });


### PR DESCRIPTION
First of three for SPEC gap 19 (`grade` → `grade_level`). This one covers the evaluator API surface only; #2 does the Knowledge Graph boundary, #3 the batch CSV column.

TypeScript takes these positionally, so the **parameter renames are cosmetic** — no caller breaks. The observable content is:

- `BackgroundKnowledge.grade` → `gradeLevel`
- `EvaluationFailure.input.grade` → `gradeLevel`
- `validateGrade` → `validateGradeLevel` (protected)
- Error wording: `Invalid grade "5"` → `Invalid grade level "5"`, and `Supported grades` → `Supported grade levels`

### Deliberately not renamed

- **`GradeLevelAppropriatenessSchema.grade` and `alternative_grade`, and conventionality's `grade_context`.** These are the *model's* output fields, declared in the eval's schema, and the `.describe()` text is prompt content. Renaming them changes what the model is asked to emit. The read site in `grade-level-appropriateness.ts` carries a comment saying so.
- **The four `'{grade}'` prompt placeholders.** They must move in lockstep with the sha256-pinned `.txt` files, which are handled in the eval PRs. Only 2 of the 4 substitution sites have a test asserting the grade reaches the prompt, so flipping these early would silently ship a literal `{grade}` to the model at the other two.
- **`supportedGrades`** — that is the spec's `supported_grades`, already conformant.
- **Telemetry's `grade` wire field** — held until the telemetry schema is renamed as a whole; the comment at the emit site records this.

### Also here: coverage for the functional API

`codecov/patch` flagged this PR's diff, and the uncovered lines turned out to be the nine functional wrappers (`evaluateVocabulary`, `evaluateSmk`, …). Every one is re-exported from the package root and **no test called any of them** — a wrapper forwarding the wrong argument would have shipped unnoticed.

Added one table-driven test covering all nine. Verified load-bearing: making a wrapper pass a hardcoded grade level instead of its argument fails it.

677/677 pass · `tsc --noEmit` clean · lint 0 errors.

