### PR TITLE
refactor(sdk)!: migrate evaluate() onto the result envelope

### DIFF
--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -99,7 +99,11 @@ class QtcRunner implements FamilyRunner {
 
   async runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome> {
     const result = await this.getEvaluator(memberId).evaluate(row.columns.text, row.columns['grade_level']);
-    return readOutcome(result.evaluator, result.result);
+    const { score, reasoning } = readOutcome(result);
+
+    // A report cell has to be a string. An absent verdict renders blank, and doing
+    // that here rather than inside readOutcome keeps the gap visible to any other caller.
+    return { score: score ?? '', reasoning };
   }
 }
 

--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -11,6 +11,7 @@ import {
 import type { BaseEvaluatorConfig, ModelOverride } from '../../evaluators/base.js';
 import { Provider } from '../../evaluators/base.js';
 import type { EvaluationResult } from '../../schemas/index.js';
+import { readOutcome } from '../../schemas/outcome.js';
 import {
   type ColumnSpec,
   type EvaluatorFamily,
@@ -23,7 +24,7 @@ import {
 } from './family.js';
 
 interface SimpleEvaluator {
-  evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<string, unknown>>;
+  evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<unknown>>;
 }
 type EvaluatorConstructor = new (config: BaseEvaluatorConfig) => SimpleEvaluator;
 
@@ -98,7 +99,7 @@ class QtcRunner implements FamilyRunner {
 
   async runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome> {
     const result = await this.getEvaluator(memberId).evaluate(row.columns.text, row.columns['grade_level']);
-    return { score: result.score, reasoning: result.reasoning };
+    return readOutcome(result.evaluator, result.result);
   }
 }
 

--- a/sdks/typescript/src/batch/formatters.ts
+++ b/sdks/typescript/src/batch/formatters.ts
@@ -58,7 +58,10 @@ function getGLAStatus(inputGrade: string, glaBand: string): 'on-band' | 'adjacen
 }
 
 function complexityToNumeric(score: string): number | undefined {
-  return COMPLEXITY_SCORE_MAP[score.toLowerCase().trim()];
+  // Underscores are folded so the contract's `slightly_complex` and the spaced form
+  // the not-yet-generated schemas still return both resolve. An unrecognised score
+  // drops the row from every aggregate, so this must accept both spellings.
+  return COMPLEXITY_SCORE_MAP[score.toLowerCase().trim().replace(/_/g, ' ')];
 }
 
 function complexityScoreLabel(avg: number): string {

--- a/sdks/typescript/src/evaluators/background-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/background-knowledge-demands.ts
@@ -2,7 +2,7 @@ import type { LLMProvider } from '../providers/index.js';
 import { BackgroundKnowledgeDemandsOutputSchema, type BackgroundKnowledgeDemandsInternal } from '../schemas/background-knowledge-demands.js';
 import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/background-knowledge-demands/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -66,7 +66,7 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
   async evaluate(
     text: string,
     gradeLevel: string
-  ): Promise<EvaluationResult<TextComplexityLevel, BackgroundKnowledgeDemandsInternal>> {
+  ): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
     this.logger.info('Starting Background Knowledge Demands evaluation', {
       evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
       operation: 'evaluate',
@@ -109,15 +109,16 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
       };
 
       const result = {
-        score: response.data.complexity_score,
-        reasoning: response.data.reasoning,
+        evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: totalTokenUsage.input_tokens,
-          outputTokens: totalTokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: totalTokenUsage.input_tokens,
+            outputTokens: totalTokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       // Send success telemetry (fire-and-forget)
@@ -140,7 +141,7 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
         evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -225,7 +226,7 @@ export async function evaluateBackgroundKnowledgeDemands(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig
-): Promise<EvaluationResult<TextComplexityLevel, BackgroundKnowledgeDemandsInternal>> {
+): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
   const evaluator = new BackgroundKnowledgeDemandsEvaluator(config);
   return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -4,7 +4,7 @@ import {
   type GradeLevelAppropriatenessInternal,
 } from '../schemas/grade-level-appropriateness.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/grade-level-appropriateness/index.js';
-import type { EvaluationResult, GradeBand } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
@@ -68,7 +68,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string): Promise<EvaluationResult<GradeBand, GradeLevelAppropriatenessInternal>> {
+  async evaluate(text: string): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
     this.logger.info('Starting grade level appropriateness evaluation', {
       evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
       operation: 'evaluate',
@@ -105,15 +105,16 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       const result = {
         // `grade` is the model's output field, declared in the eval's schema —
         // not the SDK's parameter name.
-        score: response.data.grade,
-        reasoning: response.data.reasoning,
+        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: tokenUsage.input_tokens,
-          outputTokens: tokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: tokenUsage.input_tokens,
+            outputTokens: tokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       // Send success telemetry (fire-and-forget)
@@ -132,7 +133,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       this.logger.info('Grade level appropriateness evaluation completed successfully', {
         evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
         operation: 'evaluate',
-        gradeLevel: result.score,
+        gradeLevel: response.data.grade,
         processingTimeMs: latencyMs,
       });
 
@@ -187,7 +188,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
 export async function evaluateGradeLevelAppropriateness(
   text: string,
   config: BaseEvaluatorConfig
-): Promise<EvaluationResult<GradeBand, GradeLevelAppropriatenessInternal>> {
+): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
   const evaluator = new GradeLevelAppropriatenessEvaluator(config);
   return evaluator.evaluate(text);
 }

--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -35,7 +35,6 @@ export {
 export {
   PurposeClarityEvaluator,
   evaluatePurposeClarity,
-  type PurposeClarityComplexityLevel,
 } from './purpose-clarity.js';
 
 export {

--- a/sdks/typescript/src/evaluators/meaning-directness.ts
+++ b/sdks/typescript/src/evaluators/meaning-directness.ts
@@ -2,7 +2,7 @@ import type { LLMProvider } from '../providers/index.js';
 import { MeaningDirectnessOutputSchema, type MeaningDirectnessInternal } from '../schemas/meaning-directness.js';
 import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/meaning-directness/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -66,7 +66,7 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
   async evaluate(
     text: string,
     gradeLevel: string
-  ): Promise<EvaluationResult<TextComplexityLevel, MeaningDirectnessInternal>> {
+  ): Promise<EvaluationResult<MeaningDirectnessInternal>> {
     this.logger.info('Starting Meaning Directness evaluation', {
       evaluator: MeaningDirectnessEvaluator.metadata.id,
       operation: 'evaluate',
@@ -109,15 +109,16 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
       };
 
       const result = {
-        score: response.data.complexity_score,
-        reasoning: response.data.reasoning,
+        evaluator: MeaningDirectnessEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: totalTokenUsage.input_tokens,
-          outputTokens: totalTokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: totalTokenUsage.input_tokens,
+            outputTokens: totalTokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       // Send success telemetry (fire-and-forget)
@@ -140,7 +141,7 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
         evaluator: MeaningDirectnessEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -225,7 +226,7 @@ export async function evaluateMeaningDirectness(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig
-): Promise<EvaluationResult<TextComplexityLevel, MeaningDirectnessInternal>> {
+): Promise<EvaluationResult<MeaningDirectnessInternal>> {
   const evaluator = new MeaningDirectnessEvaluator(config);
   return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -5,7 +5,7 @@ import {
 } from '../schemas/organizational-structure.js';
 import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/organizational-structure/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, InputValidationError, wrapProviderError } from '../errors.js';
@@ -22,14 +22,6 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that also admits non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
-
-// Maps snake_case LLM output → SDK-standard sentence case score.
-const COMPLEXITY_SCORE_DISPLAY: Record<OrganizationalStructureInternal['complexity_score'], TextComplexityLevel> = {
-  'slightly_complex': 'Slightly complex',
-  'moderately_complex': 'Moderately complex',
-  'very_complex': 'Very complex',
-  'exceedingly_complex': 'Exceedingly complex',
-};
 
 export class OrganizationalStructureEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -71,7 +63,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<OrganizationalStructureInternal>> {
     this.logger.info('Starting Organizational Structure evaluation', {
       evaluator: OrganizationalStructureEvaluator.metadata.id,
       operation: 'evaluate',
@@ -107,16 +99,17 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         token_usage: tokenUsage,
       });
 
-      const result: EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal> = {
-        score: COMPLEXITY_SCORE_DISPLAY[response.data.complexity_score],
-        reasoning: response.data.reasoning,
+      const result: EvaluationResult<OrganizationalStructureInternal> = {
+        evaluator: OrganizationalStructureEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: tokenUsage.input_tokens,
-          outputTokens: tokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: tokenUsage.input_tokens,
+            outputTokens: tokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       this.sendTelemetry({
@@ -134,7 +127,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         evaluator: OrganizationalStructureEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel: gradeNum,
-        score: result.score,
+        score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -204,6 +197,6 @@ export async function evaluateOrganizationalStructure(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig,
-): Promise<EvaluationResult<TextComplexityLevel, OrganizationalStructureInternal>> {
+): Promise<EvaluationResult<OrganizationalStructureInternal>> {
   return new OrganizationalStructureEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/purpose-clarity.ts
@@ -2,7 +2,7 @@ import type { LLMProvider } from '../providers/index.js';
 import { PurposeClarityOutputSchema, type PurposeClarityInternal } from '../schemas/purpose-clarity.js';
 import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/purpose-clarity/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -19,17 +19,6 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
-
-export type PurposeClarityComplexityLevel = TextComplexityLevel | 'More context needed';
-
-// Maps snake_case LLM output → SDK-standard sentence case score.
-const COMPLEXITY_SCORE_DISPLAY: Record<PurposeClarityInternal['complexity_score'], PurposeClarityComplexityLevel> = {
-  'slightly_complex': 'Slightly complex',
-  'moderately_complex': 'Moderately complex',
-  'very_complex': 'Very complex',
-  'exceedingly_complex': 'Exceedingly complex',
-  'more_context_needed': 'More context needed',
-};
 
 export class PurposeClarityEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -71,7 +60,7 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<PurposeClarityComplexityLevel, PurposeClarityInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<PurposeClarityInternal>> {
     this.logger.info('Starting Purpose Clarity evaluation', {
       evaluator: PurposeClarityEvaluator.metadata.id,
       operation: 'evaluate',
@@ -107,16 +96,17 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
         token_usage: tokenUsage,
       });
 
-      const result: EvaluationResult<PurposeClarityComplexityLevel, PurposeClarityInternal> = {
-        score: COMPLEXITY_SCORE_DISPLAY[response.data.complexity_score],
-        reasoning: response.data.reasoning,
+      const result: EvaluationResult<PurposeClarityInternal> = {
+        evaluator: PurposeClarityEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: tokenUsage.input_tokens,
-          outputTokens: tokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: tokenUsage.input_tokens,
+            outputTokens: tokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       this.sendTelemetry({
@@ -134,7 +124,7 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
         evaluator: PurposeClarityEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -194,6 +184,6 @@ export async function evaluatePurposeClarity(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig,
-): Promise<EvaluationResult<PurposeClarityComplexityLevel, PurposeClarityInternal>> {
+): Promise<EvaluationResult<PurposeClarityInternal>> {
   return new PurposeClarityEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
@@ -2,7 +2,7 @@ import type { LLMProvider } from '../providers/index.js';
 import { ReferenceKnowledgeDemandsOutputSchema, type ReferenceKnowledgeDemandsInternal } from '../schemas/reference-knowledge-demands.js';
 import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/reference-knowledge-demands/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -19,14 +19,6 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
-
-// Maps snake_case LLM output → SDK-standard sentence case score.
-const COMPLEXITY_SCORE_DISPLAY: Record<ReferenceKnowledgeDemandsInternal['complexity_score'], TextComplexityLevel> = {
-  'slightly_complex': 'Slightly complex',
-  'moderately_complex': 'Moderately complex',
-  'very_complex': 'Very complex',
-  'exceedingly_complex': 'Exceedingly complex',
-};
 
 export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -68,7 +60,7 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<TextComplexityLevel, ReferenceKnowledgeDemandsInternal>> {
+  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
     this.logger.info('Starting Reference Knowledge Demands evaluation', {
       evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
       operation: 'evaluate',
@@ -104,16 +96,17 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
         token_usage: tokenUsage,
       });
 
-      const result: EvaluationResult<TextComplexityLevel, ReferenceKnowledgeDemandsInternal> = {
-        score: COMPLEXITY_SCORE_DISPLAY[response.data.complexity_score],
-        reasoning: response.data.reasoning,
+      const result: EvaluationResult<ReferenceKnowledgeDemandsInternal> = {
+        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
+        result: response.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: tokenUsage.input_tokens,
-          outputTokens: tokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: tokenUsage.input_tokens,
+            outputTokens: tokenUsage.output_tokens,
+          },
         },
-        _internal: response.data,
       };
 
       this.sendTelemetry({
@@ -131,7 +124,7 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
         evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -191,6 +184,6 @@ export async function evaluateReferenceKnowledgeDemands(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig,
-): Promise<EvaluationResult<TextComplexityLevel, ReferenceKnowledgeDemandsInternal>> {
+): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
   return new ReferenceKnowledgeDemandsEvaluator(config).evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -5,7 +5,6 @@ import {
   type SentenceAnalysis,
   type SentenceFeatures,
   type ComplexityClassification,
-  type SentenceStructureInternal,
 } from '../schemas/sentence-structure.js';
 import { calculateReadabilityMetrics, addEngineeredFeatures, featuresToJSON } from '../features/index.js';
 import {
@@ -100,7 +99,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
   async evaluate(
     text: string,
     gradeLevel: string
-  ): Promise<EvaluationResult<TextComplexityLevel, SentenceStructureInternal>> {
+  ): Promise<EvaluationResult<ComplexityClassification>> {
     this.logger.info('Starting sentence structure evaluation', {
       evaluator: SentenceStructureEvaluator.metadata.id,
       operation: 'evaluate',
@@ -161,18 +160,15 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
       };
 
       const result = {
-        score: complexityResponse.data.answer,
-        reasoning: complexityResponse.data.reasoning,
+        evaluator: SentenceStructureEvaluator.metadata.id,
+        result: complexityResponse.data,
         metadata: {
           model: this.provider.label,
           processingTimeMs: latencyMs,
-          inputTokens: totalTokenUsage.input_tokens,
-          outputTokens: totalTokenUsage.output_tokens,
-        },
-        _internal: {
-          sentenceAnalysis: analysisResponse.data,
-          features,
-          complexity: complexityResponse.data,
+          tokenUsage: {
+            inputTokens: totalTokenUsage.input_tokens,
+            outputTokens: totalTokenUsage.output_tokens,
+          },
         },
       };
 
@@ -196,7 +192,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         evaluator: SentenceStructureEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: complexityResponse.data.answer,
         processingTimeMs: latencyMs,
       });
 
@@ -346,7 +342,7 @@ export async function evaluateSentenceStructure(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig
-): Promise<EvaluationResult<TextComplexityLevel, SentenceStructureInternal>> {
+): Promise<EvaluationResult<ComplexityClassification>> {
   const evaluator = new SentenceStructureEvaluator(config);
   return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/evaluators/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/vocabulary-complexity.ts
@@ -10,7 +10,7 @@ import {
   getSystemPrompt,
   getUserPrompt,
 } from '../prompts/vocabulary-complexity/index.js';
-import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -91,7 +91,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
   async evaluate(
     text: string,
     gradeLevel: string
-  ): Promise<EvaluationResult<TextComplexityLevel, VocabularyComplexityInternal>> {
+  ): Promise<EvaluationResult<VocabularyComplexityInternal>> {
     this.logger.info('Starting Vocabulary Complexity evaluation', {
       evaluator: VocabularyComplexityEvaluator.metadata.id,
       operation: 'evaluate',
@@ -163,15 +163,16 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
       };
 
       const result = {
-        score: complexityResponse.data.complexity_score,
-        reasoning: complexityResponse.data.reasoning,
+        evaluator: VocabularyComplexityEvaluator.metadata.id,
+        result: complexityResponse.data,
         metadata: {
           model: modelLabel,
           processingTimeMs: latencyMs,
-          inputTokens: totalTokenUsage.input_tokens,
-          outputTokens: totalTokenUsage.output_tokens,
+          tokenUsage: {
+            inputTokens: totalTokenUsage.input_tokens,
+            outputTokens: totalTokenUsage.output_tokens,
+          },
         },
-        _internal: complexityResponse.data,
       };
 
       // Send success telemetry (fire-and-forget)
@@ -194,7 +195,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
         evaluator: VocabularyComplexityEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: result.score,
+        score: complexityResponse.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -330,7 +331,7 @@ export async function evaluateVocabularyComplexity(
   text: string,
   gradeLevel: string,
   config: BaseEvaluatorConfig
-): Promise<EvaluationResult<TextComplexityLevel, VocabularyComplexityInternal>> {
+): Promise<EvaluationResult<VocabularyComplexityInternal>> {
   const evaluator = new VocabularyComplexityEvaluator(config);
   return evaluator.evaluate(text, gradeLevel);
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -2,10 +2,12 @@
 export type {
   EvaluationResult,
   EvaluationMetadata,
+  EvaluationTokenUsage,
   EvaluationFailure,
 } from './schemas/index.js';
 
 export { TextComplexityLevel, GradeBand } from './schemas/index.js';
+export { readOutcome, type Outcome } from './schemas/index.js';
 
 // Error types
 export {
@@ -59,7 +61,6 @@ export type {
   SentenceAnalysis,
   ComplexityClassification,
   SentenceFeatures,
-  SentenceStructureInternal,
 } from './schemas/sentence-structure.js';
 
 export {
@@ -103,7 +104,6 @@ export {
   evaluateGradeLevelAppropriateness,
   PurposeClarityEvaluator,
   evaluatePurposeClarity,
-  type PurposeClarityComplexityLevel,
   ReferenceKnowledgeDemandsEvaluator,
   evaluateReferenceKnowledgeDemands,
   OrganizationalStructureEvaluator,

--- a/sdks/typescript/src/schemas/index.ts
+++ b/sdks/typescript/src/schemas/index.ts
@@ -2,6 +2,7 @@ export {
   TextComplexityLevel,
   type EvaluationResult,
   type EvaluationMetadata,
+  type EvaluationTokenUsage,
   type EvaluationFailure,
 } from './outputs.js';
 
@@ -15,3 +16,5 @@ export {
   PurposeClarityOutputSchema,
   type PurposeClarityInternal,
 } from './purpose-clarity.js';
+
+export { readOutcome, type Outcome } from './outcome.js';

--- a/sdks/typescript/src/schemas/outcome.ts
+++ b/sdks/typescript/src/schemas/outcome.ts
@@ -1,0 +1,59 @@
+/**
+ * Reading one comparable value out of an evaluation payload.
+ *
+ * The result envelope carries the payload exactly as the registry declares it, so
+ * there is no top-level score to read. Batch runs and reports still need a single
+ * scalar per evaluation to sort, group and chart on, and this is where that is
+ * derived — once, from the shape the contracts already share, rather than in a
+ * per-evaluator table each SDK would have to keep in step.
+ */
+
+/** The scalar verdict and its rationale, as a report consumes them. */
+export interface Outcome {
+  score: string;
+  reasoning: string;
+}
+
+/**
+ * Evaluators whose verdict is not a `*_score` field.
+ *
+ * Grade Level Appropriateness answers with a grade band rather than a complexity
+ * level, so its verdict field is a band and there is no score to find. It will stay
+ * listed here after the rename to `grade_band`.
+ *
+ * Sentence Structure is listed only until its Zod schema is generated from its
+ * contract, which declares `complexity_score`; the SDK currently asks the model for
+ * `answer`.
+ */
+const VERDICT_FIELD_OVERRIDES: Readonly<Record<string, string>> = {
+  'student_facing_text.ela_reading.grade_level_appropriateness': 'grade',
+  'student_facing_text.ela_reading.sentence_structure': 'answer',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Pick the verdict and reasoning out of `result`.
+ *
+ * By convention every payload carries exactly one property ending in `_score`
+ * (`complexity_score`, `quality_score`) plus `reasoning`; evaluators that break the
+ * convention are listed above. A payload with neither yields empty strings rather
+ * than throwing — a missing verdict is a reporting gap, not a reason to fail an
+ * evaluation that already succeeded.
+ */
+export function readOutcome(evaluatorId: string, result: unknown): Outcome {
+  if (!isRecord(result)) return { score: '', reasoning: '' };
+
+  const override = VERDICT_FIELD_OVERRIDES[evaluatorId];
+  const field = override ?? Object.keys(result).find((key) => key.endsWith('_score'));
+
+  const score = field !== undefined ? result[field] : undefined;
+  const reasoning = result['reasoning'];
+
+  return {
+    score: score === undefined || score === null ? '' : String(score),
+    reasoning: typeof reasoning === 'string' ? reasoning : '',
+  };
+}

--- a/sdks/typescript/src/schemas/outcome.ts
+++ b/sdks/typescript/src/schemas/outcome.ts
@@ -8,9 +8,17 @@
  * per-evaluator table each SDK would have to keep in step.
  */
 
-/** The scalar verdict and its rationale, as a report consumes them. */
+import type { EvaluationResult } from './outputs.js';
+
+/**
+ * The scalar verdict and its rationale, as a report consumes them.
+ *
+ * `score` is undefined when the payload carries no verdict field. That is a reporting
+ * gap rather than an evaluation failure, so it is surfaced as absent for the caller to
+ * handle, not quietly rendered as an empty string here.
+ */
 export interface Outcome {
-  score: string;
+  score: string | undefined;
   reasoning: string;
 }
 
@@ -35,16 +43,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Pick the verdict and reasoning out of `result`.
+ * Pick the verdict and reasoning out of an evaluation's payload.
  *
  * By convention every payload carries exactly one property ending in `_score`
  * (`complexity_score`, `quality_score`) plus `reasoning`; evaluators that break the
- * convention are listed above. A payload with neither yields empty strings rather
- * than throwing — a missing verdict is a reporting gap, not a reason to fail an
- * evaluation that already succeeded.
+ * convention are listed above. A payload with no verdict field yields an
+ * undefined score rather than throwing — a missing verdict is a reporting gap, not a
+ * reason to fail an evaluation that already succeeded.
  */
-export function readOutcome(evaluatorId: string, result: unknown): Outcome {
-  if (!isRecord(result)) return { score: '', reasoning: '' };
+export function readOutcome({ evaluator, result }: EvaluationResult): Outcome {
+  if (!isRecord(result)) return { score: undefined, reasoning: '' };
 
   // An override only wins while its field is actually present, so an evaluator that
   // later adopts the convention starts working without anyone remembering to delete
@@ -52,7 +60,7 @@ export function readOutcome(evaluatorId: string, result: unknown): Outcome {
   //
   // `''` stands in for "no field": no payload declares an empty key, so both lookups
   // below miss and the outcome comes back blank.
-  const declared = VERDICT_FIELD_OVERRIDES[evaluatorId] ?? '';
+  const declared = VERDICT_FIELD_OVERRIDES[evaluator] ?? '';
   const field = declared in result
     ? declared
     : Object.keys(result).find((key) => key.endsWith('_score')) ?? '';
@@ -61,7 +69,7 @@ export function readOutcome(evaluatorId: string, result: unknown): Outcome {
   const reasoning = result['reasoning'];
 
   return {
-    score: score === undefined || score === null ? '' : String(score),
+    score: score === undefined || score === null ? undefined : String(score),
     reasoning: typeof reasoning === 'string' ? reasoning : '',
   };
 }

--- a/sdks/typescript/src/schemas/outcome.ts
+++ b/sdks/typescript/src/schemas/outcome.ts
@@ -31,7 +31,7 @@ const VERDICT_FIELD_OVERRIDES: Readonly<Record<string, string>> = {
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -46,10 +46,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export function readOutcome(evaluatorId: string, result: unknown): Outcome {
   if (!isRecord(result)) return { score: '', reasoning: '' };
 
-  const override = VERDICT_FIELD_OVERRIDES[evaluatorId];
-  const field = override ?? Object.keys(result).find((key) => key.endsWith('_score'));
+  // An override only wins while its field is actually present, so an evaluator that
+  // later adopts the convention starts working without anyone remembering to delete
+  // its entry — the alternative silently reports no verdict at all.
+  //
+  // `''` stands in for "no field": no payload declares an empty key, so both lookups
+  // below miss and the outcome comes back blank.
+  const declared = VERDICT_FIELD_OVERRIDES[evaluatorId] ?? '';
+  const field = declared in result
+    ? declared
+    : Object.keys(result).find((key) => key.endsWith('_score')) ?? '';
 
-  const score = field !== undefined ? result[field] : undefined;
+  const score = result[field];
   const reasoning = result['reasoning'];
 
   return {

--- a/sdks/typescript/src/schemas/outputs.ts
+++ b/sdks/typescript/src/schemas/outputs.ts
@@ -13,24 +13,35 @@ export const TextComplexityLevel = z.enum([
 
 export type TextComplexityLevel = z.infer<typeof TextComplexityLevel>;
 
-/**
- * Metadata attached to all evaluation results
- */
-export interface EvaluationMetadata {
-  model: string;
-  processingTimeMs: number;
+/** Tokens consumed by an evaluation, summed across every step. */
+export interface EvaluationTokenUsage {
   inputTokens: number;
   outputTokens: number;
 }
 
+/** Operational facts about how an evaluation ran, identical for every evaluator. */
+export interface EvaluationMetadata {
+  /** `provider:model` for the model that actually ran, including any override. */
+  model: string;
+  /** Wall-clock time for the whole evaluation, not just the LLM calls. */
+  processingTimeMs: number;
+  tokenUsage: EvaluationTokenUsage;
+}
+
 /**
- * Base evaluation result structure
+ * What every `evaluate()` resolves to. The three fields are the whole envelope:
+ * operational facts go in `metadata`, everything domain-specific in `result`.
+ *
+ * `result` is the model's structured output as the evaluator's `output_schema.json`
+ * declares it, keys and values unaltered. There is no scalar score hoisted up here
+ * and no casing translation, so the payload is byte-identical across SDKs. Reports
+ * that need one comparable value per evaluation use `readOutcome`.
  */
-export interface EvaluationResult<TScore = string, TInternal = unknown> {
-  score: TScore;
-  reasoning: string;
+export interface EvaluationResult<TResult = unknown> {
+  /** The evaluator's current registry id; renames stay resolvable via `idHistory`. */
+  evaluator: string;
+  result: TResult;
   metadata: EvaluationMetadata;
-  _internal?: TInternal;
 }
 
 /**

--- a/sdks/typescript/src/schemas/sentence-structure.ts
+++ b/sdks/typescript/src/schemas/sentence-structure.ts
@@ -77,12 +77,6 @@ export type ComplexityClassification = z.infer<typeof ComplexityClassificationSc
 /**
  * Internal data structure for sentence structure evaluation
  */
-export interface SentenceStructureInternal {
-  sentenceAnalysis: SentenceAnalysis;
-  features: SentenceFeatures;
-  complexity: ComplexityClassification;
-}
-
 /**
  * Engineered features computed from sentence analysis
  * These are calculated in TypeScript, not requested from LLM

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Provider, type BaseEvaluatorConfig } from '../../src/evaluators/base.js';
 import type { EvaluationResult } from '../../src/schemas/index.js';
+import { readOutcome } from '../../src/schemas/index.js';
 import { GradeLevelAppropriatenessEvaluator } from '../../src/evaluators/grade-level-appropriateness.js';
 import { MeaningDirectnessEvaluator } from '../../src/evaluators/meaning-directness.js';
 import { BackgroundKnowledgeDemandsEvaluator } from '../../src/evaluators/background-knowledge-demands.js';
@@ -46,31 +47,35 @@ function anthropicConfig(): BaseEvaluatorConfig {
 
 /** Per-entry `run` so each evaluator is called with its real arity — GLA takes only `text`. */
 const EVALUATORS: Array<{
-  name: string;
-  run: (config: BaseEvaluatorConfig) => Promise<EvaluationResult<string, unknown>>;
+  metadata: { id: string; name: string };
+  run: (config: BaseEvaluatorConfig) => Promise<EvaluationResult<unknown>>;
 }> = [
   {
-    name: 'GradeLevelAppropriateness',
+    metadata: GradeLevelAppropriatenessEvaluator.metadata,
     run: (c) => new GradeLevelAppropriatenessEvaluator(c).evaluate(SAMPLE_TEXT),
   },
-  { name: 'Meaning Directness', run: (c) => new MeaningDirectnessEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { name: 'Background Knowledge Demands', run: (c) => new BackgroundKnowledgeDemandsEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { name: 'SentenceStructure', run: (c) => new SentenceStructureEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { name: 'Purpose', run: (c) => new PurposeClarityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { name: 'Vocabulary', run: (c) => new VocabularyComplexityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: MeaningDirectnessEvaluator.metadata, run: (c) => new MeaningDirectnessEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: BackgroundKnowledgeDemandsEvaluator.metadata, run: (c) => new BackgroundKnowledgeDemandsEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: SentenceStructureEvaluator.metadata, run: (c) => new SentenceStructureEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: PurposeClarityEvaluator.metadata, run: (c) => new PurposeClarityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: VocabularyComplexityEvaluator.metadata, run: (c) => new VocabularyComplexityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
 ];
 
 describeIntegration('Anthropic provider — all text-complexity evaluators (live API)', () => {
-  for (const { name, run } of EVALUATORS) {
+  for (const { metadata, run } of EVALUATORS) {
     it(
-      `${name} completes on Anthropic and returns a structured result`,
+      `${metadata.name} completes on Anthropic and returns a structured result`,
       async () => {
         const result = await run(anthropicConfig());
 
-        expect(result.score).toBeDefined();
-        expect(typeof result.score).toBe('string');
-        expect((result.score as string).length).toBeGreaterThan(0);
-        expect(typeof result.reasoning).toBe('string');
+        // readOutcome is the only generic way to reach a verdict now that the
+        // envelope carries the payload as its contract declares it. Asserting
+        // through it here covers every evaluator's payload shape at once.
+        const outcome = readOutcome(result.evaluator, result.result);
+
+        expect(outcome.score.length).toBeGreaterThan(0);
+        expect(outcome.reasoning.length).toBeGreaterThan(0);
+        expect(result.evaluator).toBe(metadata.id);
         expect(result.metadata.model).toContain('anthropic');
         expect(result.metadata.model).toContain(ANTHROPIC_MODEL);
       },

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -71,9 +71,9 @@ describeIntegration('Anthropic provider — all text-complexity evaluators (live
         // readOutcome is the only generic way to reach a verdict now that the
         // envelope carries the payload as its contract declares it. Asserting
         // through it here covers every evaluator's payload shape at once.
-        const outcome = readOutcome(result.evaluator, result.result);
+        const outcome = readOutcome(result);
 
-        expect(outcome.score.length).toBeGreaterThan(0);
+        expect(outcome.score).toBeTruthy();
         expect(outcome.reasoning.length).toBeGreaterThan(0);
         expect(result.evaluator).toBe(metadata.id);
         expect(result.metadata.model).toContain('anthropic');

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration('modelOverride — model validity (live API)', () => {
     });
 
     const result = await evaluator.evaluate(SAMPLE_TEXT, '5');
-    expect(result.score).toBeDefined();
+    expect(result.result.answer).toBeDefined();
     expect(result.metadata.model).toMatch(/^openai:gpt-4o-mini/);
   }, TEST_TIMEOUT_MS);
 

--- a/sdks/typescript/tests/unit/batch/formatters.test.ts
+++ b/sdks/typescript/tests/unit/batch/formatters.test.ts
@@ -66,6 +66,35 @@ function extractReportData(html: string): any {
   return JSON.parse(json);
 }
 
+describe('complexity aggregates accept the contract score values', () => {
+  // Payloads carry the contract's own value (`slightly_complex`), so a report that
+  // only recognises the spaced form silently drops those rows from every average
+  // and from the heatmap -- no error, just missing data.
+  it('counts snake_case scores in the complexity averages', () => {
+    const html = formatAsHTML(
+      makeOutput([
+        makeResult({ rowIndex: 1, evaluatorId: 'purpose_clarity', score: 'slightly_complex' }),
+        makeResult({ rowIndex: 2, evaluatorId: 'purpose_clarity', score: 'very_complex' }),
+      ]),
+      makeMeta(),
+    );
+    const [stats] = extractReportData(html).complexityStats;
+
+    expect(stats.average).toBe(2);
+    expect(stats.label).not.toBe('N/A');
+  });
+
+  it('still counts the spaced form, which four evaluators emit until their schemas are generated', () => {
+    const html = formatAsHTML(
+      makeOutput([makeResult({ rowIndex: 1, evaluatorId: 'v', score: 'Very complex' })]),
+      makeMeta(),
+    );
+    const [stats] = extractReportData(html).complexityStats;
+
+    expect(stats.average).toBe(3);
+  });
+});
+
 // ============================================================
 // Evaluator id -> column and label derivation
 // ============================================================

--- a/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
@@ -79,12 +79,12 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
 
     const result = await evaluator.evaluate(testText, testGrade);
 
-    expect(result.score).toBe('Very complex');
-    expect(result.reasoning).toContain('hydraulic systems');
+    expect(result.result.complexity_score).toBe('Very complex');
+    expect(result.result.reasoning).toContain('hydraulic systems');
     expect(result.metadata.model).toBe('google:gemini-3-flash-preview');
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-    expect(result.metadata.inputTokens).toBe(200);
-    expect(result.metadata.outputTokens).toBe(100);
+    expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+    expect(result.metadata.tokenUsage.outputTokens).toBe(100);
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0];
@@ -155,6 +155,6 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
 
     const result = await evaluator.evaluate('The mitochondria is the powerhouse of the cell.', '5');
 
-    expect(result._internal).toEqual(mockData);
+    expect(result.result).toEqual(mockData);
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
@@ -136,7 +136,7 @@ describe('functional API wrappers', () => {
   it('evaluateGradeLevelAppropriateness takes no gradeLevel', async () => {
     const result = await evaluateGradeLevelAppropriateness(TEXT, CONFIG);
 
-    expect(result.score).toBe('6-8');
+    expect(result.result.grade).toBe('6-8');
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
 

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -90,17 +90,17 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate(testText);
 
       // Verify result structure
-      expect(result.score).toBe('6-8');
-      expect(result._internal).toBeDefined();
-      expect(result._internal!.grade).toBe('6-8');
-      expect(result._internal!.alternative_grade).toBe('4-5');
-      expect(result._internal!.scaffolding_needed).toContain('gravitational forces');
-      expect(result.reasoning).toContain('gravitational forces');
+      expect(result.result.grade).toBe('6-8');
+      expect(result.result).toBeDefined();
+      expect(result.result!.grade).toBe('6-8');
+      expect(result.result!.alternative_grade).toBe('4-5');
+      expect(result.result!.scaffolding_needed).toContain('gravitational forces');
+      expect(result.result.reasoning).toContain('gravitational forces');
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('google:gemini-2.5-pro');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-      expect(result.metadata.inputTokens).toBe(200);
-      expect(result.metadata.outputTokens).toBe(150);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(150);
 
       // Verify provider was called
       expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
@@ -153,19 +153,19 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate('Test text here');
 
       // Verify result structure
-      expect(result).toHaveProperty('score');
-      expect(result).toHaveProperty('reasoning');
+      expect(result).toHaveProperty('evaluator');
+      expect(result).toHaveProperty('result');
       expect(result).toHaveProperty('metadata');
-      expect(result).toHaveProperty('_internal');
+      expect(result).not.toHaveProperty('score');
 
       // Verify score is the grade string
-      expect(result.score).toBe('9-10');
+      expect(result.result.grade).toBe('9-10');
 
       // Verify _internal structure (GradeLevelAppropriateness)
-      expect(result._internal).toHaveProperty('grade');
-      expect(result._internal).toHaveProperty('alternative_grade');
-      expect(result._internal).toHaveProperty('scaffolding_needed');
-      expect(result._internal).toHaveProperty('reasoning');
+      expect(result.result).toHaveProperty('grade');
+      expect(result.result).toHaveProperty('alternative_grade');
+      expect(result.result).toHaveProperty('scaffolding_needed');
+      expect(result.result).toHaveProperty('reasoning');
 
       // Verify metadata structure
       expect(result.metadata).toHaveProperty('model');
@@ -174,13 +174,13 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('google:gemini-2.5-pro');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-      expect(result.metadata.inputTokens).toBe(200);
-      expect(result.metadata.outputTokens).toBe(150);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(150);
 
       // Verify _internal values
-      expect(result._internal!.grade).toBe('9-10');
-      expect(result._internal!.alternative_grade).toBe('6-8');
-      expect(result._internal!.scaffolding_needed).toBeTruthy();
+      expect(result.result!.grade).toBe('9-10');
+      expect(result.result!.alternative_grade).toBe('6-8');
+      expect(result.result!.scaffolding_needed).toBeTruthy();
     });
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
@@ -64,7 +64,7 @@ describe('llmProvider — bring-your-own-provider', () => {
     const result = await evaluator.evaluate(SAMPLE_TEXT);
 
     expect(generateStructured).toHaveBeenCalledTimes(1);
-    expect(result.score).toBe('6-8');
+    expect(result.result.grade).toBe('6-8');
     expect(result.metadata.model).toBe('vertex:gemini-2.5-pro');
     // The injected provider is the one in use, not a createProvider-built one.
     // @ts-expect-error accessing private property for testing

--- a/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
@@ -80,12 +80,12 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
 
     const result = await evaluator.evaluate(testText, testGrade);
 
-    expect(result.score).toBe('Very complex');
-    expect(result.reasoning).toContain('irony');
+    expect(result.result.complexity_score).toBe('Very complex');
+    expect(result.result.reasoning).toContain('irony');
     expect(result.metadata.model).toBe('google:gemini-3-flash-preview');
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-    expect(result.metadata.inputTokens).toBe(250);
-    expect(result.metadata.outputTokens).toBe(120);
+    expect(result.metadata.tokenUsage.inputTokens).toBe(250);
+    expect(result.metadata.tokenUsage.outputTokens).toBe(120);
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0];
@@ -126,10 +126,10 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
 
     const result = await evaluator.evaluate('Clouds form when water evaporates and rises into the sky.', '5');
 
-    expect(result._internal).toEqual(mockData);
-    expect(result._internal?.conventionality_features).toEqual(['literal narrative', 'concrete actions']);
-    expect(result._internal?.grade_context).toBe('Text uses mostly literal, accessible language for Grade 5.');
-    expect(result._internal?.instructional_insights).toBe('No special scaffolding needed for conventionality.');
+    expect(result.result).toEqual(mockData);
+    expect(result.result.conventionality_features).toEqual(['literal narrative', 'concrete actions']);
+    expect(result.result.grade_context).toBe('Text uses mostly literal, accessible language for Grade 5.');
+    expect(result.result.instructional_insights).toBe('No special scaffolding needed for conventionality.');
   });
 
   it('should include fk_score in user prompt', async () => {

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -197,16 +197,16 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
 
     const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
 
-    expect(result.score).toBe('Slightly complex');
-    expect(result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
+    expect(result.result.complexity_score).toBe('slightly_complex');
+    expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
     expect(result.metadata.model).toBe(`${STEP.model.provider}:${STEP.model.name}`);
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-    expect(result.metadata.inputTokens).toBe(200);
-    expect(result.metadata.outputTokens).toBe(120);
-    expect(result._internal).toEqual(MOCK_RESPONSE.data);
-    expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
-    expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
-    expect(result._internal?.details.recommended_use_cases).toBeInstanceOf(Array);
+    expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+    expect(result.metadata.tokenUsage.outputTokens).toBe(120);
+    expect(result.result).toEqual(MOCK_RESPONSE.data);
+    expect(result.result.details.detailed_summary).toBeInstanceOf(Array);
+    expect(result.result.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
+    expect(result.result.details.recommended_use_cases).toBeInstanceOf(Array);
   });
 
   it('reflects modelOverride in metadata.model', async () => {

--- a/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
@@ -188,16 +188,16 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
 
     const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
 
-    expect(result.score).toBe('Slightly complex');
-    expect(result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
+    expect(result.result.complexity_score).toBe('slightly_complex');
+    expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
     expect(result.metadata.model).toBe(`${STEP.model.provider}:${STEP.model.name}`);
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-    expect(result.metadata.inputTokens).toBe(200);
-    expect(result.metadata.outputTokens).toBe(120);
-    expect(result._internal).toEqual(MOCK_RESPONSE.data);
-    expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
-    expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
-    expect(result._internal?.details.recommended_use_cases).toBeInstanceOf(Array);
+    expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+    expect(result.metadata.tokenUsage.outputTokens).toBe(120);
+    expect(result.result).toEqual(MOCK_RESPONSE.data);
+    expect(result.result.details.detailed_summary).toBeInstanceOf(Array);
+    expect(result.result.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
+    expect(result.result.details.recommended_use_cases).toBeInstanceOf(Array);
   });
 
   it('reflects modelOverride in metadata.model', async () => {

--- a/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
@@ -188,16 +188,16 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
 
     const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
 
-    expect(result.score).toBe('Slightly complex');
-    expect(result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
+    expect(result.result.complexity_score).toBe('slightly_complex');
+    expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
     expect(result.metadata.model).toBe(`${STEP.model.provider}:${STEP.model.name}`);
     expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-    expect(result.metadata.inputTokens).toBe(200);
-    expect(result.metadata.outputTokens).toBe(120);
-    expect(result._internal).toEqual(MOCK_RESPONSE.data);
-    expect(result._internal?.details.detailed_summary).toBeInstanceOf(Array);
-    expect(result._internal?.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
-    expect(result._internal?.details.recommended_use_cases).toBeInstanceOf(Array);
+    expect(result.metadata.tokenUsage.inputTokens).toBe(200);
+    expect(result.metadata.tokenUsage.outputTokens).toBe(120);
+    expect(result.result).toEqual(MOCK_RESPONSE.data);
+    expect(result.result.details.detailed_summary).toBeInstanceOf(Array);
+    expect(result.result.details.adjustment_and_scaffolding).toBeInstanceOf(Array);
+    expect(result.result.details.recommended_use_cases).toBeInstanceOf(Array);
   });
 
   it('reflects modelOverride in metadata.model', async () => {

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -139,23 +139,22 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate(testText, testGrade);
 
       // Verify result structure
-      expect(result.score).toBe('Slightly complex');
-      expect(result.reasoning).toContain('simple sentence structures');
+      expect(result.result.answer).toBe('Slightly complex');
+      expect(result.result.reasoning).toContain('simple sentence structures');
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe(EXPECTED_MODEL);
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
       // Token usage is aggregated across both stages: stage 1 (150/100) + stage 2 (250/80)
-      expect(result.metadata.inputTokens).toBe(400);
-      expect(result.metadata.outputTokens).toBe(180);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(400);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(180);
 
       // Verify provider was called twice (once per stage)
       expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
 
-      // Verify internal data structure
-      expect(result._internal).toBeDefined();
-      expect(result._internal?.sentenceAnalysis).toBeDefined();
-      expect(result._internal?.features).toBeDefined();
-      expect(result._internal?.complexity).toBeDefined();
+      // The payload is the classify step's output, which is all output_schema.json
+      // declares -- the analysis step's counts are an internal intermediate.
+      expect(result.result.answer).toBe('Slightly complex');
+      expect(result.result.reasoning).toContain('simple sentence structures');
     });
   });
 
@@ -223,10 +222,10 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate('Test text here', '5');
 
       // Verify result structure
-      expect(result).toHaveProperty('score');
-      expect(result).toHaveProperty('reasoning');
+      expect(result).toHaveProperty('evaluator');
+      expect(result).toHaveProperty('result');
       expect(result).toHaveProperty('metadata');
-      expect(result).toHaveProperty('_internal');
+      expect(result).not.toHaveProperty('score');
 
       // Verify metadata structure
       expect(result.metadata).toHaveProperty('model');
@@ -235,8 +234,8 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe(EXPECTED_MODEL);
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
-      expect(result.metadata.inputTokens).toBe(400);
-      expect(result.metadata.outputTokens).toBe(180);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(400);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(180);
     });
   });
 

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -151,10 +151,10 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       // Verify provider was called twice (once per stage)
       expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
 
-      // The payload is the classify step's output, which is all output_schema.json
-      // declares -- the analysis step's counts are an internal intermediate.
-      expect(result.result.answer).toBe('Slightly complex');
-      expect(result.result.reasoning).toContain('simple sentence structures');
+      // output_schema.json declares the classify step's output only, so the analysis
+      // step's ~30 grammatical counts are not surfaced.
+      expect(result.result).not.toHaveProperty('sentenceAnalysis');
+      expect(result.result).not.toHaveProperty('features');
     });
   });
 

--- a/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
@@ -114,14 +114,14 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate(testText, testGrade);
 
       // Verify result structure
-      expect(result.score).toBe('Moderately complex');
-      expect(result.reasoning).toContain('grade-appropriate vocabulary');
+      expect(result.result.complexity_score).toBe('Moderately complex');
+      expect(result.result.reasoning).toContain('grade-appropriate vocabulary');
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThan(0);
       // Token usage is aggregated across both stages: background (100/50) + complexity (200/100)
-      expect(result.metadata.inputTokens).toBe(300);
-      expect(result.metadata.outputTokens).toBe(150);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(300);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(150);
 
       // Verify both providers were called
       expect(mockBackgroundProvider.generateText).toHaveBeenCalledTimes(1);
@@ -207,10 +207,10 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate('Test text here', '5');
 
       // Verify result structure
-      expect(result).toHaveProperty('score');
-      expect(result).toHaveProperty('reasoning');
+      expect(result).toHaveProperty('evaluator');
+      expect(result).toHaveProperty('result');
       expect(result).toHaveProperty('metadata');
-      expect(result).toHaveProperty('_internal');
+      expect(result).not.toHaveProperty('score');
 
       // Verify metadata structure
       expect(result.metadata).toHaveProperty('model');
@@ -219,8 +219,8 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       // Verify metadata values
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0); // Mocked calls can be instant (0ms)
-      expect(result.metadata.inputTokens).toBe(300);
-      expect(result.metadata.outputTokens).toBe(150);
+      expect(result.metadata.tokenUsage.inputTokens).toBe(300);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(150);
     });
 
     it('should reflect modelOverride in metadata.model for both stages', async () => {
@@ -276,7 +276,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate('Test text here', '5');
 
       // Verify internal data is included
-      expect(result._internal).toEqual(mockComplexityData);
+      expect(result.result).toEqual(mockComplexityData);
     });
   });
 });

--- a/sdks/typescript/tests/unit/schemas/outcome.test.ts
+++ b/sdks/typescript/tests/unit/schemas/outcome.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { readOutcome } from '../../../src/schemas/outcome.js';
+import {
+  MeaningDirectnessEvaluator,
+  GradeLevelAppropriatenessEvaluator,
+  SentenceStructureEvaluator,
+  PurposeClarityEvaluator,
+} from '../../../src/evaluators/index.js';
+
+const COMPLEXITY_ID = MeaningDirectnessEvaluator.metadata.id;
+const GLA_ID = GradeLevelAppropriatenessEvaluator.metadata.id;
+const SENTENCE_ID = SentenceStructureEvaluator.metadata.id;
+
+describe('readOutcome — by convention', () => {
+  it('reads the single *_score property', () => {
+    const outcome = readOutcome(COMPLEXITY_ID, {
+      complexity_score: 'slightly_complex',
+      reasoning: 'because',
+    });
+
+    expect(outcome).toEqual({ score: 'slightly_complex', reasoning: 'because' });
+  });
+
+  it('reads a *_score property it has never seen before', () => {
+    // The convention is what makes a new evaluator work with no registration.
+    const outcome = readOutcome('feedback.ela_writing.revision_accuracy', {
+      quality_score: 1,
+      reasoning: 'meets the criterion',
+    });
+
+    expect(outcome).toEqual({ score: '1', reasoning: 'meets the criterion' });
+  });
+
+  it('does not treat `reasoning` as the verdict', () => {
+    expect(readOutcome(COMPLEXITY_ID, { reasoning: 'no verdict here' })).toEqual({
+      score: '',
+      reasoning: 'no verdict here',
+    });
+  });
+});
+
+describe('readOutcome — declared exceptions', () => {
+  it('reads the grade band for Grade Level Appropriateness', () => {
+    const outcome = readOutcome(GLA_ID, {
+      grade: '4-5',
+      alternative_grade: '6-8',
+      reasoning: 'band fits',
+    });
+
+    expect(outcome.score).toBe('4-5');
+  });
+
+  it('prefers the declared field over a *_score property that happens to exist', () => {
+    // Guards the precedence: GLA's payload gains a *_score field and the band must
+    // still win, otherwise the report silently starts charting the wrong value.
+    const outcome = readOutcome(GLA_ID, {
+      grade: '4-5',
+      confidence_score: 0.9,
+      reasoning: 'band fits',
+    });
+
+    expect(outcome.score).toBe('4-5');
+  });
+
+  it('reads `answer` for Sentence Structure', () => {
+    const outcome = readOutcome(SENTENCE_ID, {
+      answer: 'Moderately complex',
+      reasoning: 'mixed structures',
+    });
+
+    expect(outcome.score).toBe('Moderately complex');
+  });
+
+  it('applies no exception to an evaluator that follows the convention', () => {
+    const outcome = readOutcome(PurposeClarityEvaluator.metadata.id, {
+      complexity_score: 'very_complex',
+      reasoning: 'implicit purpose',
+    });
+
+    expect(outcome.score).toBe('very_complex');
+  });
+});
+
+describe('readOutcome — payloads with nothing to read', () => {
+  // A missing verdict is a reporting gap. Throwing here would fail an evaluation
+  // that already succeeded and whose payload the caller can still use.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'not a payload'],
+    ['a number', 7],
+    ['an empty object', {}],
+  ])('returns empty strings for %s', (_label, payload) => {
+    expect(readOutcome(COMPLEXITY_ID, payload)).toEqual({ score: '', reasoning: '' });
+  });
+
+  it('returns an empty score when the declared field is absent', () => {
+    expect(readOutcome(GLA_ID, { reasoning: 'no band' })).toEqual({
+      score: '',
+      reasoning: 'no band',
+    });
+  });
+
+  it('coerces a non-string verdict to a string', () => {
+    expect(readOutcome('feedback.ela_writing.tone_appropriateness', { quality_score: 0 }).score)
+      .toBe('0');
+  });
+
+  it('ignores a non-string reasoning rather than coercing it', () => {
+    // A report prints reasoning verbatim; "[object Object]" is worse than blank.
+    expect(readOutcome(COMPLEXITY_ID, { complexity_score: 'x', reasoning: { a: 1 } })).toEqual({
+      score: 'x',
+      reasoning: '',
+    });
+  });
+
+  it('treats a null verdict as absent', () => {
+    expect(readOutcome(COMPLEXITY_ID, { complexity_score: null, reasoning: 'r' }).score).toBe('');
+  });
+});

--- a/sdks/typescript/tests/unit/schemas/outcome.test.ts
+++ b/sdks/typescript/tests/unit/schemas/outcome.test.ts
@@ -62,6 +62,18 @@ describe('readOutcome — declared exceptions', () => {
     expect(outcome.score).toBe('4-5');
   });
 
+  it('falls back to the convention once the declared field is gone', () => {
+    // Sentence Structure's schema will be regenerated to `complexity_score`. If the
+    // stale `answer` entry still took precedence, the verdict would silently go
+    // empty; instead the convention takes over and the entry becomes inert.
+    const outcome = readOutcome(SENTENCE_ID, {
+      complexity_score: 'moderately_complex',
+      reasoning: 'mixed structures',
+    });
+
+    expect(outcome.score).toBe('moderately_complex');
+  });
+
   it('reads `answer` for Sentence Structure', () => {
     const outcome = readOutcome(SENTENCE_ID, {
       answer: 'Moderately complex',
@@ -90,6 +102,7 @@ describe('readOutcome — payloads with nothing to read', () => {
     ['a string', 'not a payload'],
     ['a number', 7],
     ['an empty object', {}],
+    ['an array', [{ complexity_score: 'slightly_complex' }]],
   ])('returns empty strings for %s', (_label, payload) => {
     expect(readOutcome(COMPLEXITY_ID, payload)).toEqual({ score: '', reasoning: '' });
   });

--- a/sdks/typescript/tests/unit/schemas/outcome.test.ts
+++ b/sdks/typescript/tests/unit/schemas/outcome.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readOutcome } from '../../../src/schemas/outcome.js';
+import type { EvaluationResult } from '../../../src/schemas/index.js';
 import {
   MeaningDirectnessEvaluator,
   GradeLevelAppropriatenessEvaluator,
@@ -11,41 +12,50 @@ const COMPLEXITY_ID = MeaningDirectnessEvaluator.metadata.id;
 const GLA_ID = GradeLevelAppropriatenessEvaluator.metadata.id;
 const SENTENCE_ID = SentenceStructureEvaluator.metadata.id;
 
+/** Minimal envelope — readOutcome reads only `evaluator` and `result`. */
+const envelope = (evaluator: string, result: unknown): EvaluationResult => ({
+  evaluator,
+  result,
+  metadata: {
+    model: 'stub:model',
+    processingTimeMs: 0,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  },
+});
+
 describe('readOutcome — by convention', () => {
   it('reads the single *_score property', () => {
-    const outcome = readOutcome(COMPLEXITY_ID, {
-      complexity_score: 'slightly_complex',
-      reasoning: 'because',
-    });
+    const outcome = readOutcome(
+      envelope(COMPLEXITY_ID, { complexity_score: 'slightly_complex', reasoning: 'because' }),
+    );
 
     expect(outcome).toEqual({ score: 'slightly_complex', reasoning: 'because' });
   });
 
   it('reads a *_score property it has never seen before', () => {
     // The convention is what makes a new evaluator work with no registration.
-    const outcome = readOutcome('feedback.ela_writing.revision_accuracy', {
-      quality_score: 1,
-      reasoning: 'meets the criterion',
-    });
+    const outcome = readOutcome(
+      envelope('feedback.ela_writing.revision_accuracy', {
+        quality_score: 1,
+        reasoning: 'meets the criterion',
+      }),
+    );
 
     expect(outcome).toEqual({ score: '1', reasoning: 'meets the criterion' });
   });
 
   it('does not treat `reasoning` as the verdict', () => {
-    expect(readOutcome(COMPLEXITY_ID, { reasoning: 'no verdict here' })).toEqual({
-      score: '',
-      reasoning: 'no verdict here',
-    });
+    const outcome = readOutcome(envelope(COMPLEXITY_ID, { reasoning: 'no verdict here' }));
+
+    expect(outcome).toEqual({ score: undefined, reasoning: 'no verdict here' });
   });
 });
 
 describe('readOutcome — declared exceptions', () => {
   it('reads the grade band for Grade Level Appropriateness', () => {
-    const outcome = readOutcome(GLA_ID, {
-      grade: '4-5',
-      alternative_grade: '6-8',
-      reasoning: 'band fits',
-    });
+    const outcome = readOutcome(
+      envelope(GLA_ID, { grade: '4-5', alternative_grade: '6-8', reasoning: 'band fits' }),
+    );
 
     expect(outcome.score).toBe('4-5');
   });
@@ -53,49 +63,47 @@ describe('readOutcome — declared exceptions', () => {
   it('prefers the declared field over a *_score property that happens to exist', () => {
     // Guards the precedence: GLA's payload gains a *_score field and the band must
     // still win, otherwise the report silently starts charting the wrong value.
-    const outcome = readOutcome(GLA_ID, {
-      grade: '4-5',
-      confidence_score: 0.9,
-      reasoning: 'band fits',
-    });
+    const outcome = readOutcome(
+      envelope(GLA_ID, { grade: '4-5', confidence_score: 0.9, reasoning: 'band fits' }),
+    );
 
     expect(outcome.score).toBe('4-5');
   });
 
   it('falls back to the convention once the declared field is gone', () => {
     // Sentence Structure's schema will be regenerated to `complexity_score`. If the
-    // stale `answer` entry still took precedence, the verdict would silently go
-    // empty; instead the convention takes over and the entry becomes inert.
-    const outcome = readOutcome(SENTENCE_ID, {
-      complexity_score: 'moderately_complex',
-      reasoning: 'mixed structures',
-    });
+    // stale `answer` entry still took precedence the verdict would silently go empty;
+    // instead the convention takes over and the entry becomes inert.
+    const outcome = readOutcome(
+      envelope(SENTENCE_ID, { complexity_score: 'moderately_complex', reasoning: 'mixed' }),
+    );
 
     expect(outcome.score).toBe('moderately_complex');
   });
 
   it('reads `answer` for Sentence Structure', () => {
-    const outcome = readOutcome(SENTENCE_ID, {
-      answer: 'Moderately complex',
-      reasoning: 'mixed structures',
-    });
+    const outcome = readOutcome(
+      envelope(SENTENCE_ID, { answer: 'Moderately complex', reasoning: 'mixed structures' }),
+    );
 
     expect(outcome.score).toBe('Moderately complex');
   });
 
   it('applies no exception to an evaluator that follows the convention', () => {
-    const outcome = readOutcome(PurposeClarityEvaluator.metadata.id, {
-      complexity_score: 'very_complex',
-      reasoning: 'implicit purpose',
-    });
+    const outcome = readOutcome(
+      envelope(PurposeClarityEvaluator.metadata.id, {
+        complexity_score: 'very_complex',
+        reasoning: 'implicit purpose',
+      }),
+    );
 
     expect(outcome.score).toBe('very_complex');
   });
 });
 
 describe('readOutcome — payloads with nothing to read', () => {
-  // A missing verdict is a reporting gap. Throwing here would fail an evaluation
-  // that already succeeded and whose payload the caller can still use.
+  // An absent verdict is surfaced as undefined rather than rendered as an empty string:
+  // it is a reporting gap, and throwing would fail an evaluation that already succeeded.
   it.each([
     ['null', null],
     ['undefined', undefined],
@@ -103,31 +111,42 @@ describe('readOutcome — payloads with nothing to read', () => {
     ['a number', 7],
     ['an empty object', {}],
     ['an array', [{ complexity_score: 'slightly_complex' }]],
-  ])('returns empty strings for %s', (_label, payload) => {
-    expect(readOutcome(COMPLEXITY_ID, payload)).toEqual({ score: '', reasoning: '' });
+  ])('returns an undefined score for %s', (_label, payload) => {
+    expect(readOutcome(envelope(COMPLEXITY_ID, payload))).toEqual({
+      score: undefined,
+      reasoning: '',
+    });
   });
 
-  it('returns an empty score when the declared field is absent', () => {
-    expect(readOutcome(GLA_ID, { reasoning: 'no band' })).toEqual({
-      score: '',
+  it('returns an undefined score when the declared field is absent', () => {
+    expect(readOutcome(envelope(GLA_ID, { reasoning: 'no band' }))).toEqual({
+      score: undefined,
       reasoning: 'no band',
     });
   });
 
   it('coerces a non-string verdict to a string', () => {
-    expect(readOutcome('feedback.ela_writing.tone_appropriateness', { quality_score: 0 }).score)
-      .toBe('0');
+    const outcome = readOutcome(
+      envelope('feedback.ela_writing.tone_appropriateness', { quality_score: 0 }),
+    );
+
+    expect(outcome.score).toBe('0');
   });
 
   it('ignores a non-string reasoning rather than coercing it', () => {
     // A report prints reasoning verbatim; "[object Object]" is worse than blank.
-    expect(readOutcome(COMPLEXITY_ID, { complexity_score: 'x', reasoning: { a: 1 } })).toEqual({
-      score: 'x',
-      reasoning: '',
-    });
+    const outcome = readOutcome(
+      envelope(COMPLEXITY_ID, { complexity_score: 'x', reasoning: { a: 1 } }),
+    );
+
+    expect(outcome).toEqual({ score: 'x', reasoning: '' });
   });
 
   it('treats a null verdict as absent', () => {
-    expect(readOutcome(COMPLEXITY_ID, { complexity_score: null, reasoning: 'r' }).score).toBe('');
+    const outcome = readOutcome(
+      envelope(COMPLEXITY_ID, { complexity_score: null, reasoning: 'r' }),
+    );
+
+    expect(outcome.score).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes the largest conformance gap: §5.1's result envelope.

## The shape

```ts
// before
{ score, reasoning, metadata: { model, processingTimeMs, inputTokens, outputTokens }, _internal }

// after
{ evaluator, result, metadata: { model, processingTimeMs, tokenUsage: { inputTokens, outputTokens } } }
```

`result` is the model's structured output as the evaluator's `output_schema.json` declares it — keys and values unaltered, no scalar hoisted up, no casing translation.

That last point is deliberate and worth a reviewer's attention. §5.2 says field names follow §2, which maps snake_case to camelCase for the SDK surface. I read that as **not** applying to the payload, because §5.2 also requires the payload be *identical across SDKs* — and casing-mapping it would give Python `complexity_score` and TypeScript `complexityScore`, i.e. two different payloads for the same evaluator. Keeping the registry's own keys is the only reading that satisfies both sentences. Worth confirming in the spec.

## The display maps are gone

Callers now see `slightly_complex`, not `Slightly complex`. Three per-evaluator lookup tables deleted — exactly the kind of thing a second SDK would have to clone byte-for-byte or drift on.

## readOutcome

Reports need one comparable value per evaluation and the envelope has no score slot, so this derives it from the shape the contracts already share: the single required `*_score` property plus `reasoning`. A new evaluator that follows the convention needs no registration — the feedback family's `quality_score` works untouched, and there's a test asserting that.

Two declared exceptions, both with a reason in the code:

| evaluator | field | why |
| --- | --- | --- |
| Grade Level Appropriateness | `grade` | answers with a band, not a score |
| Sentence Structure | `answer` | until its schema is generated from its contract |

`Outcome.score` is `string | undefined`: a payload with no verdict field reports the gap rather than rendering it as `''`, since a silent fallback is what Principle 4 calls a defect. Batch still renders blank, but coerces at its own call site where the gap stays visible. `readOutcome` takes the envelope — it already carries `evaluator`, so making the caller disassemble it was needless.

## One place data is dropped

**Sentence Structure's payload narrows.** Its `output_schema.json` declares `complexity_score` and `reasoning` only, and calls the analysis step's ~30 grammatical counts *"an internal intermediate artifact, not part of this contract"* — so they are no longer returned. This was a real choice between the contract and §5.2's "never withhold data the model returned"; the contract won because §5.2 also says the payload's shape *is* the registry definition. Flagging it as the one caller-visible capability loss.

## Out of scope

- **Math Standards Alignment** shares none of these types — it has its own `StandardAlignmentResult` and never used `EvaluationResult`. It needs the envelope too, in its own PR.
- **`evaluateItems` / `evaluateByGradeLevel`** stay as they are. §9.1 is Draft and Q-12 explicitly lists batch result shapes as undecided, so settling them here would be inventing a contract.
- **Per-step detail in `metadata`.** A multi-step evaluator's envelope shows only sums: `tokenUsage` across all steps, wall-clock `processingTimeMs`, one `model` string. Every evaluator already builds a per-step `stageDetails` array, but it goes to telemetry only — so the breakdown exists and the caller can't see it. The spec-legal home is `metadata`, but §8.3 phase details are Draft pending Q-10, which covers the `stage`/`step`/`phase` naming itself. Adding it now would commit to that vocabulary, inside the one structure §5.1 says is fixed forever.

## Breaking

Every `evaluate()` return shape; `_internal` → `result`; flat metadata token counts → `metadata.tokenUsage`; score values for Purpose Clarity, Organizational Structure and Reference Knowledge Demands; and three removed exports — `SentenceStructureInternal`, `PurposeClarityComplexityLevel`, and the second type parameter of `EvaluationResult`.

## Validation

- `tsc --noEmit`, `npm run lint`, `npm run test:unit`, `npm run build`
- `scripts/check.py` from the repo root
- StrykerJS on `src/schemas/outcome.ts` — one surviving mutant, equivalent (with `field` undefined, `result[field]` is `undefined` on both branches, so Stryker flags it whichever way the ternary is written)
- The live cross-provider integration test now asserts through `readOutcome`, so it exercises every evaluator's payload shape in one place


