### PR TITLE
feat(evals)!: declare what the contracts mean, and validate it

### DIFF
--- a/evals/_schemas/config.schema.json
+++ b/evals/_schemas/config.schema.json
@@ -11,14 +11,13 @@
     "evaluator": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "description", "supported_grades"],
-      "dependentRequired": { "id_history": ["stable_id"] },
+      "required": ["id", "stable_id", "name", "description", "supported_grades"],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "stable_id": {
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-          "description": "Permanent UUID, assigned once and never changed, even when `id` changes because the evaluator moves between taxonomy groupings. Optional for now while this is backfilled evaluator-by-evaluator; will become required once every evaluator has one."
+          "description": "Permanent UUID, assigned once and never changed, even when `id` changes because the evaluator moves between taxonomy groupings."
         },
         "id_history": {
           "type": "array",
@@ -32,12 +31,23 @@
           "minItems": 1,
           "items": {
             "enum": ["K", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]
-          }
+          },
+          "description": "The grades this evaluator is built for. Declared for every evaluator, including those that take no grade as input -- for those it is the only record of what the evaluator targets. This is NOT what validates a caller's grade: when the evaluator accepts one, `input_schema.properties.grade_level.enum` is the accepted set and the two must agree. Consumers validate against that enum, never against this field."
         }
       }
     },
     "input_schema": { "type": "object" },
     "output_schema": { "type": "object" },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "reasoning"],
+      "properties": {
+        "score": { "type": "string", "minLength": 1 },
+        "reasoning": { "type": "string", "minLength": 1 }
+      },
+      "description": "Names the `output_schema` properties carrying the scalar verdict and its rationale, so consumers read one comparable value per evaluation instead of inferring which field holds it. Omitted by an evaluator whose output is not a single judgement."
+    },
     "preprocessing": {
       "type": "array",
       "items": {
@@ -52,6 +62,13 @@
           "description": { "type": "string" },
           "input": { "type": "string" },
           "output": { "type": "string" },
+          "required_credentials": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "enum": ["learning_commons_api_key"] },
+            "description": "Canonical config keys for non-LLM services this entry calls. LLM keys are not listed: those are derived from `model.provider`. Declared per entry so a step that does not run cannot demand a credential, and unaffected by a model override, which narrows only the LLM providers. `auth` names the header; this names what fills it."
+          },
           "implementation": {
             "type": "object",
             "minProperties": 1,
@@ -108,6 +125,13 @@
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "type": { "enum": ["llm", "api"] },
+          "required_credentials": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "enum": ["learning_commons_api_key"] },
+            "description": "Canonical config keys for non-LLM services this entry calls. LLM keys are not listed: those are derived from `model.provider`. Declared per entry so a step that does not run cannot demand a credential, and unaffected by a model override, which narrows only the LLM providers. `auth` names the header; this names what fills it."
+          },
           "optional": {
             "type": "boolean",
             "default": false,
@@ -141,7 +165,11 @@
                   "required": ["required", "source"],
                   "properties": {
                     "required": { "type": "boolean" },
-                    "source": { "type": "string" },
+                    "source": {
+                      "type": "string",
+                      "pattern": "^(input|input\\.[A-Za-z_][A-Za-z0-9_]*|preprocessing\\.[A-Za-z_][A-Za-z0-9_]*|steps\\.[A-Za-z_][A-Za-z0-9_]*\\.output)$",
+                      "description": "Where the value comes from. Exactly four forms: `input` (the caller input of the same name as the placeholder), `input.<field>` (a caller input under a different name), `preprocessing.<output>` (a preprocessing entry's declared `output` key, never its `id`), and `steps.<id>.output` (an earlier step's result). Constrained by pattern because an undeclared fifth form is unresolvable by any consumer."
+                    },
                     "note": { "type": "string" }
                   }
                 }

