### PR TITLE
test(sdk): close the blind spots in the registry conformance suite

### DIFF
--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -48,7 +48,7 @@ import {
 const constructed: Array<{ type: string; model: string }> = [];
 
 /** Records the generation settings of every LLM call an evaluator makes. */
-const sent: Array<{ temperature?: number }> = [];
+const llmCalls: Array<{ temperature?: number }> = [];
 
 vi.mock('../../src/providers/index.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -59,7 +59,7 @@ vi.mock('../../src/providers/index.js', async (importOriginal) => {
       return {
         label: `${config.type}:${config.model}`,
         generateStructured: vi.fn(async (request: { temperature?: number }) => {
-          sent.push({ temperature: request.temperature });
+          llmCalls.push({ temperature: request.temperature });
           return {
             data: {},
             model: config.model,
@@ -405,12 +405,12 @@ describe('the schema the SDK sends matches the contract', () => {
 
   it.each(withSchema)('$name', ({ E }) => {
     const { outputSchema } = contractFor(E.metadata.id);
-    const sent = Object.keys(SDK_OUTPUT_SCHEMAS[E.metadata.id].shape).sort();
+    const sentFields = Object.keys(SDK_OUTPUT_SCHEMAS[E.metadata.id].shape).sort();
     const declared = Object.keys(outputSchema.properties).sort();
 
     expectAgainstContract(
       SCHEMA_GAPS.has(E.metadata.id),
-      sent,
+      sentFields,
       declared,
       `${E.metadata.name} sent payload fields`,
     );
@@ -599,18 +599,18 @@ describe('the report can order every family member', () => {
 
 describe('the temperature sent matches the contract', () => {
   beforeEach(() => {
-    sent.length = 0;
+    llmCalls.length = 0;
   });
 
   it.each(singleStepCases)('$name', async ({ E }) => {
     const { config } = contractFor(E.metadata.id);
     await INVOKE[E.metadata.id](E, 'A sentence long enough to pass validation.');
 
-    expect(sent, `${E.metadata.name} made no LLM call`).toHaveLength(1);
+    expect(llmCalls, `${E.metadata.name} made no LLM call`).toHaveLength(1);
 
     expectAgainstContract(
       TEMPERATURE_GAPS.has(E.metadata.id),
-      sent[0].temperature,
+      llmCalls[0].temperature,
       config.steps[0].generation?.temperature,
       `${E.metadata.name} temperature`,
     );

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+import * as exported from '../../src/evaluators/index.js';
 import {
   GradeLevelAppropriatenessEvaluator,
   BackgroundKnowledgeDemandsEvaluator,
@@ -13,9 +14,29 @@ import {
   VocabularyComplexityEvaluator,
   MathStandardsAlignmentEvaluator,
 } from '../../src/evaluators/index.js';
-import { VALIDATION_LIMITS } from '../../src/evaluators/base.js';
+import { InputValidationError } from '../../src/errors.js';
 import { readOutcome } from '../../src/schemas/outcome.js';
 import type { EvaluationResult } from '../../src/schemas/index.js';
+import { BackgroundKnowledgeDemandsOutputSchema } from '../../src/schemas/background-knowledge-demands.js';
+import { GradeLevelAppropriatenessOutputSchema } from '../../src/schemas/grade-level-appropriateness.js';
+import { MeaningDirectnessOutputSchema } from '../../src/schemas/meaning-directness.js';
+import { OrganizationalStructureOutputSchema } from '../../src/schemas/organizational-structure.js';
+import { PurposeClarityOutputSchema } from '../../src/schemas/purpose-clarity.js';
+import { ReferenceKnowledgeDemandsOutputSchema } from '../../src/schemas/reference-knowledge-demands.js';
+import { VocabularyComplexityOutputSchema } from '../../src/schemas/vocabulary-complexity.js';
+import { ComplexityClassificationSchema } from '../../src/schemas/sentence-structure.js';
+
+interface EvaluatorClass {
+  metadata: {
+    id: string;
+    stableId: string;
+    idHistory: readonly string[];
+    name: string;
+    description: string;
+    supportedGrades: readonly string[];
+    defaultProviders: readonly string[];
+  };
+}
 import {
   formatAsHTML,
   getFamilies,
@@ -26,6 +47,9 @@ import {
 /** Records every (provider, model) an evaluator asks for at construction. */
 const constructed: Array<{ type: string; model: string }> = [];
 
+/** Records the generation settings of every LLM call an evaluator makes. */
+const sent: Array<{ temperature?: number }> = [];
+
 vi.mock('../../src/providers/index.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
@@ -34,8 +58,21 @@ vi.mock('../../src/providers/index.js', async (importOriginal) => {
       constructed.push({ type: config.type, model: config.model });
       return {
         label: `${config.type}:${config.model}`,
-        generateStructured: vi.fn(),
-        generateText: vi.fn(),
+        generateStructured: vi.fn(async (request: { temperature?: number }) => {
+          sent.push({ temperature: request.temperature });
+          return {
+            data: {},
+            model: config.model,
+            usage: { inputTokens: 1, outputTokens: 1 },
+            latencyMs: 1,
+          };
+        }),
+        generateText: vi.fn(async () => ({
+          text: '{}',
+          model: config.model,
+          usage: { inputTokens: 1, outputTokens: 1 },
+          latencyMs: 1,
+        })),
       };
     }),
   };
@@ -53,17 +90,34 @@ vi.mock('../../src/providers/index.js', async (importOriginal) => {
  * moment it appears in EVALUATORS below.
  */
 
-const EVALUATORS = [
-  GradeLevelAppropriatenessEvaluator,
-  BackgroundKnowledgeDemandsEvaluator,
-  MeaningDirectnessEvaluator,
-  OrganizationalStructureEvaluator,
-  PurposeClarityEvaluator,
-  ReferenceKnowledgeDemandsEvaluator,
-  SentenceStructureEvaluator,
-  VocabularyComplexityEvaluator,
-  MathStandardsAlignmentEvaluator,
-];
+/**
+ * Every evaluator the SDK exports, discovered rather than listed: anything with a
+ * static `metadata.id` is an evaluator. A hand-maintained array silently gives an
+ * omitted evaluator zero coverage, which is the failure this suite exists to prevent.
+ */
+const EVALUATORS = (Object.values(exported) as unknown[])
+  .filter(
+    (v): v is EvaluatorClass =>
+      typeof v === 'function' && typeof (v as unknown as EvaluatorClass).metadata?.id === 'string',
+  )
+  .sort((a, b) => a.metadata.id.localeCompare(b.metadata.id));
+
+/**
+ * Contracts with no TypeScript implementation yet.
+ *
+ * Listing them here is what keeps them visible: the test below asserts that every
+ * contract on disk is either implemented or named here, so a new contract cannot sit
+ * unimplemented and unmentioned.
+ */
+const UNIMPLEMENTED = new Set<string>([
+  'feedback.ela_writing.revision_accuracy',
+  'feedback.ela_writing.revision_actionability',
+  'feedback.ela_writing.revision_manageability',
+  'feedback.ela_writing.strength_acknowledgment',
+  'feedback.ela_writing.student_response_specificity',
+  'feedback.ela_writing.tone_appropriateness',
+  'feedback.ela_writing.withholding_answers',
+]);
 
 // ---------------------------------------------------------------------------
 // Known gaps
@@ -112,32 +166,7 @@ const LIMIT_GAPS = new Set<string>([
   `${SENTENCE_ID}::text`,
 ]);
 
-/**
- * Inputs the shared text-validation path does not govern, so the check below cannot
- * speak for them.
- *
- * `statementCode` is an identifier with its own declared bound rather than prose, and
- * nothing enforces it — a real gap, but not one this comparison can observe: it
- * measures the declared bounds against the SDK's single global pair, which would keep
- * differing even after per-field enforcement landed, so an entry here could never
- * self-clean. Enforcement is verified by calling the evaluator, which becomes uniform
- * once inputs are named.
- *
- * The underlying gap is in the contract schema: nothing distinguishes a prose input
- * from an identifier, so this set cannot be derived.
- */
-const NON_PROSE_INPUTS = new Set<string>([`${MATH_ID}::statementCode`]);
 
-/** Evaluators where a contract-shaped payload yields no verdict. */
-const VERDICT_GAPS = new Set<string>([
-  // The live trap: readOutcome's override names `grade`, the contract declares
-  // `grade_band`. Regenerating this schema from its contract silently blanks every
-  // GLA verdict in every report until the override is updated in the same change.
-  GLA_ID,
-  // No `*_score` and no `reasoning` — alignment counts instead. Math reports through
-  // its own output path and never goes through readOutcome.
-  MATH_ID,
-]);
 
 /**
  * Grade bands the report's own band list does not contain.
@@ -162,6 +191,44 @@ const ORDER_GAPS = new Set<string>([
   ReferenceKnowledgeDemandsEvaluator.metadata.id,
   // The standards family has its own report, which does not use this ordering.
   MathStandardsAlignmentEvaluator.metadata.id,
+]);
+
+/**
+ * Evaluators sending a temperature their contract does not declare.
+ */
+const TEMPERATURE_GAPS = new Set<string>([
+  // Sends 0.25; the contract declares 1.
+  GLA_ID,
+]);
+
+/**
+ * The Zod schema each evaluator actually sends to the model.
+ *
+ * This is the side of the comparison the suite was missing: the contract says what the
+ * payload should be, and only this says what it is.
+ *
+ * Math Standards Alignment is absent deliberately — its payload is assembled from
+ * per-component results rather than being one model output, so there is no single
+ * schema to compare.
+ */
+const SDK_OUTPUT_SCHEMAS: Record<string, { shape: Record<string, unknown> }> = {
+  [BackgroundKnowledgeDemandsEvaluator.metadata.id]: BackgroundKnowledgeDemandsOutputSchema,
+  [GradeLevelAppropriatenessEvaluator.metadata.id]: GradeLevelAppropriatenessOutputSchema,
+  [MeaningDirectnessEvaluator.metadata.id]: MeaningDirectnessOutputSchema,
+  [OrganizationalStructureEvaluator.metadata.id]: OrganizationalStructureOutputSchema,
+  [PurposeClarityEvaluator.metadata.id]: PurposeClarityOutputSchema,
+  [ReferenceKnowledgeDemandsEvaluator.metadata.id]: ReferenceKnowledgeDemandsOutputSchema,
+  [VocabularyComplexityEvaluator.metadata.id]: VocabularyComplexityOutputSchema,
+  [SentenceStructureEvaluator.metadata.id]: ComplexityClassificationSchema,
+};
+
+/** Evaluators whose sent schema does not match their contract's declared payload. */
+const SCHEMA_GAPS = new Set<string>([
+  // Sends `grade` / `alternative_grade`; the contract declares `grade_band` /
+  // `alternative_grade_band`, and its enum says `11-12` where the SDK says `11-CCR`.
+  GLA_ID,
+  // Sends `answer`; the contract declares `complexity_score`.
+  SENTENCE_ID,
 ]);
 
 // ---------------------------------------------------------------------------
@@ -227,6 +294,46 @@ function expectAgainstContract(
 
 const cases = EVALUATORS.map((E) => ({ name: E.metadata.name, E }));
 
+/**
+ * How to run each text-taking evaluator with inputs its contract accepts.
+ *
+ * Math is absent: its inputs are a question and a standard code, and it calls the
+ * Knowledge Graph before any model. Naming inputs will make this map derivable.
+ */
+const INVOKE: Record<string, (E: EvaluatorClass, text: string) => Promise<unknown>> = {
+  [GLA_ID]: (E, text) => construct(E).evaluate(text),
+  [BKD_ID]: (E, text) => construct(E).evaluate(text, '5'),
+  [MD_ID]: (E, text) => construct(E).evaluate(text, '5'),
+  [OrganizationalStructureEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
+  [PurposeClarityEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
+  [ReferenceKnowledgeDemandsEvaluator.metadata.id]: (E, text) =>
+    construct(E).evaluate(text, '5'),
+  [SENTENCE_ID]: (E, text) => construct(E).evaluate(text, '5'),
+  [VocabularyComplexityEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
+};
+
+/**
+ * Evaluators with more than one step.
+ *
+ * The temperature check needs each step's own response stubbed to its own shape, so it
+ * skips these. The minimum-length check does not: validation runs before any LLM call.
+ */
+const MULTI_STEP = new Set<string>([SENTENCE_ID, VocabularyComplexityEvaluator.metadata.id]);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function construct(E: EvaluatorClass): any {
+  return new (E as unknown as new (c: Record<string, unknown>) => unknown)({
+    googleApiKey: 'k',
+    openaiApiKey: 'k',
+    anthropicApiKey: 'k',
+    learningCommonsApiKey: 'k',
+    telemetry: false,
+  });
+}
+
+const invocableCases = cases.filter(({ E }) => INVOKE[E.metadata.id]);
+const singleStepCases = invocableCases.filter(({ E }) => !MULTI_STEP.has(E.metadata.id));
+
 describe('every evaluator has a contract at the derived path', () => {
   it.each(cases)('$name', ({ E }) => {
     const dir = join(
@@ -288,46 +395,39 @@ describe('declared providers match the contract steps', () => {
   });
 });
 
-describe('text limits honour the contract', () => {
-  it.each(cases)('$name', ({ E }) => {
-    const { inputSchema } = contractFor(E.metadata.id);
-    const textInputs = Object.entries(inputSchema.properties).filter(
-      ([field, spec]) =>
-        spec.type === 'string' &&
-        spec.maxLength !== undefined &&
-        !NON_PROSE_INPUTS.has(`${E.metadata.id}::${field}`),
+describe('the schema the SDK sends matches the contract', () => {
+  const withSchema = cases.filter(({ E }) => SDK_OUTPUT_SCHEMAS[E.metadata.id]);
+
+  it('covers every evaluator that sends a single schema', () => {
+    // Guards the map above from silently falling behind the evaluator list.
+    expect(withSchema.length).toBe(EVALUATORS.length - 1);
+  });
+
+  it.each(withSchema)('$name', ({ E }) => {
+    const { outputSchema } = contractFor(E.metadata.id);
+    const sent = Object.keys(SDK_OUTPUT_SCHEMAS[E.metadata.id].shape).sort();
+    const declared = Object.keys(outputSchema.properties).sort();
+
+    expectAgainstContract(
+      SCHEMA_GAPS.has(E.metadata.id),
+      sent,
+      declared,
+      `${E.metadata.name} sent payload fields`,
     );
-    if (textInputs.length === 0) return;
-
-    for (const [field, spec] of textInputs) {
-      const declared = [spec.minLength, spec.maxLength];
-      const enforced = [VALIDATION_LIMITS.MIN_TEXT_LENGTH, VALIDATION_LIMITS.MAX_TEXT_LENGTH];
-
-      expectAgainstContract(
-        LIMIT_GAPS.has(`${E.metadata.id}::${field}`),
-        declared,
-        enforced,
-        `${E.metadata.name}.${field} bounds`,
-      );
-    }
   });
 });
 
-describe('readOutcome finds a verdict in a contract-shaped payload', () => {
-  it.each(cases)('$name', ({ E }) => {
-    const { outputSchema } = contractFor(E.metadata.id);
+describe('readOutcome finds a verdict in the payload the SDK actually returns', () => {
+  const withSchema = cases.filter(({ E }) => SDK_OUTPUT_SCHEMAS[E.metadata.id]);
 
-    // Build the smallest payload the contract permits: every required property, with
-    // an enum's first value where one is declared.
+  it.each(withSchema)('$name', ({ E }) => {
+    // Built from the SDK's own schema, so an override that stops matching what the SDK
+    // sends fails here. Building it from the contract instead hid exactly that.
+    const shape = SDK_OUTPUT_SCHEMAS[E.metadata.id].shape;
     const payload: Record<string, unknown> = {};
-    for (const field of outputSchema.required) {
-      const spec = outputSchema.properties[field] ?? {};
-      const ref = spec.$ref as string | undefined;
-      const resolved = ref
-        ? (outputSchema.$defs?.[ref.split('/').pop()!] ?? {})
-        : spec;
-      const values = resolved.enum as unknown[] | undefined;
-      payload[field] = values ? values[0] : `stub ${field}`;
+    for (const [field, spec] of Object.entries(shape)) {
+      const options = (spec as { options?: unknown[] }).options;
+      payload[field] = options ? options[0] : `stub ${field}`;
     }
 
     const envelope = {
@@ -340,12 +440,41 @@ describe('readOutcome finds a verdict in a contract-shaped payload', () => {
       },
     } as EvaluationResult;
 
-    expectAgainstContract(
-      VERDICT_GAPS.has(E.metadata.id),
-      readOutcome(envelope).score !== undefined,
-      true,
-      `${E.metadata.name} readOutcome`,
-    );
+    expect(
+      readOutcome(envelope).score,
+      `${E.metadata.name}: readOutcome found no verdict in the payload the SDK returns`,
+    ).toBeDefined();
+  });
+});
+
+describe('every contract is implemented or explicitly listed as not', () => {
+  const contractIds = EVALUATORS.map((E) => E.metadata.id);
+
+  it.each(
+    readdirSync(join(REPO_ROOT, 'evals'), { withFileTypes: true })
+      .filter((d) => d.isDirectory() && !d.name.startsWith('_'))
+      .flatMap((domain) =>
+        readdirSync(join(REPO_ROOT, 'evals', domain.name), { withFileTypes: true })
+          .filter((d) => d.isDirectory())
+          .flatMap((skill) =>
+            readdirSync(join(REPO_ROOT, 'evals', domain.name, skill.name), {
+              withFileTypes: true,
+            })
+              .filter((d) => d.isDirectory())
+              .map((ev) => ({
+                dir: join(REPO_ROOT, 'evals', domain.name, skill.name, ev.name),
+                label: `${domain.name}/${skill.name}/${ev.name}`,
+              })),
+          ),
+      )
+      .filter(({ dir }) => existsSync(join(dir, 'config.json'))),
+  )('$label', ({ dir }) => {
+    const id = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf-8')).evaluator.id;
+
+    expect(
+      contractIds.includes(id) || UNIMPLEMENTED.has(id),
+      `"${id}" has a contract but no implementation and is not in UNIMPLEMENTED`,
+    ).toBe(true);
   });
 });
 
@@ -366,6 +495,10 @@ describe('constructed models match the contract', () => {
       telemetry: false,
     });
 
+    // A deduped set, so this cannot see which step got which model. Swapping the two
+    // grade-conditioned models in vocabulary-complexity would pass here — the
+    // temperature check below is per-call but skips multi-step evaluators, so that
+    // binding is only covered once the runner drives steps from the contract.
     const asked = [...new Set(constructed.map((c) => `${c.type}:${c.model}`))].sort();
     const declared = [
       ...new Set(config.steps.map((s) => `${s.model.provider}:${s.model.name}`)),
@@ -461,5 +594,61 @@ describe('the report can order every family member', () => {
       true,
       `"${id}" is absent from the report's EVALUATOR_ORDER`,
     );
+  });
+});
+
+describe('the temperature sent matches the contract', () => {
+  beforeEach(() => {
+    sent.length = 0;
+  });
+
+  it.each(singleStepCases)('$name', async ({ E }) => {
+    const { config } = contractFor(E.metadata.id);
+    await INVOKE[E.metadata.id](E, 'A sentence long enough to pass validation.');
+
+    expect(sent, `${E.metadata.name} made no LLM call`).toHaveLength(1);
+
+    expectAgainstContract(
+      TEMPERATURE_GAPS.has(E.metadata.id),
+      sent[0].temperature,
+      config.steps[0].generation?.temperature,
+      `${E.metadata.name} temperature`,
+    );
+  });
+});
+
+describe('a declared minimum length is enforced', () => {
+  const withMinimum = invocableCases
+    .map(({ name, E }) => {
+      const { inputSchema } = contractFor(E.metadata.id);
+      const min = inputSchema.properties.text?.minLength as number | undefined;
+      return { name, E, min };
+    })
+    .filter((c): c is { name: string; E: EvaluatorClass; min: number } => (c.min ?? 0) > 1);
+
+  it.each(withMinimum)('$name', async ({ E, min }) => {
+    // One character short of what the contract declares. Asserting on rejection rather
+    // than on the numbers is what lets this self-clean: comparing declared bounds to
+    // the SDK's global pair would keep differing however the SDK behaved.
+    const tooShort = 'a'.repeat(min - 1);
+    const failure = await INVOKE[E.metadata.id](E, tooShort).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const rejectedForLength = failure instanceof InputValidationError;
+
+    // Asserting on the error type, not on whether the call resolved: a stubbed provider
+    // can fail an evaluation for reasons that have nothing to do with validation.
+    if (LIMIT_GAPS.has(`${E.metadata.id}::text`)) {
+      expect(
+        rejectedForLength,
+        `${E.metadata.name} now enforces its declared minLength ${min} — delete its LIMIT_GAPS entry`,
+      ).toBe(false);
+    } else {
+      expect(
+        rejectedForLength,
+        `${E.metadata.name} accepts text shorter than the minLength ${min} its contract declares`,
+      ).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Tests only. An independent audit of #211 found it advertised more than it delivered — roughly 40% of its assertions tautological or vacuous, and its flagship self-cleaning property broken on its largest allowlist. Three findings were real and are fixed here.

## 1. Nothing compared any SDK schema to any contract

The `readOutcome` check built its payload **from the contract**, so it asserted `readOutcome ∘ contract` and never consulted what the SDK actually asks the model for.

Demonstrated before fixing: deleting the load-bearing `answer` override for Sentence Structure — which would blank that evaluator's verdict in every report — left all 79 tests green.

Now the payload is built from the SDK's own Zod schema, and the sent field names are compared against `output_schema.json` directly. The same deletion now fails with `readOutcome found no verdict in the payload the SDK returns`.

## 2. `LIMIT_GAPS` could not self-clean

It compared each contract's declared bounds against the SDK's **global** pair. Per-field enforcement changes neither side, so the inverted assertions would have kept passing and all four entries would have outlived their gap. The only thing that could have flipped them was *weakening* a contract.

This is the identical defect already fixed for a non-prose input in the previous review round — fixed there, not here, in the entries directly beside it. Which is the bug class this suite exists to catch, in the suite itself.

The check now calls the evaluator one character under the declared minimum and asserts on the **error type**, since that's what enforcement means. Asserting on resolution would have made it mock-dependent — Sentence Structure fails downstream on a stubbed provider for reasons unrelated to validation.

## 3. Temperature was compared nowhere

Despite `MODEL_GAPS` claiming to cover "model or temperature". Five evaluators hardcode it, and Grade Level Appropriateness sends `0.25` against a declared `1`. There's now a per-call assertion, and that divergence has its own allowlist entry.

## Also

- **`EVALUATORS` is discovered from the public exports** rather than hand-listed, so an evaluator can't be added and silently receive no coverage.
- **Every contract on disk must be implemented or named in `UNIMPLEMENTED`** — which makes the seven unimplemented feedback contracts visible rather than absent.
- Two allowlists deleted rather than migrated; both existed only to excuse the checks that were replaced.

## One blind spot documented, not closed

The constructed-models check compares a **deduped set**, so it can't see which step got which model — swapping vocabulary-complexity's two grade-conditioned models would pass. The temperature check is per-call but skips multi-step evaluators. Covering that binding needs the runner to drive steps from the contract, so it's recorded in a comment where the limitation lives.

## Validation

- `tsc --noEmit`, `npm run lint`, `npm run test:unit`, `scripts/check.py`
- **Load-bearing checks**, each breaking a guarded fact:
  - removed the Sentence Structure verdict override → now caught (previously green)
  - aligned GLA's temperature to its contract → its allowlist entry demands deletion
  - drifted a non-allowlisted temperature (`0` → `0.7`) → caught
  - raised the SDK's global minimum to 10, simulating per-field enforcement → **all four** `LIMIT_GAPS` entries demand deletion
- **Mutation testing showed no movement**, and that's expected rather than good news: `formatters.ts` holds at 72.84% and `meaning-directness.ts` at 40.74%. A bare `temperature: 0` numeric literal isn't in Stryker's default mutator set, so the new temperature assertion has no mutant to kill. The load-bearing checks above are the evidence for this PR, not the score.
