### PR TITLE
fix(ts-sdk)!: name the grade level consistently at the Knowledge Graph boundary

### DIFF
--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -40,7 +40,7 @@ export interface StandardAlignmentResult {
   coarseFiltered?: boolean;
   /**
    * Set when this pair could not be evaluated. Produced only by evaluateItems and
-   * evaluateByGrade; evaluate() throws instead.
+   * evaluateByGradeLevel; evaluate() throws instead.
    *
    * Not evidence of non-alignment: alignedCount is 0 because nothing was
    * measured, not because nothing aligned.
@@ -125,7 +125,7 @@ const DETAIL_MODEL: string = STEP.model.name;
 const TEMPERATURE: number | null = STEP.generation.temperature;
 const KG_SUBJECT = 'Mathematics';
 /**
- * Above this many question/standard pairs, evaluateByGrade warns. A grade level can carry
+ * Above this many question/standard pairs, evaluateByGradeLevel warns. A grade level can carry
  * over a thousand standards in some jurisdictions, so a handful of questions is
  * enough to run into five figures of LLM calls.
  */
@@ -208,7 +208,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   //
   // Each item specifies its own statementCodes list. Use this for:
   //   - Tagging validation: verify a question covers its pre-mapped standards
-  //   - Grade-level coverage: pass the same codes to all items (evaluateByGrade does this)
+  //   - Grade-level coverage: pass the same codes to all items (evaluateByGradeLevel does this)
   //
   // Set options.useCoarseFilter to true to run a fast pre-filter before the
   // full per-LC evaluation — reduces LLM calls at scale, slight recall trade-off.
@@ -343,14 +343,14 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   }
 
   // -------------------------------------------------------------------------
-  // evaluateByGrade — fetches all math standards for a grade level, then evaluates
+  // evaluateByGradeLevel — fetches all math standards for a grade level, then evaluates
   //
   // Use when you don't have a predetermined standards list. Jurisdiction
   // determines which state's adopted standards are fetched from the KG.
   // Returns both a by-question and by-standard view of coverage.
   // -------------------------------------------------------------------------
 