--- a/evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json
+++ b/evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json
@@ -13,6 +13,20 @@
   },
   "preprocessing": [
     {
+      "id": "get_standards",
+      "type": "api",
+      "kind": "http_get",
+      "description": "Fetch each candidate standard's description, so the coarse filter judges relevance from wording rather than from codes alone. Called once per candidate code, and only on the many-to-many path -- a single evaluate() has one standard and no need to filter, so nothing here runs for it.",
+      "endpoint": "https://api.learningcommons.org/knowledge-graph/v0/academic-standards/search",
+      "params": {
+        "jurisdiction": "{jurisdiction}",
+        "statementCode": "{statementCode}"
+      },
+      "auth": "x-api-key",
+      "required_credentials": ["learning_commons_api_key"],
+      "output": "standards"
+    },
+    {
       "id": "get_standard_uuid",
       "type": "api",
       "kind": "http_get",
@@ -23,6 +37,7 @@
         "statementCode": "{statementCode}"
       },
       "auth": "x-api-key",
+      "required_credentials": ["learning_commons_api_key"],
       "output": "caseIdentifierUUID"
     },
     {
@@ -36,6 +51,7 @@
       },
       "pagination": "cursor",
       "auth": "x-api-key",
+      "required_credentials": ["learning_commons_api_key"],
       "output": "learningComponents"
     }
   ],
@@ -60,7 +76,7 @@
           },
           "standards": {
             "required": true,
-            "source": "preprocessing.get_standards",
+            "source": "preprocessing.standards",
             "note": "One `code: description` line per candidate standard"
           }
         }
