### PR TITLE
docs(evals): correct the temperature guidance in the config schema

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -155,7 +155,7 @@
                 "type": ["number", "null"],
                 "minimum": 0,
                 "maximum": 1,
-                "description": "Sampling temperature to send, or null to send nothing so the model uses its own default. Use null for models that require it: Gemini 3 (Google recommends removing the parameter; below 1.0 risks looping and degraded reasoning), GPT-5 (rejects any value but 1 with a 400), and Claude Opus 5 / Opus 4.8 / Opus 4.7 / Sonnet 5 / Fable 5 (sampling parameters removed, 400). Models that still accept one -- Gemini 2.x, GPT-4.x, Claude 4.6 and below -- should carry an explicit number. Required rather than optional so every step records a deliberate choice; an absent key reads as 'nobody considered it'."
+                "description": "Sampling temperature to send, or null to omit the parameter entirely. Prefer an explicit number: the value an evaluator was validated at should be recorded, not inherited from a model default that can change under us. Use null only for models that reject any non-default value -- Claude Opus 4.7 and later return a 400 -- where omitting is the documented approach. A model recommending its default is not grounds for null; write the number out. Required rather than optional so every step records a deliberate choice; an absent key reads as 'nobody considered it'."
               }
             }
           },


### PR DESCRIPTION
Salvaged from #187, which was closed because its Gemini-3-must-be-1 check contradicts a decision we've since made deliberately. The schema wording is independent of that check and still wrong on `main`.

**1. "Google recommends removing the parameter" (Gemini 3) — false.** Google's docs say the opposite: *"For all Gemini 3 models, we strongly recommend keeping the temperature parameter at its default value of `1.0`."* Keeping it at a value is not removing it.

**2. "GPT-5 (rejects any value but 1 with a 400)" — false.** I verified `gpt-5.4-2026-03-05` against the live API: it accepts a temperature and honours it.

The description also instructed authors to use `null` for Gemini 3, which is now backwards — the ela-reading evaluators pin an explicit `0`, tested and preferred, except Organizational Structure at `1`.

### What replaces it

```
Sampling temperature to send, or null to omit the parameter entirely. Prefer an
explicit number: the value an evaluator was validated at should be recorded, not
inherited from a model default that can change under us. Use null only for models
that reject any non-default value -- Claude Opus 4.7 and later return a 400 --
where omitting is the documented approach. A model recommending its default is
not grounds for null; write the number out. Required rather than optional so
every step records a deliberate choice; an absent key reads as 'nobody
considered it'.
```

The per-model list is gone on purpose. It was a set of claims that rot — two had already rotted — and it invited `null` wherever a vendor merely *recommended* a default. The one hard constraint left is the only one that is a real API rejection rather than advice, and I verified it: Opus 5 returns 400 on a non-default temperature.

I did not reuse #187's phrasing verbatim. It argued for explicit numbers partly because our TypeScript provider coerced `null` to `0` via `request.temperature ?? 0` — #199 fixed that, so the argument no longer holds and repeating it would be stating a bug we don't have.

One line changed. All 6 repo checks pass.