-  async evaluateByGrade(
+  async evaluateByGradeLevel(
     questions: string[],
     gradeLevel: string,
     jurisdiction: Jurisdiction,
@@ -359,7 +359,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     if (questions.length === 0) throw new InputValidationError('questions array must not be empty');
     this.validateGradeLevel(gradeLevel, new Set(SUPPORTED_GRADES));
 
-    const academicStandards = await this.kgClient.getStandardsByGrade(gradeLevel, {
+    const academicStandards = await this.kgClient.getStandardsByGradeLevel(gradeLevel, {
       jurisdiction,
       academicSubject: KG_SUBJECT,
     });

--- a/sdks/typescript/src/knowledge-graph/client.ts
+++ b/sdks/typescript/src/knowledge-graph/client.ts
@@ -22,7 +22,7 @@ const STANDARDS_PAGE_SIZE = 500;
 const LC_PAGE_SIZE = 100;
 /** The search endpoint's maximum. Explicit because its default is 5, not the cap. */
 export const STANDARD_SEARCH_LIMIT = 50;
-/** Generous: the largest grade needs 3 pages of 500. */
+/** Generous: the largest grade level needs 3 pages of 500. */
 const MAX_PAGES = 200;
 
 /**
@@ -172,7 +172,7 @@ export class KnowledgeGraphClient {
     return p;
   }
 
-  async getStandardsByGrade(grade: string, opts?: StandardsByGradeOptions): Promise<AcademicStandard[]> {
+  async getStandardsByGradeLevel(gradeLevel: string, opts?: StandardsByGradeOptions): Promise<AcademicStandard[]> {
     const frameworkUuid = await this._getFrameworkUuid(
       opts?.jurisdiction ?? 'Multi-State',
       opts?.academicSubject,
@@ -182,11 +182,11 @@ export class KnowledgeGraphClient {
       paths['/academic-standards']['get']['parameters']['query']
     >;
 
-    return this._paginate(`grade "${grade}"`, async (cursor) => {
+    return this._paginate(`grade level "${gradeLevel}"`, async (cursor) => {
       const query: StandardsQuery = {
         limit: STANDARDS_PAGE_SIZE,
         standardsFrameworkCaseIdentifierUUID: frameworkUuid,
-        gradeLevel: [grade] as components['parameters']['GradeLevelParam'],
+        gradeLevel: [gradeLevel] as components['parameters']['GradeLevelParam'],
         normalizedStatementType: 'Standard' as components['schemas']['NormalizedStatementTypeENUM'],
         ...(opts?.academicSubject
           ? { academicSubject: opts.academicSubject as components['schemas']['AcademicSubjectENUM'] }

--- a/sdks/typescript/src/knowledge-graph/standards-catalog.ts
+++ b/sdks/typescript/src/knowledge-graph/standards-catalog.ts
@@ -120,9 +120,9 @@ export class StandardsCatalog {
     this.academicSubject = academicSubject || undefined;
   }
 
-  /** All instructional standards for a grade, across every result page. */
-  listStandards(grade: string, opts?: StandardsLookupOptions): Promise<AcademicStandard[]> {
-    return this.kg.getStandardsByGrade(grade, {
+  /** All instructional standards for a grade level, across every result page. */
+  listStandards(gradeLevel: string, opts?: StandardsLookupOptions): Promise<AcademicStandard[]> {
+    return this.kg.getStandardsByGradeLevel(gradeLevel, {
       jurisdiction: opts?.jurisdiction ?? Jurisdiction.MultiState,
       academicSubject: opts?.academicSubject ?? this.academicSubject,
     });

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -60,7 +60,7 @@ function makeMockKgClient(overrides: Partial<KnowledgeGraphClient> = {}): Knowle
   return {
     getStandardInfo: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', description: 'Recognize area as additive' }),
     getLearningComponents: vi.fn().mockResolvedValue(LC_COMPONENTS),
-    getStandardsByGrade: vi.fn().mockResolvedValue([
+    getStandardsByGradeLevel: vi.fn().mockResolvedValue([
       {
         caseIdentifierUUID: 'uuid-abc',
         statementCode: STATEMENT_CODE,
@@ -507,34 +507,34 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
 });
 
 // ---------------------------------------------------------------------------
-// evaluateByGrade
+// evaluateByGradeLevel
 // ---------------------------------------------------------------------------
 
-describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
+describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
   it('throws InputValidationError for empty questions array', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluateByGrade([], '3', JURISDICTION)).rejects.toThrow(InputValidationError);
+    await expect(evaluator.evaluateByGradeLevel([], '3', JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
   it('throws InputValidationError for invalid grade', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluateByGrade([QUESTION], '13', JURISDICTION)).rejects.toThrow(InputValidationError);
+    await expect(evaluator.evaluateByGradeLevel([QUESTION], '13', JURISDICTION)).rejects.toThrow(InputValidationError);
   });
 
   it('fetches standards for grade and jurisdiction, deduping codes reused across courses', async () => {
     // A jurisdiction reusing one code across courses returns an item per course.
     // Without deduping, byStandard would repeat that code.
     const repo = makeMockKgClient({
-      getStandardsByGrade: vi.fn().mockResolvedValue([
+      getStandardsByGradeLevel: vi.fn().mockResolvedValue([
         { caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d', description: 'Area', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
         { caseIdentifierUUID: 'u1b', statementCode: '3.MD.C.7.d', description: 'Area, other course', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
         { caseIdentifierUUID: 'u2', statementCode: '3.OA.A.1', description: 'Products', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
       ]),
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
-    const result = await evaluator.evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
+    const result = await evaluator.evaluateByGradeLevel([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
 
-    expect(repo.getStandardsByGrade).toHaveBeenCalledWith('3', { jurisdiction: JURISDICTION, academicSubject: 'Mathematics' });
+    expect(repo.getStandardsByGradeLevel).toHaveBeenCalledWith('3', { jurisdiction: JURISDICTION, academicSubject: 'Mathematics' });
     expect(result.byStandard.map((s) => s.statementCode)).toEqual(['3.MD.C.7.d', '3.OA.A.1']);
     expect(result.byQuestion[0].standards).toHaveLength(2);
   });
@@ -548,12 +548,12 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
 
     const small = makeMockKgClient();
     await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: small, logger }))
-      .evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
+      .evaluateByGradeLevel([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
     expect(logger.warn).not.toHaveBeenCalled();
 
-    const large = makeMockKgClient({ getStandardsByGrade: vi.fn().mockResolvedValue(manyStandards) });
+    const large = makeMockKgClient({ getStandardsByGradeLevel: vi.fn().mockResolvedValue(manyStandards) });
     await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: large, logger }))
-      .evaluateByGrade([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
+      .evaluateByGradeLevel([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn.mock.calls[0][1]).toMatchObject({ questions: 1, standards: 501, pairs: 501 });
@@ -576,31 +576,31 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGrade', () => {
     });
 
     const repo = makeMockKgClient({
-      getStandardsByGrade: vi.fn().mockResolvedValue([
+      getStandardsByGradeLevel: vi.fn().mockResolvedValue([
         { caseIdentifierUUID: 'u1', statementCode: STATEMENT_CODE, description: 'Area', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
       ]),
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
-    const result = await evaluator.evaluateByGrade(['Q1', 'Q2'], '3', JURISDICTION, { useCoarseFilter: false });
+    const result = await evaluator.evaluateByGradeLevel(['Q1', 'Q2'], '3', JURISDICTION, { useCoarseFilter: false });
 
     expect(result.byStandard[0].coverageCount).toBe(1);
     expect(result.byStandard[0].coveredBy[0].question).toBe('Q1');
   });
 
   it('returns empty byStandard and byQuestion stubs when KG returns no standards for grade', async () => {
-    const repo = makeMockKgClient({ getStandardsByGrade: vi.fn().mockResolvedValue([]) });
+    const repo = makeMockKgClient({ getStandardsByGradeLevel: vi.fn().mockResolvedValue([]) });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
-    const result = await evaluator.evaluateByGrade([QUESTION], '3', JURISDICTION);
+    const result = await evaluator.evaluateByGradeLevel([QUESTION], '3', JURISDICTION);
     expect(result.byStandard).toEqual([]);
     expect(result.byQuestion).toEqual([{ question: QUESTION, standards: [] }]);
   });
 
-  it('passes California jurisdiction to getStandardsByGrade', async () => {
-    const repo = makeMockKgClient({ getStandardsByGrade: vi.fn().mockResolvedValue([]) });
+  it('passes California jurisdiction to getStandardsByGradeLevel', async () => {
+    const repo = makeMockKgClient({ getStandardsByGradeLevel: vi.fn().mockResolvedValue([]) });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
-    await evaluator.evaluateByGrade([QUESTION], '5', Jurisdiction.California);
+    await evaluator.evaluateByGradeLevel([QUESTION], '5', Jurisdiction.California);
 
-    expect(repo.getStandardsByGrade).toHaveBeenCalledWith('5', { jurisdiction: Jurisdiction.California, academicSubject: 'Mathematics' });
+    expect(repo.getStandardsByGradeLevel).toHaveBeenCalledWith('5', { jurisdiction: Jurisdiction.California, academicSubject: 'Mathematics' });
   });
 });
 
@@ -795,7 +795,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       getLearningComponentsByCode: vi.fn().mockRejectedValue(new KnowledgeGraphError('nope')),
     });
     const errored = await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }))
-      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+      .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
     expect(errored.byQuestion[0].standards[0].error).toBeDefined();
     expect(errored.byStandard[0].coveredBy).toEqual([]);
@@ -811,7 +811,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       },
     });
     const unaligned = await new MathStandardsAlignmentEvaluator(makeConfig())
-      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+      .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
     expect(unaligned.byStandard[0]).toMatchObject({
       coverageCount: 0, errorCount: 0, evaluatedCount: 1, noComponentsCount: 0,
@@ -824,7 +824,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       model: 'anthropic:claude-haiku-4-5-20251001', usage: { inputTokens: 50, outputTokens: 20 }, latencyMs: 200,
     });
     const filtered = await new MathStandardsAlignmentEvaluator(makeConfig())
-      .evaluateByGrade(['Q1'], '3', JURISDICTION, { useCoarseFilter: true });
+      .evaluateByGradeLevel(['Q1'], '3', JURISDICTION, { useCoarseFilter: true });
 
     expect(filtered.byStandard[0]).toMatchObject({
       coverageCount: 0, errorCount: 0, evaluatedCount: 0, filteredCount: 1,
@@ -836,7 +836,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       getLearningComponentsByCode: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', components: [] }),
     });
     const unauthored = await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: noComponents }))
-      .evaluateByGrade(['Q1'], '3', JURISDICTION);
+      .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
     // Its own counter, so all-zeros is never the only signal.
     expect(unauthored.byStandard[0]).toMatchObject({

--- a/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/client.test.ts
@@ -448,12 +448,12 @@ describe('KnowledgeGraphClient - getLearningComponents', () => {
   });
 });
 
-describe('KnowledgeGraphClient - getStandardsByGrade', () => {
+describe('KnowledgeGraphClient - getStandardsByGradeLevel', () => {
   it('returns standards filtered to normalizedStatementType=Standard via URL', async () => {
     const body = { data: [{ caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d', normalizedStatementType: 'Standard', gradeLevel: ['3'] }] };
     const fetchMock = vi.fn().mockResolvedValue(okResponse(body));
     vi.stubGlobal('fetch', fetchMock);
-    const results = await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3');
+    const results = await new KnowledgeGraphClient(API_KEY).getStandardsByGradeLevel('3');
     const request = fetchMock.mock.calls[0][0] as Request;
     expect(request.url).toContain('normalizedStatementType=Standard');
     expect(results).toHaveLength(1);
@@ -463,7 +463,7 @@ describe('KnowledgeGraphClient - getStandardsByGrade', () => {
   it('resolves Multi-State to the CCSS framework without a lookup request', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [], pagination: { hasMore: false } }));
     vi.stubGlobal('fetch', fetchMock);
-    await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3');
+    await new KnowledgeGraphClient(API_KEY).getStandardsByGradeLevel('3');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const url = (fetchMock.mock.calls[0][0] as Request).url;
     expect(url).toContain('/academic-standards?');
@@ -480,7 +480,7 @@ describe('KnowledgeGraphClient - getStandardsByGrade', () => {
       }));
     });
     vi.stubGlobal('fetch', fetchMock);
-    const results = await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3');
+    const results = await new KnowledgeGraphClient(API_KEY).getStandardsByGradeLevel('3');
     expect(results).toHaveLength(3);
     expect(results.map((r) => r.statementCode)).toEqual(['3.MD.C.7.1', '3.MD.C.7.2', '3.MD.C.7.3']);
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -490,13 +490,13 @@ describe('KnowledgeGraphClient - getStandardsByGrade', () => {
 
   it('throws KnowledgeGraphError if hasMore=true but nextCursor is null', async () => {
     mockFetch(200, { data: [], pagination: { hasMore: true, nextCursor: null } });
-    await expect(new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3'))
+    await expect(new KnowledgeGraphClient(API_KEY).getStandardsByGradeLevel('3'))
       .rejects.toThrow(KnowledgeGraphError);
   });
 
   it('throws KnowledgeGraphError if the API repeats a cursor', async () => {
     mockFetch(200, { data: [], pagination: { hasMore: true, nextCursor: 'same-page' } });
-    const err = await new KnowledgeGraphClient(API_KEY).getStandardsByGrade('3').catch((e) => e);
+    const err = await new KnowledgeGraphClient(API_KEY).getStandardsByGradeLevel('3').catch((e) => e);
     expect(err).toBeInstanceOf(KnowledgeGraphError);
     expect(err.message).toContain('repeated');
   });

--- a/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
+++ b/sdks/typescript/tests/unit/knowledge-graph/spec-conformance.test.ts
@@ -34,7 +34,7 @@ export const listEndpointReturnsSpecStandard: NonNullable<
 // spec adds or removes a jurisdiction, this stops compiling.
 export const jurisdictionsMatchSpec: Exact<`${Jurisdiction}`, SpecJurisdiction> = true;
 
-// Mirrors the projection in client.ts getStandardsByGrade. Fails to compile if
+// Mirrors the projection in client.ts getStandardsByGradeLevel. Fails to compile if
 // the spec renames, removes, or incompatibly narrows any mapped field.
 export function projectSpecStandard(item: SpecStandard): AcademicStandard {
   return {
@@ -69,7 +69,7 @@ beforeEach(() => { vi.unstubAllGlobals(); });
 
 // A response item carrying every field the current spec marks required,
 // including ones we do not project. Regenerating the spec with a new required
-// field should not change what getStandardsByGrade returns.
+// field should not change what getStandardsByGradeLevel returns.
 const fullSpecItem: SpecStandard = {
   identifier: 'id-1',
   caseIdentifierUUID: 'uuid-1',
@@ -90,7 +90,7 @@ describe('Knowledge Graph spec conformance', () => {
   it('projects a fully spec-shaped standard to exactly the AcademicStandard fields', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ data: [fullSpecItem] })));
 
-    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGrade('3');
+    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGradeLevel('3');
 
     expect(standard).toEqual({
       caseIdentifierUUID: 'uuid-1',
@@ -115,7 +115,7 @@ describe('Knowledge Graph spec conformance', () => {
     const item: SpecStandard = { ...fullSpecItem, gradeLevel: null };
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse({ data: [item] })));
 
-    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGrade('3');
+    const [standard] = await new KnowledgeGraphClient('k').getStandardsByGradeLevel('3');
 
     expect(standard.gradeLevel).toEqual([]);
   });
@@ -134,7 +134,7 @@ describe('Knowledge Graph spec conformance', () => {
       );
       vi.stubGlobal('fetch', fetchMock);
 
-      await new KnowledgeGraphClient('k').getStandardsByGrade('3', { jurisdiction });
+      await new KnowledgeGraphClient('k').getStandardsByGradeLevel('3', { jurisdiction });
 
       const url = new URL((fetchMock.mock.calls[0][0] as Request).url);
       expect(url.pathname).toContain('/standards-frameworks');
@@ -151,7 +151,7 @@ describe('Knowledge Graph spec conformance', () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse({ data: [] }));
     vi.stubGlobal('fetch', fetchMock);
 
-    await new KnowledgeGraphClient('k').getStandardsByGrade('3', {
+    await new KnowledgeGraphClient('k').getStandardsByGradeLevel('3', {
       jurisdiction: Jurisdiction.MultiState,
     });
 


### PR DESCRIPTION
Second of three for SPEC gap 19. #204 has merged, so this now reads against `main` directly.

The Knowledge Graph's own OpenAPI schema already uses `gradeLevel` throughout — our wrapper was the only thing calling it `grade`, then mapping it onto `gradeLevel` at the query-param boundary. This makes our side match.

- `KnowledgeGraphClient.getStandardsByGrade` → `getStandardsByGradeLevel`
- `MathStandardsAlignmentEvaluator.evaluateByGrade` → `evaluateByGradeLevel`
- `StandardsCatalog.listStandards(grade)` → `(gradeLevel)` — parameter only; the method name and signature are unchanged

`kg-api.d.ts` is untouched — it is generated, and already conformant.

### Breaking

Two public method renames. `listStandards` is not among them: TypeScript takes its argument positionally, so renaming the parameter is documentation-only.

### Also

One user-visible string: the pagination `context` label, which appears in `Knowledge Graph pagination error: … for grade "5"` → `… for grade level "5"`. Diagnostics only, no callers match on it.

Otherwise the diff is the rename and nothing else — 48 insertions, 48 deletions across 6 files, with no logic change.

684/684 pass · `tsc --noEmit` clean · lint 0 errors.