@@ -95,7 +111,7 @@
         ],
         "placeholders": {
           "question": { "required": true, "source": "input" },
-          "learning_components": { "required": true, "source": "preprocessing.get_learning_components", "note": "Numbered list of LC descriptions with identifiers" }
+          "learning_components": { "required": true, "source": "preprocessing.learningComponents", "note": "Numbered list of LC descriptions with identifiers" }
         }
       },
       "model": {

--- a/evals/feedback/ela-writing/revision-accuracy/config.json
+++ b/evals/feedback/ela-writing/revision-accuracy/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/revision-actionability/config.json
+++ b/evals/feedback/ela-writing/revision-actionability/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/revision-manageability/config.json
+++ b/evals/feedback/ela-writing/revision-manageability/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/strength-acknowledgment/config.json
+++ b/evals/feedback/ela-writing/strength-acknowledgment/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/student-response-specificity/config.json
+++ b/evals/feedback/ela-writing/student-response-specificity/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/tone-appropriateness/config.json
+++ b/evals/feedback/ela-writing/tone-appropriateness/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/feedback/ela-writing/withholding-answers/config.json
+++ b/evals/feedback/ela-writing/withholding-answers/config.json
@@ -66,6 +66,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "quality_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/student-facing-text/ela-reading/background-knowledge-demands/config.json
+++ b/evals/student-facing-text/ela-reading/background-knowledge-demands/config.json
@@ -81,6 +81,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json
+++ b/evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json
@@ -52,6 +52,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "grade_band",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/evals/student-facing-text/ela-reading/meaning-directness/config.json
+++ b/evals/student-facing-text/ela-reading/meaning-directness/config.json
@@ -81,6 +81,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/organizational-structure/config.json
+++ b/evals/student-facing-text/ela-reading/organizational-structure/config.json
@@ -97,6 +97,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/purpose-clarity/config.json
+++ b/evals/student-facing-text/ela-reading/purpose-clarity/config.json
@@ -87,6 +87,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json
+++ b/evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json
@@ -82,6 +82,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/sentence-structure/config.json
+++ b/evals/student-facing-text/ela-reading/sentence-structure/config.json
@@ -203,6 +203,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json",
     "tolerance": {

--- a/evals/student-facing-text/ela-reading/vocabulary-complexity/config.json
+++ b/evals/student-facing-text/ela-reading/vocabulary-complexity/config.json
@@ -208,6 +208,10 @@
   "output_schema": {
     "$ref": "output_schema.json"
   },
+  "outcome": {
+    "score": "complexity_score",
+    "reasoning": "reasoning"
+  },
   "fixtures": {
     "path": "fixtures.json"
   }

--- a/scripts/checks/eval_config.py
+++ b/scripts/checks/eval_config.py
@@ -76,6 +76,9 @@ class EvalConfig(Check):
             step_id = step.get("id", "?")
             template_vars = self._check_prompts(prompt, base, fail, step_id)
             self._check_placeholders(prompt, template_vars, fail, step_id)
+        self._check_placeholder_sources(config, base, fail)
+        self._check_supported_grades(config, base, fail)
+        self._check_outcome(config, base, fail)
         self._check_fixtures_path(config, base, fail)
 
     # --- Layer 1: schema -----------------------------------------------------
@@ -101,6 +104,112 @@ class EvalConfig(Check):
             fail(f"schema: {loc}: {err.message}")
 
     # --- Layer 2: cross-file -------------------------------------------------
+
+    def _check_placeholder_sources(self, config: dict, base: str, fail) -> None:
+        """Every placeholder `source` must resolve to something that exists.
+
+        The four forms are `input`, `input.<field>`, `preprocessing.<output>` and
+        `steps.<id>.output`. A source naming a preprocessing entry that does not exist
+        is undetectable any other way -- the placeholder name still matches the prompt
+        text, so every other rule passes.
+
+        Note `preprocessing.<X>` resolves against an entry's declared `output` key, not
+        its `id`; those differ, and only one of them is the value a step can read.
+        """
+        try:
+            input_props = set(
+                load_json(os.path.join(base, config["input_schema"]["$ref"]))
+                .get("properties", {})
+                .keys()
+            )
+        except (KeyError, TypeError, OSError, json.JSONDecodeError):
+            return  # _check_referenced_files already reported this
+
+        outputs = {
+            entry["output"]
+            for entry in config.get("preprocessing", [])
+            if entry.get("output")
+        }
+        step_ids: set[str] = set()
+
+        for step in config.get("steps", []):
+            placeholders = (step.get("prompt") or {}).get("placeholders") or {}
+            step_id = step.get("id", "?")
+            for name, spec in placeholders.items():
+                source = spec.get("source")
+                if not isinstance(source, str):
+                    continue
+                where = f"{step_id}.{name}: source {source!r}"
+
+                if source == "input":
+                    if name not in input_props:
+                        fail(f"{where} names no input; input_schema has no {name!r}")
+                elif source.startswith("input."):
+                    field = source.split(".", 1)[1]
+                    if field not in input_props:
+                        fail(f"{where} names no input; input_schema has no {field!r}")
+                elif source.startswith("preprocessing."):
+                    key = source.split(".", 1)[1]
+                    if key not in outputs:
+                        fail(
+                            f"{where} resolves to no preprocessing output; "
+                            f"declared outputs are {sorted(outputs) or 'none'}"
+                        )
+                elif source.startswith("steps."):
+                    producer = source.split(".")[1]
+                    if producer not in step_ids:
+                        fail(f"{where} names no earlier step; {producer!r} does not run before {step_id!r}")
+            step_ids.add(step_id)
+
+    @staticmethod
+    def _check_supported_grades(config: dict, base: str, fail) -> None:
+        """`supported_grades` must agree with the grades the evaluator actually accepts.
+
+        `supported_grades` states what the evaluator is built for and is declared even
+        when no grade is an input. Where a grade *is* an input, its enum is what
+        consumers validate against, so the two disagreeing means one of them is wrong.
+        """
+        try:
+            props = load_json(os.path.join(base, config["input_schema"]["$ref"])).get(
+                "properties", {}
+            )
+        except (KeyError, TypeError, OSError, json.JSONDecodeError):
+            return
+
+        accepted = props.get("grade_level", {}).get("enum")
+        if accepted is None:
+            return
+
+        declared = config.get("evaluator", {}).get("supported_grades")
+        if declared != accepted:
+            fail(
+                "evaluator.supported_grades does not match the grades accepted by "
+                f"input_schema.properties.grade_level.enum: {declared} vs {accepted}"
+            )
+
+    @staticmethod
+    def _check_outcome(config: dict, base: str, fail) -> None:
+        """`outcome` must name properties that the output schema actually declares."""
+        outcome = config.get("outcome")
+        if not outcome:
+            return
+
+        try:
+            declared = load_json(os.path.join(base, config["output_schema"]["$ref"]))
+        except (KeyError, TypeError, OSError, json.JSONDecodeError):
+            return
+
+        properties = declared.get("properties", {})
+        required = declared.get("required", [])
+        for role in ("score", "reasoning"):
+            field = outcome.get(role)
+            if field not in properties:
+                fail(f"outcome.{role} names {field!r}, which output_schema does not declare")
+            elif field not in required:
+                fail(
+                    f"outcome.{role} names {field!r}, which output_schema declares but "
+                    "does not require -- a verdict that may be absent is not a verdict"
+                )
 
     def _check_referenced_files(self, config: dict, base: str, fail) -> None:
         """The schema $refs for input/output must resolve to real files."""

--- a/scripts/checks/eval_config.py
+++ b/scripts/checks/eval_config.py
@@ -189,7 +189,11 @@ class EvalConfig(Check):
 
     @staticmethod
     def _check_outcome(config: dict, base: str, fail) -> None:
-        """`outcome` must name properties that the output schema actually declares."""
+        """`outcome` must name properties the output schema declares *and* requires.
+
+        Declared is not enough: a verdict the schema permits to be absent is not a
+        verdict a report can rely on.
+        """
         outcome = config.get("outcome")
         if not outcome:
             return


### PR DESCRIPTION
Contract-side only — no SDK changes. Sequenced first so the codegen and runner work isn't generated against a schema that's about to move.

## `supported_grades` now means one thing

It meant three, depending on the evaluator:

| meaning | evaluators |
| --- | --- |
| the accepted input grades, duplicating `input_schema.grade_level.enum` exactly | 7 ela-reading |
| an editorial range where **no grade input exists at all** | 7 feedback |
| a bulk-method domain / output band range | math, GLA |

It now states one thing: **the grades an evaluator is built for** — declared for every evaluator, including those taking no grade, because for those it's the only record of what the evaluator targets. It is explicitly *not* what validates a caller's grade; where a grade is an input, its enum is. The harness now enforces that the two agree.

## `stable_id` is required

Its description said *"optional for now while this is backfilled."* All 16 have one, so the note was stale and the guarantee wasn't real.

## `required_credentials`

Declares non-LLM credentials on the entry that needs them, so requirements are derived rather than hand-rolled per evaluator. LLM keys aren't listed — those come from `model.provider`.

**Per entry, not per evaluator**, so a step that doesn't run can't demand a key: math's coarse filter is `optional: true`, and an evaluator-level list would require a credential for a call that never happens. This is a deliberate divergence from §10.1, which puts it at the evaluator level. `auth` names the header; this names what fills it.

## `outcome`

Names the output properties carrying the verdict and its rationale. Consumers were inferring it from a `*_score` convention plus a per-evaluator override table — something a second SDK would have to reproduce exactly, or the two would disagree about what a report shows. Declared for 15; math has no single judgement and omits it.

Note GLA's is `grade_band`, the contract's name — so the declaration is already correct for after its schema is regenerated.

## The `source` grammar is constrained

Five undeclared forms were in use against a schema saying only `{"type": "string"}`, and `preprocessing.<X>` resolved against an entry's **`id`** in one contract and its **`output` key** in another. It now resolves against `output` keys everywhere; only math used ids.

**And it fixes a live error I introduced in #193:** `coarse_filter`'s `standards` placeholder declared `source: "preprocessing.get_standards"` — an entry that does not exist. The value is real (each candidate standard's description comes from the same `/academic-standards/search` endpoint, once per code, bulk path only), so the entry is now declared rather than the reference dropped, which would have left that step's prompt and model unpinned.

## Three harness rules

The first is why that error shipped in the first place — placeholder *names* were validated against the prompt text, but nothing validated that a *source* resolved to anything.

1. every `source` resolves to a real input, preprocessing output, or earlier step
2. `supported_grades` matches the accepted grade enum
3. `outcome` names properties the output schema both declares **and requires** — a verdict that may be absent isn't a verdict

## Deliberately deferred

**`stability`** (§10.1). It's a product statement about what partners can rely on, and I'd be inventing the values. Adding an unpopulated field would repeat the `model.alias` mistake — a declared field with no semantics and no consumer.

## Validation

- `scripts/check.py` (all 6), `tsc --noEmit`, `npm run lint`, `npm run test:unit`
- **Each new rule verified by breaking it:**
  - reintroduced the original `preprocessing.get_standards` error → caught, listing the declared outputs
  - dropped grade 12 from one `supported_grades` → caught, showing both lists
  - pointed `outcome.score` at a nonexistent property → caught
  - removed a `stable_id` → caught by the schema
- No mutation testing: no `src` logic changed. The harness rules are Python, outside the Stryker setup, and each is verified by the breakage checks above.
