### PR TITLE
refactor(sdk)!: evaluate() takes named inputs validated against the contract

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -29,8 +29,8 @@ const evaluator = new GradeLevelAppropriatenessEvaluator({
   googleApiKey: process.env.GOOGLE_API_KEY,
 });
 
-const result = await evaluator.evaluate("The cat's out of the bag now.");
-console.log(result.score); // 4-5
+const result = await evaluator.evaluate({ text: "The cat's out of the bag now." });
+console.log(result.result.grade); // 4-5
 ```
 
 ## Documentation

--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -23,8 +23,14 @@ import {
   resolveMembers,
 } from './family.js';
 
+/**
+ * The shape this family needs from an evaluator: named inputs in, envelope out.
+ *
+ * Typed loosely on purpose -- members declare different input keys (GLA takes no
+ * grade), and the family builds each object from the evaluator's own schema below.
+ */
 interface SimpleEvaluator {
-  evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<unknown>>;
+  evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
 }
 type EvaluatorConstructor = new (config: BaseEvaluatorConfig) => SimpleEvaluator;
 
@@ -98,7 +104,14 @@ class QtcRunner implements FamilyRunner {
   }
 
   async runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome> {
-    const result = await this.getEvaluator(memberId).evaluate(row.columns.text, row.columns['grade_level']);
+    // Built explicitly rather than passed through: a row carries every column in the
+    // CSV, and an evaluator rejects keys its schema does not declare.
+    const inputs: Record<string, string> = { text: row.columns.text };
+    if (memberId !== GradeLevelAppropriatenessEvaluator.metadata.id) {
+      inputs.grade_level = row.columns['grade_level'];
+    }
+
+    const result = await this.getEvaluator(memberId).evaluate(inputs);
     const { score, reasoning } = readOutcome(result);
 
     // A report cell has to be a string. An absent verdict renders blank, and doing

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -72,11 +72,11 @@ class StandardsRunner implements FamilyRunner {
 
   async runTask(row: FamilyRow, _memberId?: string): Promise<TaskOutcome> {
     const jurisdiction = resolveJurisdiction(row.columns.jurisdiction);
-    const result = await this.evaluator.evaluate(
-      row.columns.question,
-      row.columns.statementCode,
+    const result = await this.evaluator.evaluate({
+      question: row.columns.question,
+      statementCode: row.columns.statementCode,
       jurisdiction,
-    );
+    });
     const verdict: StandardsVerdict = { ...result, question: row.columns.question, jurisdiction };
     return {
       score: `${result.alignedCount}/${result.totalCount}`,

--- a/sdks/typescript/src/evaluators/background-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/background-knowledge-demands.ts
@@ -4,6 +4,8 @@ import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/background-knowledge-demands/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
+import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/config.json';
@@ -31,6 +33,9 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/background
  * console.log(result.reasoning);
  * ```
  */
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type BackgroundKnowledgeDemandsInput = InputsOf<typeof INPUT_SCHEMA>;
+
 export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -63,10 +68,9 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(
-    text: string,
-    gradeLevel: string
-  ): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
+  async evaluate(input: BackgroundKnowledgeDemandsInput): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Background Knowledge Demands evaluation', {
       evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
       operation: 'evaluate',
@@ -79,8 +83,7 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(BackgroundKnowledgeDemandsEvaluator.metadata.supportedGrades));
+      validateInputs(input, INPUT_SCHEMA);
 
       this.logger.debug('Evaluating subject matter knowledge complexity', {
         evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
@@ -223,10 +226,9 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
  * ```
  */
 export async function evaluateBackgroundKnowledgeDemands(
-  text: string,
-  gradeLevel: string,
+  input: BackgroundKnowledgeDemandsInput,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
   const evaluator = new BackgroundKnowledgeDemandsEvaluator(config);
-  return evaluator.evaluate(text, gradeLevel);
+  return evaluator.evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -16,16 +16,6 @@ import { createProvider } from '../providers/index.js';
 import type { LLMProvider } from '../providers/index.js';
 
 /**
- * Validation constants for input text
- */
-export const VALIDATION_LIMITS = {
-  /** Minimum text length in characters */
-  MIN_TEXT_LENGTH: 1,
-  /** Maximum text length in characters */
-  MAX_TEXT_LENGTH: 10_000,
-} as const;
-
-/**
  * Supported LLM providers
  */
 export enum Provider {
@@ -471,37 +461,6 @@ export abstract class BaseEvaluator {
     // which is also the right answer when there is no model id to strip.
     const model = label.slice(separator + 1);
     return { dependency: prefix as DependencyId, model: model === '' ? label : model };
-  }
-
-  /**
-   * Validate text meets requirements
-   * Default implementation - can be overridden by concrete evaluators
-   *
-   * @throws {InputValidationError} If text is invalid
-   */
-  protected validateText(text: string): void {
-    this.logger.debug('Validating text input', {
-      evaluator: this.getEvaluatorType(),
-      operation: 'validateText',
-      textLength: text.length,
-    });
-
-    // Rejected, not repaired — the bounds below measure the text as sent.
-    if (!text.trim()) {
-      throw new InputValidationError('Text cannot be empty or contain only whitespace');
-    }
-
-    if (text.length < VALIDATION_LIMITS.MIN_TEXT_LENGTH) {
-      throw new InputValidationError(
-        `Text is too short. Minimum length is ${VALIDATION_LIMITS.MIN_TEXT_LENGTH} characters, received ${text.length} characters`
-      );
-    }
-
-    if (text.length > VALIDATION_LIMITS.MAX_TEXT_LENGTH) {
-      throw new InputValidationError(
-        `Text is too long. Maximum length is ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters, received ${text.length.toLocaleString()} characters`
-      );
-    }
   }
 
   /**

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -6,6 +6,8 @@ import {
 import { getSystemPrompt, getUserPrompt } from '../prompts/grade-level-appropriateness/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
+import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
 
@@ -30,12 +32,15 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-leve
  *   googleApiKey: process.env.GOOGLE_API_KEY
  * });
  *
- * const result = await evaluator.evaluate(text);
+ * const result = await evaluator.evaluate(input);
  * console.log(result.score); // "9-10"
  * console.log(result._internal.alternative_grade); // "6-8"
  * console.log(result._internal.scaffolding_needed);
  * ```
  */
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type GradeLevelAppropriatenessInput = InputsOf<typeof INPUT_SCHEMA>;
+
 export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -68,7 +73,9 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
+  async evaluate(input: GradeLevelAppropriatenessInput): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
+    const { text } = input;
+
     this.logger.info('Starting grade level appropriateness evaluation', {
       evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
       operation: 'evaluate',
@@ -79,7 +86,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      this.validateText(text);
+      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Evaluating grade level appropriateness', {
         evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
         operation: 'grade_evaluation',
@@ -186,9 +193,9 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
  * ```
  */
 export async function evaluateGradeLevelAppropriateness(
-  text: string,
+  input: GradeLevelAppropriatenessInput,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
   const evaluator = new GradeLevelAppropriatenessEvaluator(config);
-  return evaluator.evaluate(text);
+  return evaluator.evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/inputs.ts
+++ b/sdks/typescript/src/evaluators/inputs.ts
@@ -42,6 +42,15 @@ export function validateInputs(
   inputs: Record<string, unknown>,
   schema: DeclaredInputSchema,
 ): void {
+  // A JS caller, or an `any`, can hand over something that is not an object at all.
+  // Reaching Object.keys with it would raise a TypeError, which is neither diagnosable
+  // nor part of the taxonomy.
+  if (inputs === null || typeof inputs !== 'object' || Array.isArray(inputs)) {
+    throw new InputValidationError(
+      `Expected an object of inputs, received ${inputs === null ? 'null' : typeof inputs}.`,
+    );
+  }
+
   const declared = Object.keys(schema.properties);
 
   // Contracts declare `additionalProperties: false`, so an unexpected key is a caller

--- a/sdks/typescript/src/evaluators/inputs.ts
+++ b/sdks/typescript/src/evaluators/inputs.ts
@@ -1,0 +1,126 @@
+import { InputValidationError } from '../errors.js';
+
+/**
+ * Validating a caller's inputs against the schema the evaluator declares.
+ *
+ * Each evaluator's `input_schema.json` is the only description of what it accepts, so
+ * the bounds, the accepted grades and the set of field names all come from there. A
+ * global default applied to every evaluator would silently ignore a contract asking for
+ * something narrower, which §4.1 forbids.
+ */
+
+/** The shape of an `input_schema.json`, as much of it as validation reads. */
+export interface DeclaredInputSchema {
+  properties: Record<
+    string,
+    { type?: string; minLength?: number; maxLength?: number; enum?: string[] }
+  >;
+  required?: string[];
+}
+
+/**
+ * The inputs an evaluator accepts, derived from its declared schema.
+ *
+ * Keys come from the schema, so adding an input to a contract is a compile error in
+ * every call site that does not pass it. Values are `string` because TypeScript widens
+ * imported JSON string literals — the declared `enum` and bounds are enforced at
+ * runtime by {@link validateInputs}, which is the authoritative check either way.
+ */
+export type InputsOf<S extends { properties: object }> = Record<keyof S['properties'], string>;
+
+/**
+ * Check `inputs` against `schema`, in the order §4.1 fixes.
+ *
+ * Fields are visited in declared order — `required` first, then any remaining
+ * properties — so a caller passing two bad inputs always gets the same message, in
+ * this SDK and in any other reading the same schema.
+ *
+ * @throws {InputValidationError} On an unknown key, a missing field, a whitespace-only
+ * or out-of-bounds string, or a value outside a declared `enum`.
+ */
+export function validateInputs(
+  inputs: Record<string, unknown>,
+  schema: DeclaredInputSchema,
+): void {
+  const declared = Object.keys(schema.properties);
+
+  // Contracts declare `additionalProperties: false`, so an unexpected key is a caller
+  // mistake worth naming rather than something to quietly drop.
+  for (const key of Object.keys(inputs)) {
+    if (!declared.includes(key)) {
+      throw new InputValidationError(
+        `Unknown input "${key}". This evaluator accepts: ${declared.join(', ')}.`,
+      );
+    }
+  }
+
+  const required = schema.required ?? [];
+  const order = [...required, ...declared.filter((f) => !required.includes(f))];
+
+  for (const field of order) {
+    const spec = schema.properties[field];
+    const value = inputs[field];
+
+    if (value === undefined || value === null) {
+      if (required.includes(field)) {
+        throw new InputValidationError(`${field} is required.`);
+      }
+      continue;
+    }
+
+    if (spec.type === 'string' && typeof value !== 'string') {
+      throw new InputValidationError(`${field} must be a string.`);
+    }
+
+    if (typeof value === 'string') {
+      validateStringField(field, value, spec);
+    }
+  }
+}
+
+function validateStringField(
+  field: string,
+  value: string,
+  spec: { minLength?: number; maxLength?: number; enum?: string[] },
+): void {
+  if (spec.enum) {
+    if (!spec.enum.includes(value)) {
+      throw new InputValidationError(
+        `Invalid ${field} "${value}". Accepted values: ${spec.enum.join(', ')}.`,
+      );
+    }
+    return;
+  }
+
+  // Trimming decides whether the value is blank and nothing more: the bounds below
+  // measure the string as the caller sent it, which is also what reaches the model.
+  if (!value.trim()) {
+    throw new InputValidationError(`${field} cannot be empty or contain only whitespace`);
+  }
+
+  if (spec.minLength !== undefined && value.length < spec.minLength) {
+    throw new InputValidationError(
+      `${field} is too short. Minimum length is ${spec.minLength} characters.`,
+    );
+  }
+
+  if (spec.maxLength !== undefined && value.length > spec.maxLength) {
+    throw new InputValidationError(
+      `${field} is too long. Maximum length is ${spec.maxLength} characters.`,
+    );
+  }
+}
+
+/**
+ * The field a report or telemetry treats as the primary text.
+ *
+ * The wire still carries one text length, so an evaluator with two texts has to pick
+ * one: the first declared string input that is not an enum. Interim — Q-10 replaces the
+ * single length with a per-input map.
+ */
+export function primaryTextField(schema: DeclaredInputSchema): string | undefined {
+  return Object.keys(schema.properties).find((field) => {
+    const spec = schema.properties[field];
+    return spec.type === 'string' && !spec.enum;
+  });
+}

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -11,14 +11,31 @@ import {
   getCoarseFilterPrompt,
   STEP,
   SUPPORTED_GRADES,
-  MAX_QUESTION_LENGTH,
 } from '../../prompts/math/standards-alignment/index.js';
 import { KnowledgeGraphClient, Jurisdiction } from '../../knowledge-graph/index.js';
 import { EvaluatorError, DependencyError, ConfigurationError, InputValidationError, LLMOutputProcessingError, wrapProviderError } from '../../errors.js';
 import type { StageDetail } from '../../telemetry/index.js';
 import CONFIG from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json';
+import INPUT_SCHEMA from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/input_schema.json';
+import { validateInputs, type InputsOf } from '../inputs.js';
 
 const EVALUATOR_ID = CONFIG.evaluator.id;
+
+/**
+ * What this evaluator accepts, taken from its `input_schema.json`.
+ *
+ * `jurisdiction` keeps the narrow union: the schema supplies the key set, and the
+ * SDK has a stronger type for that field than an imported JSON can carry.
+ */
+/** The question alone, for validating one item of a bulk request. */
+const QUESTION_ONLY_SCHEMA = {
+  properties: { question: INPUT_SCHEMA.properties.question },
+  required: ['question'],
+};
+
+export type MathStandardsAlignmentInput = InputsOf<typeof INPUT_SCHEMA> & {
+  jurisdiction: Jurisdiction;
+};
 
 export { Jurisdiction } from '../../knowledge-graph/index.js';
 
@@ -199,12 +216,9 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   // evaluate — single question × single standard (the primitive)
   // -------------------------------------------------------------------------
 
-  async evaluate(
-    question: string,
-    statementCode: string,
-    jurisdiction: Jurisdiction,
-  ): Promise<StandardAlignmentResult> {
-    return this._evaluateCore(question, statementCode, jurisdiction);
+  async evaluate(input: MathStandardsAlignmentInput): Promise<StandardAlignmentResult> {
+    validateInputs(input, INPUT_SCHEMA);
+    return this._evaluateCore(input.question, input.statementCode, input.jurisdiction);
   }
 
   // -------------------------------------------------------------------------
@@ -230,7 +244,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     const dedupedItems = items.map((item) => {
       let validationError: EvaluatorError | undefined;
       try {
-        this.validateQuestion(item.question);
+        validateInputs({ question: item.question }, QUESTION_ONLY_SCHEMA);
       } catch (err) {
         // Only a domain error is a per-item validation failure. Anything else is a
         // bug here, and turning it into a InputValidationError would report it as bad
@@ -441,8 +455,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     statementCode: string,
     jurisdiction: Jurisdiction,
   ): Promise<StandardAlignmentResult> {
-    this.validateQuestion(question);
-    this.validateStatementCode(statementCode);
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
@@ -650,29 +662,11 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     }
   }
 
-  private validateQuestion(question: string): void {
-    if (question.trim().length === 0) {
-      throw new InputValidationError('question must not be empty');
-    }
-    if (question.length > MAX_QUESTION_LENGTH) {
-      throw new InputValidationError(
-        `question exceeds maximum length of ${MAX_QUESTION_LENGTH} characters (got ${question.length})`,
-      );
-    }
-  }
-
-  private validateStatementCode(code: string): void {
-    if (code.trim().length === 0) {
-      throw new InputValidationError('statementCode must not be empty');
-    }
-  }
 }
 
 export async function evaluateMathStandardsAlignment(
-  question: string,
-  statementCode: string,
-  jurisdiction: Jurisdiction,
+  input: MathStandardsAlignmentInput,
   config: MathStandardsAlignmentEvaluatorConfig,
 ): Promise<StandardAlignmentResult> {
-  return new MathStandardsAlignmentEvaluator(config).evaluate(question, statementCode, jurisdiction);
+  return new MathStandardsAlignmentEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -27,10 +27,21 @@ const EVALUATOR_ID = CONFIG.evaluator.id;
  * `jurisdiction` keeps the narrow union: the schema supplies the key set, and the
  * SDK has a stronger type for that field than an imported JSON can carry.
  */
-/** The question alone, for validating one item of a bulk request. */
-const QUESTION_ONLY_SCHEMA = {
+/**
+ * One item of a bulk request: its question and one of its statement codes.
+ *
+ * The bulk paths call `_evaluateCore` directly rather than through `evaluate()`, so
+ * without this an empty code would reach the Knowledge Graph and be reported as a
+ * dependency failure rather than as the caller's invalid input.
+ */
+const QUESTION_SCHEMA = {
   properties: { question: INPUT_SCHEMA.properties.question },
   required: ['question'],
+};
+
+const CODE_SCHEMA = {
+  properties: { statementCode: INPUT_SCHEMA.properties.statementCode },
+  required: ['statementCode'],
 };
 
 export type MathStandardsAlignmentInput = InputsOf<typeof INPUT_SCHEMA> & {
@@ -244,7 +255,12 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     const dedupedItems = items.map((item) => {
       let validationError: EvaluatorError | undefined;
       try {
-        validateInputs({ question: item.question }, QUESTION_ONLY_SCHEMA);
+        // The question is checked whether or not the item carries codes: an item with
+        // an empty list still has a question the caller may have got wrong.
+        validateInputs({ question: item.question }, QUESTION_SCHEMA);
+        for (const code of item.statementCodes) {
+          validateInputs({ statementCode: code }, CODE_SCHEMA);
+        }
       } catch (err) {
         // Only a domain error is a per-item validation failure. Anything else is a
         // bug here, and turning it into a InputValidationError would report it as bad

--- a/sdks/typescript/src/evaluators/meaning-directness.ts
+++ b/sdks/typescript/src/evaluators/meaning-directness.ts
@@ -4,6 +4,8 @@ import { calculateFleschKincaidGrade } from '../features/index.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/meaning-directness/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
+import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/meaning-directness/config.json';
@@ -31,6 +33,9 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/meaning-di
  * console.log(result.reasoning);
  * ```
  */
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type MeaningDirectnessInput = InputsOf<typeof INPUT_SCHEMA>;
+
 export class MeaningDirectnessEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -63,10 +68,9 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(
-    text: string,
-    gradeLevel: string
-  ): Promise<EvaluationResult<MeaningDirectnessInternal>> {
+  async evaluate(input: MeaningDirectnessInput): Promise<EvaluationResult<MeaningDirectnessInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Meaning Directness evaluation', {
       evaluator: MeaningDirectnessEvaluator.metadata.id,
       operation: 'evaluate',
@@ -79,8 +83,7 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(MeaningDirectnessEvaluator.metadata.supportedGrades));
+      validateInputs(input, INPUT_SCHEMA);
 
       this.logger.debug('Evaluating conventionality complexity', {
         evaluator: MeaningDirectnessEvaluator.metadata.id,
@@ -223,10 +226,9 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
  * ```
  */
 export async function evaluateMeaningDirectness(
-  text: string,
-  gradeLevel: string,
+  input: MeaningDirectnessInput,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<MeaningDirectnessInternal>> {
   const evaluator = new MeaningDirectnessEvaluator(config);
-  return evaluator.evaluate(text, gradeLevel);
+  return evaluator.evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -7,8 +7,9 @@ import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/organizational-structure/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
 import type { StageDetail } from '../telemetry/index.js';
-import { EvaluatorError, InputValidationError, wrapProviderError } from '../errors.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json';
 
@@ -22,6 +23,9 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that also admits non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
+
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type OrganizationalStructureInput = InputsOf<typeof INPUT_SCHEMA>;
 
 export class OrganizationalStructureEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -63,7 +67,9 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<OrganizationalStructureInternal>> {
+  async evaluate(input: OrganizationalStructureInput): Promise<EvaluationResult<OrganizationalStructureInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Organizational Structure evaluation', {
       evaluator: OrganizationalStructureEvaluator.metadata.id,
       operation: 'evaluate',
@@ -75,16 +81,14 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      this.validateText(text);
-      const gradeNum = this.parseAndValidateGrade(gradeLevel);
+      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = OrganizationalStructureEvaluator.computeFkScore(text);
-      const inputs: Record<string, string> = {
-        text,
-        grade_level: String(gradeNum),
+      const promptInputs: Record<string, string> = {
+        ...input,
         fk_score: String(fkScore),
       };
-      const response = await this.callLLM(inputs);
+      const response = await this.callLLM(promptInputs);
 
       const latencyMs = Date.now() - startTime;
       const tokenUsage = {
@@ -116,7 +120,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
         status: 'success',
         latencyMs,
         textLength: text.length,
-        gradeLevel: String(gradeNum),
+        gradeLevel,
         provider: this.provider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
@@ -126,7 +130,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
       this.logger.info('Organizational Structure evaluation completed successfully', {
         evaluator: OrganizationalStructureEvaluator.metadata.id,
         operation: 'evaluate',
-        gradeLevel: gradeNum,
+        gradeLevel,
         score: response.data.complexity_score,
         processingTimeMs: latencyMs,
       });
@@ -167,16 +171,6 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
     }
   }
 
-  private parseAndValidateGrade(gradeLevel: string): number {
-    const trimmed = gradeLevel.trim();
-    if (!SUPPORTED_GRADES.includes(trimmed)) {
-      throw new InputValidationError(
-        `Invalid grade level "${gradeLevel}". Organizational Structure evaluator supports grade levels ${SUPPORTED_GRADES.join(', ')}.`,
-      );
-    }
-    return Number(trimmed);
-  }
-
   private async callLLM(
     inputs: Record<string, string>,
   ): Promise<{ data: OrganizationalStructureInternal; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
@@ -194,9 +188,8 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
 }
 
 export async function evaluateOrganizationalStructure(
-  text: string,
-  gradeLevel: string,
+  input: OrganizationalStructureInput,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<OrganizationalStructureInternal>> {
-  return new OrganizationalStructureEvaluator(config).evaluate(text, gradeLevel);
+  return new OrganizationalStructureEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/purpose-clarity.ts
@@ -4,6 +4,7 @@ import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/purpose-clarity/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
@@ -19,6 +20,9 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
+
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type PurposeClarityInput = InputsOf<typeof INPUT_SCHEMA>;
 
 export class PurposeClarityEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -52,36 +56,35 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
   /**
    * Evaluate purpose complexity for a given text and grade level
    *
-   * @param text - The text to evaluate
-   * @param gradeLevel - The target grade level (3-12)
+   * @param input - The inputs declared in this evaluator's `input_schema.json`
    * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
+   * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
    * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<PurposeClarityInternal>> {
+  async evaluate(input: PurposeClarityInput): Promise<EvaluationResult<PurposeClarityInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Purpose Clarity evaluation', {
       evaluator: PurposeClarityEvaluator.metadata.id,
       operation: 'evaluate',
       gradeLevel,
-      textLength: text.length,
+      textLength: text?.length,
     });
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(SUPPORTED_GRADES));
+      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = PurposeClarityEvaluator.computeFkScore(text);
-      const inputs: Record<string, string> = {
-        text,
-        grade_level: gradeLevel,
+      const promptInputs: Record<string, string> = {
+        ...input,
         fk_score: String(fkScore),
       };
-      const response = await this.callLLM(inputs);
+      const response = await this.callLLM(promptInputs);
 
       const latencyMs = Date.now() - startTime;
       const tokenUsage = {
@@ -181,9 +184,8 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
 }
 
 export async function evaluatePurposeClarity(
-  text: string,
-  gradeLevel: string,
+  input: PurposeClarityInput,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<PurposeClarityInternal>> {
-  return new PurposeClarityEvaluator(config).evaluate(text, gradeLevel);
+  return new PurposeClarityEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
@@ -4,6 +4,7 @@ import { runPreprocessingStep } from '../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../prompts/reference-knowledge-demands/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
@@ -19,6 +20,9 @@ const STEP = _step;
 // module level. The enum is the declared set, so it is used verbatim rather than
 // reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
 const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
+
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type ReferenceKnowledgeDemandsInput = InputsOf<typeof INPUT_SCHEMA>;
 
 export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -60,7 +64,9 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(text: string, gradeLevel: string): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
+  async evaluate(input: ReferenceKnowledgeDemandsInput): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Reference Knowledge Demands evaluation', {
       evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
       operation: 'evaluate',
@@ -72,16 +78,14 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(SUPPORTED_GRADES));
+      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = ReferenceKnowledgeDemandsEvaluator.computeFkScore(text);
-      const inputs: Record<string, string> = {
-        text,
-        grade_level: gradeLevel,
+      const promptInputs: Record<string, string> = {
+        ...input,
         fk_score: String(fkScore),
       };
-      const response = await this.callLLM(inputs);
+      const response = await this.callLLM(promptInputs);
 
       const latencyMs = Date.now() - startTime;
       const tokenUsage = {
@@ -181,9 +185,8 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
 }
 
 export async function evaluateReferenceKnowledgeDemands(
-  text: string,
-  gradeLevel: string,
+  input: ReferenceKnowledgeDemandsInput,
   config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
-  return new ReferenceKnowledgeDemandsEvaluator(config).evaluate(text, gradeLevel);
+  return new ReferenceKnowledgeDemandsEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -15,6 +15,8 @@ import {
 } from '../prompts/sentence-structure/index.js';
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
+import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/sentence-structure/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, LLMOutputProcessingError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/sentence-structure/config.json';
@@ -64,6 +66,9 @@ function normalizeLabel(label: string | null | undefined): TextComplexityLevel |
  * console.log(result.reasoning);
  * ```
  */
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type SentenceStructureInput = InputsOf<typeof INPUT_SCHEMA>;
+
 export class SentenceStructureEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -96,10 +101,9 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(
-    text: string,
-    gradeLevel: string
-  ): Promise<EvaluationResult<ComplexityClassification>> {
+  async evaluate(input: SentenceStructureInput): Promise<EvaluationResult<ComplexityClassification>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting sentence structure evaluation', {
       evaluator: SentenceStructureEvaluator.metadata.id,
       operation: 'evaluate',
@@ -112,8 +116,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(SentenceStructureEvaluator.metadata.supportedGrades));
+      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Stage 1: Analyzing sentence structure', {
         evaluator: SentenceStructureEvaluator.metadata.id,
         operation: 'sentence_analysis',
@@ -339,10 +342,9 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
  * ```
  */
 export async function evaluateSentenceStructure(
-  text: string,
-  gradeLevel: string,
+  input: SentenceStructureInput,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<ComplexityClassification>> {
   const evaluator = new SentenceStructureEvaluator(config);
-  return evaluator.evaluate(text, gradeLevel);
+  return evaluator.evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/vocabulary-complexity.ts
@@ -12,6 +12,8 @@ import {
 } from '../prompts/vocabulary-complexity/index.js';
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
+import { validateInputs, type InputsOf } from './inputs.js';
+import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/config.json';
@@ -42,6 +44,9 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/vocabulary
  * console.log(result.reasoning);
  * ```
  */
+/** What this evaluator accepts, taken from its `input_schema.json`. */
+export type VocabularyComplexityInput = InputsOf<typeof INPUT_SCHEMA>;
+
 export class VocabularyComplexityEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -88,10 +93,9 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
    * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
-  async evaluate(
-    text: string,
-    gradeLevel: string
-  ): Promise<EvaluationResult<VocabularyComplexityInternal>> {
+  async evaluate(input: VocabularyComplexityInput): Promise<EvaluationResult<VocabularyComplexityInternal>> {
+    const { text, grade_level: gradeLevel } = input;
+
     this.logger.info('Starting Vocabulary Complexity evaluation', {
       evaluator: VocabularyComplexityEvaluator.metadata.id,
       operation: 'evaluate',
@@ -114,8 +118,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     try {
       // Validate inputs — inside try so validation errors are telemetered.
       // If partners consistently pass invalid grade levels/text, telemetry will surface documentation gaps.
-      this.validateText(text);
-      this.validateGradeLevel(gradeLevel, new Set(VocabularyComplexityEvaluator.metadata.supportedGrades));
+      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Stage 1: Generating background knowledge', {
         evaluator: VocabularyComplexityEvaluator.metadata.id,
         operation: 'background_knowledge',
@@ -328,10 +331,9 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
  * ```
  */
 export async function evaluateVocabularyComplexity(
-  text: string,
-  gradeLevel: string,
+  input: VocabularyComplexityInput,
   config: BaseEvaluatorConfig
 ): Promise<EvaluationResult<VocabularyComplexityInternal>> {
   const evaluator = new VocabularyComplexityEvaluator(config);
-  return evaluator.evaluate(text, gradeLevel);
+  return evaluator.evaluate(input);
 }

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -52,13 +52,13 @@ const EVALUATORS: Array<{
 }> = [
   {
     metadata: GradeLevelAppropriatenessEvaluator.metadata,
-    run: (c) => new GradeLevelAppropriatenessEvaluator(c).evaluate(SAMPLE_TEXT),
+    run: (c) => new GradeLevelAppropriatenessEvaluator(c).evaluate({ text: SAMPLE_TEXT }),
   },
-  { metadata: MeaningDirectnessEvaluator.metadata, run: (c) => new MeaningDirectnessEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { metadata: BackgroundKnowledgeDemandsEvaluator.metadata, run: (c) => new BackgroundKnowledgeDemandsEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { metadata: SentenceStructureEvaluator.metadata, run: (c) => new SentenceStructureEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { metadata: PurposeClarityEvaluator.metadata, run: (c) => new PurposeClarityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
-  { metadata: VocabularyComplexityEvaluator.metadata, run: (c) => new VocabularyComplexityEvaluator(c).evaluate(SAMPLE_TEXT, GRADE) },
+  { metadata: MeaningDirectnessEvaluator.metadata, run: (c) => new MeaningDirectnessEvaluator(c).evaluate({ text: SAMPLE_TEXT, grade_level: GRADE }) },
+  { metadata: BackgroundKnowledgeDemandsEvaluator.metadata, run: (c) => new BackgroundKnowledgeDemandsEvaluator(c).evaluate({ text: SAMPLE_TEXT, grade_level: GRADE }) },
+  { metadata: SentenceStructureEvaluator.metadata, run: (c) => new SentenceStructureEvaluator(c).evaluate({ text: SAMPLE_TEXT, grade_level: GRADE }) },
+  { metadata: PurposeClarityEvaluator.metadata, run: (c) => new PurposeClarityEvaluator(c).evaluate({ text: SAMPLE_TEXT, grade_level: GRADE }) },
+  { metadata: VocabularyComplexityEvaluator.metadata, run: (c) => new VocabularyComplexityEvaluator(c).evaluate({ text: SAMPLE_TEXT, grade_level: GRADE }) },
 ];
 
 describeIntegration('Anthropic provider — all text-complexity evaluators (live API)', () => {

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -38,7 +38,7 @@ describeIntegration('modelOverride — model validity (live API)', () => {
       telemetry: false,
     });
 
-    const result = await evaluator.evaluate(SAMPLE_TEXT, '5');
+    const result = await evaluator.evaluate({ text: SAMPLE_TEXT, grade_level: '5' });
     expect(result.result.answer).toBeDefined();
     expect(result.metadata.model).toMatch(/^openai:gpt-4o-mini/);
   }, TEST_TIMEOUT_MS);
@@ -50,6 +50,6 @@ describeIntegration('modelOverride — model validity (live API)', () => {
       telemetry: false,
     });
 
-    await expect(evaluator.evaluate(SAMPLE_TEXT, '5')).rejects.toThrow(ConfigurationError);
+    await expect(evaluator.evaluate({ text: SAMPLE_TEXT, grade_level: '5' })).rejects.toThrow(ConfigurationError);
   }, TEST_TIMEOUT_MS);
 });

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -105,7 +105,11 @@ describe('STANDARDS_FAMILY.runTask', () => {
       MEMBER,
     );
 
-    expect(evaluate).toHaveBeenCalledWith('What is the area?', '3.MD.C.7.d', Jurisdiction.Utah);
+    expect(evaluate).toHaveBeenCalledWith({
+      question: 'What is the area?',
+      statementCode: '3.MD.C.7.d',
+      jurisdiction: Jurisdiction.Utah,
+    });
     expect(outcome.score).toBe('1/2');
     expect(outcome.reasoning).toContain('1 of 2');
     expect(outcome.payload).toMatchObject({
@@ -120,7 +124,11 @@ describe('STANDARDS_FAMILY.runTask', () => {
     const evaluate = vi.fn().mockResolvedValue(ALIGNMENT);
     await runnerWithStub(evaluate).runTask(row({ question: 'q', statementCode: '3.MD.C.7.d' }), MEMBER);
 
-    expect(evaluate).toHaveBeenCalledWith('q', '3.MD.C.7.d', Jurisdiction.MultiState);
+    expect(evaluate).toHaveBeenCalledWith({
+      question: 'q',
+      statementCode: '3.MD.C.7.d',
+      jurisdiction: Jurisdiction.MultiState,
+    });
   });
 
   it('rejects an unrecognised jurisdiction instead of passing it to the Knowledge Graph', async () => {

--- a/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
@@ -77,7 +77,7 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
       latencyMs: 800,
     });
 
-    const result = await evaluator.evaluate(testText, testGrade);
+    const result = await evaluator.evaluate({ text: testText, grade_level: testGrade });
 
     expect(result.result.complexity_score).toBe('Very complex');
     expect(result.result.reasoning).toContain('hydraulic systems');
@@ -117,9 +117,7 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
       latencyMs: 400,
     });
 
-    const result = await overrideEvaluator.evaluate(
-      'The mitochondria is the powerhouse of the cell.', '5'
-    );
+    const result = await overrideEvaluator.evaluate({ text: 'The mitochondria is the powerhouse of the cell.', grade_level: '5' });
 
     expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
@@ -127,12 +125,12 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
   it('should propagate LLM API errors', async () => {
     vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
 
-    await expect(evaluator.evaluate('The mitochondria is the powerhouse of the cell.', '5'))
+    await expect(evaluator.evaluate({ text: 'The mitochondria is the powerhouse of the cell.', grade_level: '5' }))
       .rejects.toThrow('API timeout');
   });
 
   it('should not call provider when input validation fails', async () => {
-    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    await expect(evaluator.evaluate({ text: '', grade_level: '5' })).rejects.toThrow();
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -153,7 +151,7 @@ describe('BackgroundKnowledgeDemandsEvaluator - Evaluation Flow', () => {
       latencyMs: 800,
     });
 
-    const result = await evaluator.evaluate('The mitochondria is the powerhouse of the cell.', '5');
+    const result = await evaluator.evaluate({ text: 'The mitochondria is the powerhouse of the cell.', grade_level: '5' });
 
     expect(result.result).toEqual(mockData);
   });

--- a/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
@@ -114,12 +114,10 @@ describe('functional API wrappers', () => {
     ['evaluateSentenceStructure', evaluateSentenceStructure],
     ['evaluateBackgroundKnowledgeDemands', evaluateBackgroundKnowledgeDemands],
     ['evaluateVocabularyComplexity', evaluateVocabularyComplexity],
-  ])('%s forwards text and gradeLevel and returns a result', async (_name, fn) => {
-    const result = await (fn as (t: string, g: string, c: typeof CONFIG) => Promise<unknown>)(
-      TEXT,
-      GRADE_LEVEL,
-      CONFIG
-    );
+  ])('%s forwards its inputs and returns a result', async (_name, fn) => {
+    const result = await (
+      fn as (i: { text: string; grade_level: string }, c: typeof CONFIG) => Promise<unknown>
+    )({ text: TEXT, grade_level: GRADE_LEVEL }, CONFIG);
 
     expect(result).toBeDefined();
     expect(mockProvider.generateStructured).toHaveBeenCalled();
@@ -134,15 +132,15 @@ describe('functional API wrappers', () => {
 
   // Grade-free by design: it decides the grade level rather than being told one.
   it('evaluateGradeLevelAppropriateness takes no gradeLevel', async () => {
-    const result = await evaluateGradeLevelAppropriateness(TEXT, CONFIG);
+    const result = await evaluateGradeLevelAppropriateness({ text: TEXT }, CONFIG);
 
     expect(result.result.grade).toBe('6-8');
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
 
   it('propagates a validation failure rather than swallowing it', async () => {
-    await expect(evaluateMeaningDirectness('', GRADE_LEVEL, CONFIG)).rejects.toThrow(
-      /empty|whitespace/i
-    );
+    await expect(
+      evaluateMeaningDirectness({ text: '', grade_level: GRADE_LEVEL }, CONFIG),
+    ).rejects.toThrow(/empty|whitespace/i);
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -87,7 +87,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       });
 
       // Execute evaluation (no grade parameter needed)
-      const result = await evaluator.evaluate(testText);
+      const result = await evaluator.evaluate({ text: testText });
 
       // Verify result structure
       expect(result.result.grade).toBe('6-8');
@@ -110,12 +110,12 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
 
   describe('Input Validation', () => {
     it('should throw InputValidationError for empty text', async () => {
-      await expect(evaluator.evaluate(''))
+      await expect(evaluator.evaluate({ text: '' }))
         .rejects.toThrow(InputValidationError);
     });
 
     it('should throw InputValidationError for whitespace-only text', async () => {
-      await expect(evaluator.evaluate('   '))
+      await expect(evaluator.evaluate({ text: '   ' }))
         .rejects.toThrow(InputValidationError);
     });
   });
@@ -130,7 +130,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       );
 
       // Should propagate the error
-      await expect(evaluator.evaluate(testText))
+      await expect(evaluator.evaluate({ text: testText }))
         .rejects.toThrow('API timeout');
     });
 
@@ -150,7 +150,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
         latencyMs: 800,
       });
 
-      const result = await evaluator.evaluate('Test text here');
+      const result = await evaluator.evaluate({ text: 'Test text here' });
 
       // Verify result structure
       expect(result).toHaveProperty('evaluator');

--- a/sdks/typescript/tests/unit/evaluators/inputs.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/inputs.test.ts
@@ -84,6 +84,18 @@ describe('validateInputs — rejected', () => {
     );
   });
 
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'text'],
+    ['a number', 7],
+    ['an array', ['text']],
+  ])('rejects %s in place of an inputs object', (_label, bad) => {
+    // A JS caller or an `any` can hand over anything. Reaching Object.keys with it
+    // would raise a TypeError, which is neither diagnosable nor in the taxonomy.
+    expect(() => validateInputs(bad as never, SCHEMA)).toThrow(InputValidationError);
+  });
+
   it('throws InputValidationError, not a bare Error', () => {
     expect(() => validateInputs({}, SCHEMA)).toThrow(InputValidationError);
   });

--- a/sdks/typescript/tests/unit/evaluators/inputs.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/inputs.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateInputs,
+  primaryTextField,
+  type DeclaredInputSchema,
+} from '../../../src/evaluators/inputs.js';
+import { InputValidationError } from '../../../src/errors.js';
+
+/** Two text inputs and a closed enum — between them these cover every branch. */
+const SCHEMA: DeclaredInputSchema = {
+  properties: {
+    text: { type: 'string', minLength: 10, maxLength: 40 },
+    grade_level: { type: 'string', enum: ['3', '4', '5'] },
+    note: { type: 'string', minLength: 1, maxLength: 20 },
+  },
+  required: ['text', 'grade_level'],
+};
+
+const valid = { text: 'a'.repeat(12), grade_level: '4' };
+
+describe('validateInputs — accepted', () => {
+  it('accepts exactly the required inputs', () => {
+    expect(() => validateInputs(valid, SCHEMA)).not.toThrow();
+  });
+
+  it('accepts an optional input when supplied', () => {
+    expect(() => validateInputs({ ...valid, note: 'fine' }, SCHEMA)).not.toThrow();
+  });
+
+  it('accepts an absent optional input', () => {
+    expect(() => validateInputs(valid, SCHEMA)).not.toThrow();
+  });
+
+  it('accepts the bounds themselves, not just inside them', () => {
+    expect(() => validateInputs({ ...valid, text: 'a'.repeat(10) }, SCHEMA)).not.toThrow();
+    expect(() => validateInputs({ ...valid, text: 'a'.repeat(40) }, SCHEMA)).not.toThrow();
+  });
+
+  it('accepts a schema that declares no required list', () => {
+    expect(() => validateInputs({ text: 'a'.repeat(12) }, { properties: SCHEMA.properties })).not.toThrow();
+  });
+});
+
+describe('validateInputs — rejected', () => {
+  it('rejects an unknown key and names what is accepted', () => {
+    expect(() => validateInputs({ ...valid, nope: 'x' }, SCHEMA)).toThrow(
+      'Unknown input "nope". This evaluator accepts: text, grade_level, note.',
+    );
+  });
+
+  it('rejects a missing required input', () => {
+    expect(() => validateInputs({ grade_level: '4' }, SCHEMA)).toThrow('text is required.');
+  });
+
+  it('treats an explicit null as absent', () => {
+    expect(() => validateInputs({ ...valid, text: null }, SCHEMA)).toThrow('text is required.');
+  });
+
+  it('rejects a non-string where a string is declared', () => {
+    expect(() => validateInputs({ ...valid, text: 42 }, SCHEMA)).toThrow('text must be a string.');
+  });
+
+  it.each(['   ', '\n\t', ''])('rejects blank text (%j)', (blank) => {
+    expect(() => validateInputs({ ...valid, text: blank }, SCHEMA)).toThrow(
+      'text cannot be empty or contain only whitespace',
+    );
+  });
+
+  it('rejects text under the declared minimum', () => {
+    expect(() => validateInputs({ ...valid, text: 'a'.repeat(9) }, SCHEMA)).toThrow(
+      'text is too short. Minimum length is 10 characters.',
+    );
+  });
+
+  it('rejects text over the declared maximum', () => {
+    expect(() => validateInputs({ ...valid, text: 'a'.repeat(41) }, SCHEMA)).toThrow(
+      'text is too long. Maximum length is 40 characters.',
+    );
+  });
+
+  it('rejects a value outside a declared enum and lists the accepted ones', () => {
+    expect(() => validateInputs({ ...valid, grade_level: '9' }, SCHEMA)).toThrow(
+      'Invalid grade_level "9". Accepted values: 3, 4, 5.',
+    );
+  });
+
+  it('throws InputValidationError, not a bare Error', () => {
+    expect(() => validateInputs({}, SCHEMA)).toThrow(InputValidationError);
+  });
+});
+
+describe('validateInputs — order is fixed', () => {
+  // Two bad inputs must always yield the same message, here and in any other SDK
+  // reading the same schema, or the two disagree about what the caller did wrong.
+  it('reports a required field before an optional one', () => {
+    expect(() =>
+      validateInputs({ text: 'short', grade_level: '4', note: '' }, SCHEMA),
+    ).toThrow(/^text is too short/);
+  });
+
+  it('reports required fields in declared order', () => {
+    expect(() => validateInputs({ text: 'short', grade_level: '9' }, SCHEMA)).toThrow(
+      /^text is too short/,
+    );
+  });
+
+  it('still validates an optional field when the required ones are fine', () => {
+    // Guards the field ordering: optional fields are appended after required ones, and
+    // an ordering that dropped them would accept invalid input silently.
+    expect(() => validateInputs({ ...valid, note: 'a'.repeat(21) }, SCHEMA)).toThrow(
+      'note is too long. Maximum length is 20 characters.',
+    );
+  });
+
+  it('does not bound-check an enum field', () => {
+    // An enum is a closed set; length has no meaning for it.
+    const enumOnly: DeclaredInputSchema = {
+      properties: { grade_level: { type: 'string', enum: ['3'], minLength: 99 } },
+      required: ['grade_level'],
+    };
+
+    expect(() => validateInputs({ grade_level: '3' }, enumOnly)).not.toThrow();
+  });
+});
+
+describe('primaryTextField', () => {
+  it('picks the first declared string that is not an enum', () => {
+    expect(primaryTextField(SCHEMA)).toBe('text');
+  });
+
+  it('skips an enum declared first', () => {
+    expect(
+      primaryTextField({
+        properties: {
+          grade_level: { type: 'string', enum: ['3'] },
+          student_text: { type: 'string', maxLength: 10 },
+        },
+      }),
+    ).toBe('student_text');
+  });
+
+  it('returns undefined when nothing qualifies', () => {
+    expect(primaryTextField({ properties: { n: { type: 'integer' } } })).toBeUndefined();
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/key-scoping.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/key-scoping.test.ts
@@ -38,7 +38,7 @@ async function telemetryHeaders(
     googleApiKey: 'k',
     learningCommonsApiKey: 'lc-key',
     telemetry,
-  }).evaluate(TEXT, '10');
+  }).evaluate({ text: TEXT, grade_level: '10' });
 
   // Telemetry is fire-and-forget, so let the microtask queue drain.
   await new Promise((resolve) => setImmediate(resolve));

--- a/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
@@ -61,7 +61,7 @@ describe('llmProvider — bring-your-own-provider', () => {
       telemetry: false,
     });
 
-    const result = await evaluator.evaluate(SAMPLE_TEXT);
+    const result = await evaluator.evaluate({ text: SAMPLE_TEXT });
 
     expect(generateStructured).toHaveBeenCalledTimes(1);
     expect(result.result.grade).toBe('6-8');

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -129,7 +129,7 @@ describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo, logger }));
 
-    await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+    await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
     const [message, context] = logger.warn.mock.calls[0];
@@ -145,7 +145,7 @@ describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
     const logger = makeLogger();
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ logger }));
 
-    await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+    await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -154,7 +154,7 @@ describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
 describe('MathStandardsAlignmentEvaluator - evaluate', () => {
   it('returns StandardAlignmentResult with correct shape on happy path', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    const result = await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(result.statementCode).toBe(STATEMENT_CODE);
     expect(result.totalCount).toBe(2);
@@ -171,7 +171,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
   it('passes jurisdiction and academicSubject to getLearningComponentsByCode', async () => {
     const kgClient = makeMockKgClient();
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: kgClient }));
-    await evaluator.evaluate(QUESTION, STATEMENT_CODE, Jurisdiction.California);
+    await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: Jurisdiction.California });
 
     expect(kgClient.getLearningComponentsByCode).toHaveBeenCalledWith(
       STATEMENT_CODE,
@@ -183,7 +183,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
     const emptyRepo = makeMockKgClient({ getLearningComponentsByCode: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', components: [] }) });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: emptyRepo }));
 
-    const result = await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(result.learningComponents).toHaveLength(0);
     expect(result.alignedCount).toBe(0);
@@ -197,25 +197,25 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       data: { evaluations: [MOCK_BATCH_RESPONSE.data.evaluations[0]] }, // only lc-001, missing lc-002
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow(
+    await expect(evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION })).rejects.toThrow(
       LLMOutputProcessingError,
     );
-    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow('missing verified evaluations for LC identifiers');
+    await expect(evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION })).rejects.toThrow('missing verified evaluations for LC identifiers');
   });
 
   it('throws InputValidationError for empty question', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate('', STATEMENT_CODE, JURISDICTION)).rejects.toThrow(InputValidationError);
+    await expect(evaluator.evaluate({ question: '', statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION })).rejects.toThrow(InputValidationError);
   });
 
   it('throws InputValidationError for question exceeding max length', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate('x'.repeat(10_001), STATEMENT_CODE, JURISDICTION)).rejects.toThrow(InputValidationError);
+    await expect(evaluator.evaluate({ question: 'x'.repeat(10_001), statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION })).rejects.toThrow(InputValidationError);
   });
 
   it('throws InputValidationError for empty statementCode', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    await expect(evaluator.evaluate(QUESTION, '', JURISDICTION)).rejects.toThrow(InputValidationError);
+    await expect(evaluator.evaluate({ question: QUESTION, statementCode: '', jurisdiction: JURISDICTION })).rejects.toThrow(InputValidationError);
   });
 
   it('correctly handles kindergarten standard', async () => {
@@ -227,7 +227,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       data: { evaluations: [{ lc_id: 'lc-k01', reasoning: 'ok', answer: 'Yes', feedback: '' }] },
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: kRepo }));
-    const result = await evaluator.evaluate(QUESTION, 'K.CC.A.1', JURISDICTION);
+    const result = await evaluator.evaluate({ question: QUESTION, statementCode: 'K.CC.A.1', jurisdiction: JURISDICTION });
     expect(result.statementCode).toBe('K.CC.A.1');
   });
 
@@ -239,7 +239,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       },
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    const result = await evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION);
+    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
     expect(result.alignedCount).toBe(1);
     expect(result.totalCount).toBe(2);
     expect(result.learningComponents[1].aligned).toBe(false);
@@ -738,7 +738,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       getLearningComponentsByCode: vi.fn().mockRejectedValue(new KnowledgeGraphError('nope')),
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
-    await expect(evaluator.evaluate(QUESTION, STATEMENT_CODE, JURISDICTION)).rejects.toThrow();
+    await expect(evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION })).rejects.toThrow();
   });
 
   it('isolates a validation failure to the offending item', async () => {

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -774,6 +774,21 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     expect(results[0].error).toMatchObject({ name: 'InputValidationError' });
   });
 
+  it('reports a blank statement code as invalid input, not a dependency failure', async () => {
+    // The bulk paths call the core directly rather than through evaluate(), so without
+    // a per-code check a blank code reaches the Knowledge Graph and comes back as an
+    // upstream error -- blaming the service for the caller's input.
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const results = await evaluator.evaluateItems(
+      [{ question: 'What is the area?', statementCodes: ['3.MD.C.7.d', '  '] }],
+      JURISDICTION,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].error).toMatchObject({ name: 'InputValidationError' });
+  });
+
   it('excludes an invalid item from the progress denominator', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
     const onProgress = vi.fn();

--- a/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
@@ -78,7 +78,7 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
       latencyMs: 900,
     });
 
-    const result = await evaluator.evaluate(testText, testGrade);
+    const result = await evaluator.evaluate({ text: testText, grade_level: testGrade });
 
     expect(result.result.complexity_score).toBe('Very complex');
     expect(result.result.reasoning).toContain('irony');
@@ -99,12 +99,12 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
     vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
 
     await expect(
-      evaluator.evaluate('The cat sat on the mat outside.', '5')
+      evaluator.evaluate({ text: 'The cat sat on the mat outside.', grade_level: '5' })
     ).rejects.toThrow('API timeout');
   });
 
   it('should not call provider when input validation fails', async () => {
-    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    await expect(evaluator.evaluate({ text: '', grade_level: '5' })).rejects.toThrow();
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -124,7 +124,7 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
       latencyMs: 700,
     });
 
-    const result = await evaluator.evaluate('Clouds form when water evaporates and rises into the sky.', '5');
+    const result = await evaluator.evaluate({ text: 'Clouds form when water evaporates and rises into the sky.', grade_level: '5' });
 
     expect(result.result).toEqual(mockData);
     expect(result.result.conventionality_features).toEqual(['literal narrative', 'concrete actions']);
@@ -147,7 +147,7 @@ describe('MeaningDirectnessEvaluator - Evaluation Flow', () => {
     });
 
     const testText = 'The minutes crept by as the castle grew into its place in the fog-shrouded distance.';
-    await evaluator.evaluate(testText, '7');
+    await evaluator.evaluate({ text: testText, grade_level: '7' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0];
     // The user prompt should contain the FK score (a number)

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -148,7 +148,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('calls provider once with model from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +156,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('passes temperature from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.temperature).toBe(STEP.generation.temperature);
@@ -167,7 +167,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
     const text = 'Pins are made of either brass or iron wire.';
 
-    await evaluator.evaluate(text, '4');
+    await evaluator.evaluate({ text: text, grade_level: '4' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain(text);
@@ -176,7 +176,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('includes grade_level (not grade) in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('Some sample text for testing purposes.', '7');
+    await evaluator.evaluate({ text: 'Some sample text for testing purposes.', grade_level: '7' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain('7');
@@ -186,7 +186,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('The quick brown fox jumps over the lazy dog.', '5');
+    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
@@ -195,7 +195,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('maps LLM response to result shape', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    const result = await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.result.complexity_score).toBe('slightly_complex');
     expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
@@ -233,9 +233,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
       latencyMs: 300,
     });
 
-    const result = await overrideEvaluator.evaluate(
-      'When going to the beach, find out which ones have lifeguards.', '3'
-    );
+    const result = await overrideEvaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
@@ -244,7 +242,7 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
     await expect(
-      evaluator.evaluate('Some text long enough to evaluate.', '5'),
+      evaluator.evaluate({ text: 'Some text long enough to evaluate.', grade_level: '5' }),
     ).resolves.toBeDefined();
   });
 });
@@ -263,22 +261,22 @@ describe('OrganizationalStructureEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate('Some text.', '2')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate('Some text.', '13')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects empty text', async () => {
-    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    await expect(evaluator.evaluate({ text: '', grade_level: '5' })).rejects.toThrow();
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects whitespace-only text', async () => {
-    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
+    await expect(evaluator.evaluate({ text: '   ', grade_level: '5' })).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -286,7 +284,7 @@ describe('OrganizationalStructureEvaluator - Validation', () => {
     vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
 
     await expect(
-      evaluator.evaluate('The beach is a fun place to swim and play in the sun.', '4'),
+      evaluator.evaluate({ text: 'The beach is a fun place to swim and play in the sun.', grade_level: '4' }),
     ).rejects.toThrow('API timeout');
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
@@ -139,7 +139,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('calls provider once with model from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
@@ -147,7 +147,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('passes temperature from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.temperature).toBe(STEP.generation.temperature);
@@ -158,7 +158,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
     const text = 'Pins are made of either brass or iron wire.';
 
-    await evaluator.evaluate(text, '4');
+    await evaluator.evaluate({ text: text, grade_level: '4' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain(text);
@@ -167,7 +167,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('includes grade_level (not grade) in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('Some sample text for testing purposes.', '7');
+    await evaluator.evaluate({ text: 'Some sample text for testing purposes.', grade_level: '7' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain('7');
@@ -177,7 +177,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('The quick brown fox jumps over the lazy dog.', '5');
+    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
@@ -186,7 +186,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('maps LLM response to result shape', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    const result = await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.result.complexity_score).toBe('slightly_complex');
     expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
@@ -224,9 +224,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
       latencyMs: 300,
     });
 
-    const result = await overrideEvaluator.evaluate(
-      'When going to the beach, find out which ones have lifeguards.', '3'
-    );
+    const result = await overrideEvaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
@@ -235,7 +233,7 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
     await expect(
-      evaluator.evaluate('Some text long enough to evaluate.', '5'),
+      evaluator.evaluate({ text: 'Some text long enough to evaluate.', grade_level: '5' }),
     ).resolves.toBeDefined();
   });
 });
@@ -254,22 +252,22 @@ describe('PurposeClarityEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate('Some text.', '2')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate('Some text.', '13')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects empty text', async () => {
-    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    await expect(evaluator.evaluate({ text: '', grade_level: '5' })).rejects.toThrow();
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects whitespace-only text', async () => {
-    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
+    await expect(evaluator.evaluate({ text: '   ', grade_level: '5' })).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -277,7 +275,7 @@ describe('PurposeClarityEvaluator - Validation', () => {
     vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
 
     await expect(
-      evaluator.evaluate('The beach is a fun place to swim and play in the sun.', '4'),
+      evaluator.evaluate({ text: 'The beach is a fun place to swim and play in the sun.', grade_level: '4' }),
     ).rejects.toThrow('API timeout');
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
@@ -139,7 +139,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('calls provider once with model from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
@@ -147,7 +147,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('passes temperature from config.json', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.temperature).toBe(STEP.generation.temperature);
@@ -158,7 +158,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
     const text = 'Pins are made of either brass or iron wire.';
 
-    await evaluator.evaluate(text, '4');
+    await evaluator.evaluate({ text: text, grade_level: '4' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain(text);
@@ -167,7 +167,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('includes grade_level (not grade) in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('Some sample text for testing purposes.', '7');
+    await evaluator.evaluate({ text: 'Some sample text for testing purposes.', grade_level: '7' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toContain('7');
@@ -177,7 +177,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate('The quick brown fox jumps over the lazy dog.', '5');
+    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
     expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
@@ -186,7 +186,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('maps LLM response to result shape', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    const result = await evaluator.evaluate('When going to the beach, find out which ones have lifeguards.', '3');
+    const result = await evaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.result.complexity_score).toBe('slightly_complex');
     expect(result.result.reasoning).toBe(MOCK_RESPONSE.data.reasoning);
@@ -224,9 +224,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
       latencyMs: 300,
     });
 
-    const result = await overrideEvaluator.evaluate(
-      'When going to the beach, find out which ones have lifeguards.', '3'
-    );
+    const result = await overrideEvaluator.evaluate({ text: 'When going to the beach, find out which ones have lifeguards.', grade_level: '3' });
 
     expect(result.metadata.model).toBe('anthropic:claude-haiku-4-5-20251001');
   });
@@ -235,7 +233,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
     await expect(
-      evaluator.evaluate('Some text long enough to evaluate.', '5'),
+      evaluator.evaluate({ text: 'Some text long enough to evaluate.', grade_level: '5' }),
     ).resolves.toBeDefined();
   });
 });
@@ -254,22 +252,22 @@ describe('ReferenceKnowledgeDemandsEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate('Some text.', '2')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate('Some text.', '13')).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects empty text', async () => {
-    await expect(evaluator.evaluate('', '5')).rejects.toThrow();
+    await expect(evaluator.evaluate({ text: '', grade_level: '5' })).rejects.toThrow();
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects whitespace-only text', async () => {
-    await expect(evaluator.evaluate('   ', '5')).rejects.toThrow(/empty or contain only whitespace/);
+    await expect(evaluator.evaluate({ text: '   ', grade_level: '5' })).rejects.toThrow(/empty or contain only whitespace/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -277,7 +275,7 @@ describe('ReferenceKnowledgeDemandsEvaluator - Validation', () => {
     vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('API timeout'));
 
     await expect(
-      evaluator.evaluate('The beach is a fun place to swim and play in the sun.', '4'),
+      evaluator.evaluate({ text: 'The beach is a fun place to swim and play in the sun.', grade_level: '4' }),
     ).rejects.toThrow('API timeout');
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -136,7 +136,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
         });
 
       // Execute evaluation
-      const result = await evaluator.evaluate(testText, testGrade);
+      const result = await evaluator.evaluate({ text: testText, grade_level: testGrade });
 
       // Verify result structure
       expect(result.result.answer).toBe('Slightly complex');
@@ -169,7 +169,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       );
 
       // Should propagate the error
-      await expect(evaluator.evaluate(testText, testGrade))
+      await expect(evaluator.evaluate({ text: testText, grade_level: testGrade }))
         .rejects.toThrow('API timeout');
 
       // Provider called once (stage 1 only)
@@ -191,7 +191,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
         .mockRejectedValueOnce(new Error('Schema validation failed'));
 
       // Should propagate the error
-      await expect(evaluator.evaluate(testText, testGrade))
+      await expect(evaluator.evaluate({ text: testText, grade_level: testGrade }))
         .rejects.toThrow('Schema validation failed');
 
       // Provider called twice (stage 1 completed, stage 2 failed)
@@ -219,7 +219,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
           latencyMs: 500,
         });
 
-      const result = await evaluator.evaluate('Test text here', '5');
+      const result = await evaluator.evaluate({ text: 'Test text here', grade_level: '5' });
 
       // Verify result structure
       expect(result).toHaveProperty('evaluator');
@@ -257,7 +257,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
           latencyMs: 1,
         });
 
-      await evaluator.evaluate('The cat sat on the mat. It was sleeping.', '7');
+      await evaluator.evaluate({ text: 'The cat sat on the mat. It was sleeping.', grade_level: '7' });
 
       const sent = vi
         .mocked(mockProvider.generateStructured)

--- a/sdks/typescript/tests/unit/evaluators/text-length-reporting.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/text-length-reporting.test.ts
@@ -1,127 +1,95 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MeaningDirectnessEvaluator } from '../../../src/evaluators/meaning-directness.js';
-import { VALIDATION_LIMITS } from '../../../src/evaluators/base.js';
 import { InputValidationError } from '../../../src/errors.js';
-import type { LLMProvider } from '../../../src/providers/base.js';
+import INPUT_SCHEMA from '../../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
 
 /**
- * One length, measured on the caller's text, used for the bounds, the log line,
- * the telemetry event and the prompt. The SDK does not normalize input: padding
- * is the caller's to remove, not ours to repair behind their back.
+ * Text bounds come from the evaluator's own `input_schema.json`, so the numbers here are
+ * read from the contract rather than restated. A single global pair would let an
+ * evaluator silently accept input its contract rejects, which is what these guard.
  */
 
-const mockProvider: LLMProvider = {
-  label: 'google:gemini-3-flash-preview',
-  generateStructured: vi.fn(),
-  generateText: vi.fn(),
-};
+const { minLength: MIN, maxLength: MAX } = INPUT_SCHEMA.properties.text;
 
-vi.mock('../../../src/providers/index.js', () => ({
-  createProvider: vi.fn(() => mockProvider),
-}));
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createProvider: vi.fn(() => ({
+      label: 'google:stub',
+      generateStructured: vi.fn(async () => ({
+        data: { complexity_score: 'Slightly complex', reasoning: 'r' },
+        model: 'stub',
+        usage: { inputTokens: 1, outputTokens: 1 },
+        latencyMs: 1,
+      })),
+      generateText: vi.fn(),
+    })),
+  };
+});
 
-// Captures what would go on the wire, rather than the argument passed in.
-const sent: Array<Record<string, unknown>> = [];
 vi.mock('../../../src/telemetry/client.js', () => ({
-  TelemetryClient: class MockTelemetryClient {
-    send = vi.fn(async (event: Record<string, unknown>) => {
-      sent.push(event);
-    });
+  TelemetryClient: class {
+    send = vi.fn().mockResolvedValue(undefined);
   },
 }));
 
-const CORE = 'The author sustains irony throughout to critique civilized society.';
-const evaluator = () => new MeaningDirectnessEvaluator({ googleApiKey: 'k' });
+const evaluator = () => new MeaningDirectnessEvaluator({ googleApiKey: 'k', telemetry: false });
 
 beforeEach(() => {
   vi.clearAllMocks();
-  sent.length = 0;
-  vi.mocked(mockProvider.generateStructured).mockResolvedValue({
-    data: { complexity_level: 'Very complex', reasoning: 'irony' },
-    model: 'gemini-3-flash-preview',
-    usage: { inputTokens: 10, outputTokens: 5 },
-    latencyMs: 1,
+});
+
+describe('text bounds come from the contract', () => {
+  it('accepts text exactly at the declared minimum', async () => {
+    await expect(
+      evaluator().evaluate({ text: 'a'.repeat(MIN), grade_level: '10' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects text one character under the declared minimum', async () => {
+    await expect(
+      evaluator().evaluate({ text: 'a'.repeat(MIN - 1), grade_level: '10' }),
+    ).rejects.toThrow(`text is too short. Minimum length is ${MIN} characters.`);
+  });
+
+  it('accepts text exactly at the declared maximum', async () => {
+    await expect(
+      evaluator().evaluate({ text: 'a'.repeat(MAX), grade_level: '10' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects text one character over the declared maximum', async () => {
+    await expect(
+      evaluator().evaluate({ text: 'a'.repeat(MAX + 1), grade_level: '10' }),
+    ).rejects.toThrow(`text is too long. Maximum length is ${MAX} characters.`);
   });
 });
 
-describe('text_length_chars is the length of what the caller sent', () => {
-  it('counts padding, because the model receives it too', async () => {
-    const padded = `\n\n   ${CORE}   \n\n`;
-    await evaluator().evaluate(padded, '10');
-
-    expect(sent).toHaveLength(1);
-    expect(sent[0].text_length_chars).toBe(padded.length);
-    expect(sent[0].text_length_chars).not.toBe(CORE.length);
-  });
-
-  it('reports the same length on the failure path', async () => {
-    vi.mocked(mockProvider.generateStructured).mockRejectedValue(new Error('upstream'));
-    const padded = `   ${CORE}   `;
-
-    await evaluator().evaluate(padded, '10').catch(() => undefined);
-
-    expect(sent).toHaveLength(1);
-    expect(sent[0].status).toBe('error');
-    expect(sent[0].text_length_chars).toBe(padded.length);
-  });
-
-  // The reported number has to describe the payload, so it must agree with what
-  // the prompt actually carried.
-  it('agrees with the text sent to the model', async () => {
-    const padded = `   ${CORE}   `;
-    await evaluator().evaluate(padded, '10');
-
-    const prompt = vi.mocked(mockProvider.generateStructured).mock.calls[0][0].messages
-      .map((m) => m.content)
-      .join('');
-    expect(prompt).toContain(padded);
-    expect(sent[0].text_length_chars).toBe(padded.length);
-  });
-});
-
-describe('validation measures the caller\'s text, unmodified', () => {
-  it('is 10,000 characters', () => {
-    expect(VALIDATION_LIMITS.MAX_TEXT_LENGTH).toBe(10_000);
-  });
-
-  it('accepts text exactly at the bound', async () => {
-    const atBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH);
-    await expect(evaluator().evaluate(atBound, '10')).resolves.toBeDefined();
-  });
-
-  it('rejects one character past the bound', async () => {
-    const overBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH + 1);
-    await expect(evaluator().evaluate(overBound, '10')).rejects.toThrow(InputValidationError);
-  });
-
-  // The deliberate consequence: padding is not silently absorbed. Text that
-  // only fits once trimmed is rejected, and the caller is told the real length.
+describe('text is measured as the caller sent it', () => {
+  // Trimming decides only whether the value is blank. Padding that pushes text past the
+  // bound is rejected rather than silently trimmed to fit, because the string that is
+  // measured is the string that reaches the model.
   it('rejects text pushed past the bound by padding alone', async () => {
-    const atBound = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH);
-    await expect(evaluator().evaluate(`  ${atBound}  `, '10')).rejects.toThrow(
-      /Maximum length is 10,000 characters, received 10,004 characters/
-    );
+    const atBound = 'a'.repeat(MAX);
+
+    await expect(
+      evaluator().evaluate({ text: `  ${atBound}  `, grade_level: '10' }),
+    ).rejects.toThrow(`text is too long. Maximum length is ${MAX} characters.`);
   });
 
-  // The minimum carries no product opinion: it excludes empty input and nothing
-  // else, so padding has nothing to sneak past. Meaningful minimums belong to
-  // each evaluator's input schema.
-  it('has a minimum of 1', () => {
-    expect(VALIDATION_LIMITS.MIN_TEXT_LENGTH).toBe(1);
-  });
-
-  it('accepts a single character', async () => {
-    await expect(evaluator().evaluate('a', '10')).resolves.toBeDefined();
-  });
-
-  // Trim survives as a validity test only: whitespace-only is rejected outright
-  // rather than being measured as content.
-  it.each(['   ', '\n\t\n', ' '.repeat(VALIDATION_LIMITS.MIN_TEXT_LENGTH + 5)])(
+  it.each(['   ', '\n\t\n', ' '.repeat(MIN + 5)])(
     'rejects whitespace-only input (%j)',
     async (blank) => {
-      await expect(evaluator().evaluate(blank, '10')).rejects.toThrow(
-        'Text cannot be empty or contain only whitespace'
+      await expect(evaluator().evaluate({ text: blank, grade_level: '10' })).rejects.toThrow(
+        'text cannot be empty or contain only whitespace',
       );
-    }
+    },
   );
+
+  it('reports a blank input as a validation failure, not a provider one', async () => {
+    await expect(evaluator().evaluate({ text: '   ', grade_level: '10' })).rejects.toThrow(
+      InputValidationError,
+    );
+  });
 });

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VocabularyComplexityEvaluator } from '../../../src/evaluators/vocabulary-complexity.js';
 import { BackgroundKnowledgeDemandsEvaluator } from '../../../src/evaluators/background-knowledge-demands.js';
-import { VALIDATION_LIMITS, Provider, BaseEvaluator } from '../../../src/evaluators/base.js';
+import { Provider, BaseEvaluator } from '../../../src/evaluators/base.js';
+import MD_INPUT_SCHEMA from '../../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
+
+// Read from the contract, not restated: the bound is the evaluator's, not a global.
+const MAX_TEXT_LENGTH = MD_INPUT_SCHEMA.properties.text.maxLength;
 import { ConfigurationError, InputValidationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 import { createProvider } from '../../../src/providers/index.js';
@@ -156,7 +160,7 @@ describe('ModelOverride', () => {
       vi.mocked(evaluator.provider.generateStructured).mockRejectedValueOnce(notFoundError);
 
       await expect(
-        evaluator.evaluate('This is a sample text long enough to pass validation.', '5')
+        evaluator.evaluate({ text: 'This is a sample text long enough to pass validation.', grade_level: '5' })
       ).rejects.toThrow(ConfigurationError);
     });
   });
@@ -183,8 +187,8 @@ describe('Input Validation - Text Validation', () => {
       ['newlines only', '\n\n\n'],
       ['mixed whitespace', '  \t\n  '],
     ])('should reject %s', async (_label, text) => {
-      await expect(evaluator.evaluate(text, '5'))
-        .rejects.toThrow('Text cannot be empty or contain only whitespace');
+      await expect(evaluator.evaluate({ text: text, grade_level: '5' }))
+        .rejects.toThrow('text cannot be empty or contain only whitespace');
     });
   });
 
@@ -193,17 +197,17 @@ describe('Input Validation - Text Validation', () => {
     // longer a validation failure. Meaningful minimums are declared in each
     // evaluator's input schema.
     it('does not reject short text as invalid input', async () => {
-      const error = await evaluator.evaluate('Hello wo', '5').catch((e) => e);
+      const error = await evaluator.evaluate({ text: 'Hello wo', grade_level: '5' }).catch((e) => e);
       expect(error).not.toBeInstanceOf(InputValidationError);
     });
   });
 
   describe('Maximum length validation', () => {
-    it(`should reject text longer than ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters`, async () => {
-      const longText = 'a'.repeat(VALIDATION_LIMITS.MAX_TEXT_LENGTH + 1);
+    it(`should reject text longer than ${MAX_TEXT_LENGTH} characters`, async () => {
+      const longText = 'a'.repeat(MAX_TEXT_LENGTH + 1);
 
-      await expect(evaluator.evaluate(longText, '5'))
-        .rejects.toThrow(new RegExp(`Text is too long\\. Maximum length is ${VALIDATION_LIMITS.MAX_TEXT_LENGTH.toLocaleString()} characters, received ${(VALIDATION_LIMITS.MAX_TEXT_LENGTH + 1).toLocaleString()} characters`));
+      await expect(evaluator.evaluate({ text: longText, grade_level: '5' }))
+        .rejects.toThrow('text is too long. Maximum length is 10000 characters.');
     });
   });
 });
@@ -229,8 +233,8 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (below minimum)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+        .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
 
     it.each([
@@ -239,8 +243,8 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (above maximum)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+        .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
 
     it.each([
@@ -250,8 +254,8 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (invalid format)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate(validText, grade))
-        .rejects.toThrow(`Invalid grade level "${grade}". Supported grade levels for this evaluator: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12`);
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+        .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
@@ -111,7 +111,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       });
 
       // Execute evaluation
-      const result = await evaluator.evaluate(testText, testGrade);
+      const result = await evaluator.evaluate({ text: testText, grade_level: testGrade });
 
       // Verify result structure
       expect(result.result.complexity_score).toBe('Moderately complex');
@@ -152,7 +152,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       );
 
       // Should propagate the error
-      await expect(evaluator.evaluate(testText, testGrade))
+      await expect(evaluator.evaluate({ text: testText, grade_level: testGrade }))
         .rejects.toThrow('API timeout');
 
       // Verify complexity provider was never called
@@ -176,7 +176,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       );
 
       // Should propagate the error
-      await expect(evaluator.evaluate(testText, testGrade))
+      await expect(evaluator.evaluate({ text: testText, grade_level: testGrade }))
         .rejects.toThrow('Schema validation failed');
 
       // Verify background provider was called (stage 1 completed)
@@ -204,7 +204,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
         latencyMs: 800,
       });
 
-      const result = await evaluator.evaluate('Test text here', '5');
+      const result = await evaluator.evaluate({ text: 'Test text here', grade_level: '5' });
 
       // Verify result structure
       expect(result).toHaveProperty('evaluator');
@@ -246,7 +246,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
         latencyMs: 400,
       });
 
-      const result = await overrideEvaluator.evaluate('Test text here', '5');
+      const result = await overrideEvaluator.evaluate({ text: 'Test text here', grade_level: '5' });
 
       // All providers resolve to the same model under override — label is a single entry
       expect(result.metadata.model).toBe('openai:gpt-4o-mini');
@@ -273,7 +273,7 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
         latencyMs: 800,
       });
 
-      const result = await evaluator.evaluate('Test text here', '5');
+      const result = await evaluator.evaluate({ text: 'Test text here', grade_level: '5' });
 
       // Verify internal data is included
       expect(result.result).toEqual(mockComplexityData);

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -150,21 +150,6 @@ const GRADE_GAPS = new Set<string>([
   MATH_ID,
 ]);
 
-/**
- * `evaluatorId::field` pairs whose declared bounds the SDK does not enforce.
- *
- * §4.1 requires each text input to be validated against its own registry-declared
- * limits; the SDK applies one global pair to every input, so a contract asking for
- * anything narrower is silently ignored.
- */
-const LIMIT_GAPS = new Set<string>([
-  // Declare `text.minLength: 10`; the SDK enforces 1, so it accepts input these
-  // contracts reject. The other four ela-reading evaluators declare 1 and agree.
-  `${GLA_ID}::text`,
-  `${BKD_ID}::text`,
-  `${MD_ID}::text`,
-  `${SENTENCE_ID}::text`,
-]);
 
 
 
@@ -301,15 +286,15 @@ const cases = EVALUATORS.map((E) => ({ name: E.metadata.name, E }));
  * Knowledge Graph before any model. Naming inputs will make this map derivable.
  */
 const INVOKE: Record<string, (E: EvaluatorClass, text: string) => Promise<unknown>> = {
-  [GLA_ID]: (E, text) => construct(E).evaluate(text),
-  [BKD_ID]: (E, text) => construct(E).evaluate(text, '5'),
-  [MD_ID]: (E, text) => construct(E).evaluate(text, '5'),
-  [OrganizationalStructureEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
-  [PurposeClarityEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
+  [GLA_ID]: (E, text) => construct(E).evaluate({ text }),
+  [BKD_ID]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
+  [MD_ID]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
+  [OrganizationalStructureEvaluator.metadata.id]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
+  [PurposeClarityEvaluator.metadata.id]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
   [ReferenceKnowledgeDemandsEvaluator.metadata.id]: (E, text) =>
-    construct(E).evaluate(text, '5'),
-  [SENTENCE_ID]: (E, text) => construct(E).evaluate(text, '5'),
-  [VocabularyComplexityEvaluator.metadata.id]: (E, text) => construct(E).evaluate(text, '5'),
+    construct(E).evaluate({ text, grade_level: '5' }),
+  [SENTENCE_ID]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
+  [VocabularyComplexityEvaluator.metadata.id]: (E, text) => construct(E).evaluate({ text, grade_level: '5' }),
 };
 
 /**
@@ -639,16 +624,9 @@ describe('a declared minimum length is enforced', () => {
 
     // Asserting on the error type, not on whether the call resolved: a stubbed provider
     // can fail an evaluation for reasons that have nothing to do with validation.
-    if (LIMIT_GAPS.has(`${E.metadata.id}::text`)) {
-      expect(
-        rejectedForLength,
-        `${E.metadata.name} now enforces its declared minLength ${min} — delete its LIMIT_GAPS entry`,
-      ).toBe(false);
-    } else {
-      expect(
-        rejectedForLength,
-        `${E.metadata.name} accepts text shorter than the minLength ${min} its contract declares`,
-      ).toBe(true);
-    }
+    expect(
+      rejectedForLength,
+      `${E.metadata.name} accepts text shorter than the minLength ${min} its contract declares`,
+    ).toBe(true);
   });
 });

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -184,7 +184,7 @@ export async function runEvaluatorTest(
   // Phase 1: Try to match expected value (short-circuit on match)
   for (let attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
     const result = testCase.grade
-      ? await evaluator.evaluate(testCase.text, testCase.grade)
+      ? await evaluator.evaluate({ text: testCase.text, grade_level: testCase.grade })
       : await evaluator.evaluate(testCase.text);
 
     const actualValue = extractResult(result);

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -185,7 +185,7 @@ export async function runEvaluatorTest(
   for (let attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
     const result = testCase.grade
       ? await evaluator.evaluate({ text: testCase.text, grade_level: testCase.grade })
-      : await evaluator.evaluate(testCase.text);
+      : await evaluator.evaluate({ text: testCase.text });
 
     const actualValue = extractResult(result);
     const isExpectedMatch = compareFn(actualValue, testCase.expected);


### PR DESCRIPTION
34 files, +616/−418.

```ts
evaluate({ text, grade_level: '5' })
evaluate({ student_text, feedback_text })      // expressible for the first time
evaluate({ question, statementCode, jurisdiction })
```

§5 requires inputs be *"passed by their canonical names … never as ad-hoc parameters"*, and the positional form couldn't express the seven merged feedback contracts at all — two text inputs, no grade.

## The type is derived, not written or generated

I probed this rather than assumed it: **TypeScript narrows imported JSON property keys even though it widens their string values.** Since every input in all 16 contracts is a required string, `Record<keyof S['properties'], string>` is exact:

```ts
export type PurposeClarityInput = InputsOf<typeof INPUT_SCHEMA>;
```

Adding an input to a contract is now a compile error at every call site that omits it, with **no codegen step** — which matters, because the design review had assumed named inputs would have to wait for the generator PR. The declared enum and bounds are enforced at runtime, which is authoritative either way.

## Validation now comes from the contract

Per input, from that input's own declared bounds and enum, in §4.1's fixed order, with the field's canonical name substituted into the message.

Four contracts declare `text.minLength: 10` that the SDK had been ignoring in favour of a global minimum of 1 — which §4.1 explicitly forbids. **So text shorter than 10 characters is now rejected by those four evaluators, as their contracts have always said.**

Messages lose the `received N characters` clause. A caller can measure its own input.

## Three pieces of code died rather than migrating

- **`VALIDATION_LIMITS` and `validateText`** — a single global pair has nothing left to govern, and keeping it would let an evaluator fall back to bounds its contract never declared. `validateGradeLevel` stays: math's `evaluateByGradeLevel` still uses it.
- **Organizational Structure's `parseAndValidateGrade`** — trimmed the grade and worded its error differently from every other evaluator. One of the drifts flagged in the very first survey, now gone.
- **Math's `validateQuestion` / `validateStatementCode`** — the schema declares both bounds, and `statementCode`'s was declared but never enforced by anything.

## Batch builds inputs explicitly

Families construct each object from the evaluator's declared fields rather than forwarding a row. A row carries every CSV column, and an evaluator now rejects keys its schema doesn't declare — so forwarding would break on any extra column.

## `LIMIT_GAPS` is gone

All four entries demanded deletion once the bounds were honoured. That's the self-cleaning allowlist from #211/#212 doing exactly what it was built for — the test told me the gap had closed rather than me remembering to check.

`text-length-reporting` is rewritten to read bounds from the contract instead of asserting a global.

## Validation

- `tsc --noEmit`, `npm run lint`, `npm run test:unit`, `npm run build`, `scripts/check.py`
- **Mutation testing on `src/evaluators/inputs.ts`: 58.43% → 94.38%.** The first run exposed that the new logic had *20 uncovered mutants* — the existing tests only exercised validation incidentally through evaluators. Added a dedicated 23-case unit test; uncovered went to 0, survivors 17 → 5. One survivor was a real gap: if the field-ordering filter dropped optional fields, an invalid optional input would pass unchecked, and nothing asserted otherwise. That test now exists.
- A false positive worth noting: my first pass at rewriting call sites also rewrote `BatchEvaluator.evaluate(inputs, familyId)` — a different method with the same name. `tsc` caught it; that file is reverted and batch call sites are excluded.

## Not included

- **README** updated; `demos/typescript` deliberately untouched (pinned to published `0.8.0`, and it's the migration-guide canary).
- **Notebooks** untouched — they call providers directly, not the SDK.
- Narrowing `grade_level` to its enum union at the type level. It's enforced at runtime; narrowing later would break callers passing a computed string, so it's a deliberate non-goal rather than an oversight.
