### PR TITLE
refactor(sdk)!: consume the contract declarations, and fix three bugs

### DIFF
--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -32,7 +32,11 @@ import {
 interface SimpleEvaluator {
   evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
 }
-type EvaluatorConstructor = new (config: BaseEvaluatorConfig) => SimpleEvaluator;
+type EvaluatorConstructor = (new (config: BaseEvaluatorConfig) => SimpleEvaluator) & {
+  // The declared outcome travels with the class, so the family reads which field holds
+  // the verdict from the contract rather than knowing it per member.
+  metadata: { outcome?: { score: string; reasoning: string } };
+};
 
 const EVALUATOR_MAP = new Map<string, EvaluatorConstructor>([
   [GradeLevelAppropriatenessEvaluator.metadata.id, GradeLevelAppropriatenessEvaluator],
@@ -112,7 +116,8 @@ class QtcRunner implements FamilyRunner {
     }
 
     const result = await this.getEvaluator(memberId).evaluate(inputs);
-    const { score, reasoning } = readOutcome(result);
+    const declared = EVALUATOR_MAP.get(memberId)?.metadata.outcome;
+    const { score, reasoning } = readOutcome(result, declared);
 
     // A report cell has to be a string. An absent verdict renders blank, and doing
     // that here rather than inside readOutcome keeps the gap visible to any other caller.

--- a/sdks/typescript/src/evaluators/background-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/background-knowledge-demands.ts
@@ -30,8 +30,8 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/background
  * });
  *
  * const result = await evaluator.evaluate(text, "6");
- * console.log(result.score); // "Moderately complex"
- * console.log(result.reasoning);
+ * console.log(result.result.complexity_score); // "Moderately complex"
+ * console.log(result.result.reasoning);
  * ```
  */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
@@ -72,21 +72,23 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: BackgroundKnowledgeDemandsInput): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Background Knowledge Demands evaluation', {
-      evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
-      // Validate inputs — inside try so validation errors are telemetered.
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Background Knowledge Demands evaluation', {
+        evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
 
       this.logger.debug('Evaluating subject matter knowledge complexity', {
         evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,

--- a/sdks/typescript/src/evaluators/background-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/background-knowledge-demands.ts
@@ -5,6 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/background-knowledge-
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -43,6 +44,8 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
     defaultProviders: [Provider.Google] as const,
   };
@@ -69,6 +72,7 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: BackgroundKnowledgeDemandsInput): Promise<EvaluationResult<BackgroundKnowledgeDemandsInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Background Knowledge Demands evaluation', {
@@ -83,7 +87,6 @@ export class BackgroundKnowledgeDemandsEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      validateInputs(input, INPUT_SCHEMA);
 
       this.logger.debug('Evaluating subject matter knowledge complexity', {
         evaluator: BackgroundKnowledgeDemandsEvaluator.metadata.id,

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -12,6 +12,7 @@ import {
   type DependencyId,
 } from '../errors.js';
 import { createLogger, LogLevel, type Logger } from '../logger.js';
+import { configFieldFor } from './credentials.js';
 import { createProvider } from '../providers/index.js';
 import type { LLMProvider } from '../providers/index.js';
 
@@ -180,6 +181,18 @@ export interface EvaluatorMetadata {
   readonly description: string;
   /** Supported grade levels (e.g., ['3', '4', '5', ...]) */
   readonly supportedGrades: readonly string[];
+  /**
+   * Which output properties carry the verdict and its rationale, as the evaluator's
+   * contract declares them. Absent for an evaluator whose output is not a single
+   * judgement, which is why {@link readOutcome} can report no verdict.
+   */
+  readonly outcome?: { readonly score: string; readonly reasoning: string };
+  /**
+   * Canonical config keys for non-LLM services this evaluator calls, from its
+   * contract. LLM keys are not listed — those follow `defaultProviders`, which a model
+   * override narrows; these it does not touch.
+   */
+  readonly requiredCredentials?: readonly string[];
   /** Providers required by this evaluator's default configuration */
   readonly defaultProviders: readonly Provider[];
 }
@@ -355,45 +368,56 @@ export abstract class BaseEvaluator {
   }
 
   /**
-   * Validate that the required API key is present.
-   * When modelOverride is set, checks the override provider's key.
-   * Otherwise checks the keys required by the evaluator's default providers.
-   * @throws {ConfigurationError} If a required key is missing
+   * Validate that every credential this evaluator needs was supplied.
+   *
+   * Requirements are derived, not listed: the LLM keys come from the providers its
+   * steps use, and the non-LLM ones from the contract's `required_credentials`. A model
+   * override replaces the former and leaves the latter alone, so an override cannot
+   * skip a credential for a service the evaluator still calls.
+   *
+   * @throws {ConfigurationError} If a required credential is missing
    */
   private validateApiKeys(config: BaseEvaluatorConfig): void {
-    const keyFor: Record<Provider, string | undefined> = {
-      [Provider.OpenAI]: config.openaiApiKey?.trim() || undefined,
-      [Provider.Google]: config.googleApiKey?.trim() || undefined,
-      [Provider.Anthropic]: config.anthropicApiKey?.trim() || undefined,
-    };
-    const humanName: Record<Provider, string> = {
-      [Provider.OpenAI]: 'OpenAI API key',
-      [Provider.Google]: 'Google API key',
-      [Provider.Anthropic]: 'Anthropic API key',
-    };
-    const configKey: Record<Provider, string> = {
-      [Provider.OpenAI]: 'openaiApiKey',
-      [Provider.Google]: 'googleApiKey',
-      [Provider.Anthropic]: 'anthropicApiKey',
+    // The one table that has to exist: these are the SDK's own config fields, which
+    // cannot be indexed dynamically. Names and messages are derived from the canonical
+    // key, so no per-provider table.
+    const provided: Record<string, string | undefined> = {
+      openaiApiKey: config.openaiApiKey,
+      googleApiKey: config.googleApiKey,
+      anthropicApiKey: config.anthropicApiKey,
+      learningCommonsApiKey: config.learningCommonsApiKey,
     };
 
-    if (config.modelOverride) {
-      if (!keyFor[config.modelOverride.provider]) {
-        throw new ConfigurationError(
-          `${humanName[config.modelOverride.provider]} is required when using modelOverride with provider "${config.modelOverride.provider}". Pass ${configKey[config.modelOverride.provider]} in config.`
-        );
-      }
-      return;
-    }
+    const providers = config.modelOverride
+      ? [config.modelOverride.provider]
+      : this.metadata.defaultProviders;
 
-    for (const provider of this.metadata.defaultProviders) {
-      if (!keyFor[provider]) {
+    const satisfied = new Set(this.credentialsSatisfiedByInjection(config));
+    const required = [
+      ...providers.map((provider) => `${provider}_api_key`),
+      ...(this.metadata.requiredCredentials ?? []).filter((key) => !satisfied.has(key)),
+    ];
+
+    for (const canonical of required) {
+      const field = configFieldFor(canonical);
+      if (!provided[field]?.trim()) {
         throw new ConfigurationError(
-          // No " evaluator" suffix: registry names already end in "Evaluator".
-          `${humanName[provider]} is required for ${this.metadata.name}. Pass ${configKey[provider]} in config.`
+          `Missing required credential: ${field}. Required by ${this.metadata.name}.`,
         );
       }
     }
+  }
+
+  /**
+   * Credentials a subclass no longer needs because the caller injected the client that
+   * would have used them.
+   *
+   * Reads only `config`, since this runs from the base constructor before the subclass
+   * is initialised. Same rule as an injected `llmProvider`: whoever supplies the client
+   * owns its auth.
+   */
+  protected credentialsSatisfiedByInjection(_config: BaseEvaluatorConfig): readonly string[] {
+    return [];
   }
 
   /**

--- a/sdks/typescript/src/evaluators/credentials.ts
+++ b/sdks/typescript/src/evaluators/credentials.ts
@@ -1,0 +1,45 @@
+/**
+ * Working out which credentials an evaluator needs, from what its contract declares.
+ *
+ * Two kinds, with different behaviour under a model override. LLM keys follow the
+ * providers the evaluator's steps use, so an override replaces them — it changes which
+ * model runs. Non-LLM credentials are declared per entry and an override never touches
+ * them, because it does not change which services the evaluator calls.
+ */
+
+/** As much of a contract as credential derivation reads. */
+export interface CredentialDeclaringConfig {
+  // `id` is required only so this is not a weak type: an entry shape with nothing but
+  // optional properties would reject a contract that declares no credentials at all.
+  preprocessing?: ReadonlyArray<{ id: string; required_credentials?: readonly string[] }>;
+  steps: ReadonlyArray<{
+    id: string;
+    optional?: boolean;
+    required_credentials?: readonly string[];
+  }>;
+}
+
+/**
+ * The non-LLM credentials a contract declares, across every entry that can run.
+ *
+ * An optional step is excluded: it runs only when a caller opts in, so requiring its
+ * credential at construction would demand a key for a call that never happens.
+ */
+export function declaredCredentials(config: CredentialDeclaringConfig): readonly string[] {
+  const entries = [
+    ...(config.preprocessing ?? []),
+    ...config.steps.filter((step) => !step.optional),
+  ];
+
+  return [...new Set(entries.flatMap((entry) => entry.required_credentials ?? []))];
+}
+
+/**
+ * The config field carrying a canonical credential, per §2.1's mechanical casing map.
+ *
+ * A formula rather than a lookup table: `openai_api_key` is `openaiApiKey`, and a
+ * provider added later needs no entry anywhere.
+ */
+export function configFieldFor(canonicalKey: string): string {
+  return canonicalKey.replace(/_([a-z])/g, (_match, letter: string) => letter.toUpperCase());
+}

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -7,6 +7,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/grade-level-appropria
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
@@ -34,7 +35,7 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-leve
  *
  * const result = await evaluator.evaluate(input);
  * console.log(result.score); // "9-10"
- * console.log(result._internal.alternative_grade); // "6-8"
+ * console.log(result.result.alternative_grade_band); // "6-8"
  * console.log(result._internal.scaffolding_needed);
  * ```
  */
@@ -48,6 +49,8 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: [] as const, // No gradeLevel parameter required - evaluates what grade level the text is appropriate for
     defaultProviders: [Provider.Google] as const,
   };
@@ -74,6 +77,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: GradeLevelAppropriatenessInput): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text } = input;
 
     this.logger.info('Starting grade level appropriateness evaluation', {
@@ -86,7 +90,6 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Evaluating grade level appropriateness', {
         evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
         operation: 'grade_evaluation',
@@ -140,7 +143,7 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
       this.logger.info('Grade level appropriateness evaluation completed successfully', {
         evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
         operation: 'evaluate',
-        gradeLevel: response.data.grade,
+        gradeLevel: response.data.grade_band,
         processingTimeMs: latencyMs,
       });
 

--- a/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/grade-level-appropriateness.ts
@@ -33,10 +33,10 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/grade-leve
  *   googleApiKey: process.env.GOOGLE_API_KEY
  * });
  *
- * const result = await evaluator.evaluate(input);
- * console.log(result.score); // "9-10"
+ * const result = await evaluator.evaluate({ text });
+ * console.log(result.result.grade_band); // "9-10"
  * console.log(result.result.alternative_grade_band); // "6-8"
- * console.log(result._internal.scaffolding_needed);
+ * console.log(result.result.scaffolding_needed);
  * ```
  */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
@@ -77,19 +77,21 @@ export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: GradeLevelAppropriatenessInput): Promise<EvaluationResult<GradeLevelAppropriatenessInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text } = input;
-
-    this.logger.info('Starting grade level appropriateness evaluation', {
-      evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-      operation: 'evaluate',
-      textLength: text.length,
-    });
-
+    let text = '';
     const startTime = Date.now();
 
     try {
-      // Validate inputs — inside try so validation errors are telemetered.
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text } = input);
+
+      this.logger.info('Starting grade level appropriateness evaluation', {
+        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
+        operation: 'evaluate',
+        textLength: text.length,
+      });
+
       this.logger.debug('Evaluating grade level appropriateness', {
         evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
         operation: 'grade_evaluation',

--- a/sdks/typescript/src/evaluators/math/standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/math/standards-alignment.ts
@@ -13,11 +13,12 @@ import {
   SUPPORTED_GRADES,
 } from '../../prompts/math/standards-alignment/index.js';
 import { KnowledgeGraphClient, Jurisdiction } from '../../knowledge-graph/index.js';
-import { EvaluatorError, DependencyError, ConfigurationError, InputValidationError, LLMOutputProcessingError, wrapProviderError } from '../../errors.js';
+import { EvaluatorError, DependencyError, InputValidationError, LLMOutputProcessingError, wrapProviderError } from '../../errors.js';
 import type { StageDetail } from '../../telemetry/index.js';
 import CONFIG from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json';
 import INPUT_SCHEMA from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/input_schema.json';
 import { validateInputs, type InputsOf } from '../inputs.js';
+import { declaredCredentials } from '../credentials.js';
 
 const EVALUATOR_ID = CONFIG.evaluator.id;
 
@@ -188,7 +189,16 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     description: CONFIG.evaluator.description,
     supportedGrades: SUPPORTED_GRADES as string[],
     defaultProviders: [Provider.Anthropic] as const,
+    outcome: undefined,
+    requiredCredentials: declaredCredentials(CONFIG),
   };
+
+  /** An injected client carries its own auth, so the key it would have used is not required. */
+  protected override credentialsSatisfiedByInjection(
+    config: MathStandardsAlignmentEvaluatorConfig,
+  ): readonly string[] {
+    return config._kgClient ? ['learning_commons_api_key'] : [];
+  }
 
   private readonly kgClient: KnowledgeGraphClient;
   private readonly detailProvider: LLMProvider;
@@ -198,12 +208,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
   constructor(config: MathStandardsAlignmentEvaluatorConfig) {
     super(config);
-
-    if (!config.learningCommonsApiKey && !config._kgClient) {
-      throw new ConfigurationError(
-        'MathStandardsAlignmentEvaluator requires a learningCommonsApiKey to access the Learning Commons Knowledge Graph.',
-      );
-    }
 
     this.kgClient =
       config._kgClient ??

--- a/sdks/typescript/src/evaluators/meaning-directness.ts
+++ b/sdks/typescript/src/evaluators/meaning-directness.ts
@@ -5,6 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/meaning-directness/in
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -43,6 +44,8 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
     defaultProviders: [Provider.Google] as const,
   };
@@ -69,6 +72,7 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: MeaningDirectnessInput): Promise<EvaluationResult<MeaningDirectnessInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Meaning Directness evaluation', {
@@ -83,7 +87,6 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      validateInputs(input, INPUT_SCHEMA);
 
       this.logger.debug('Evaluating conventionality complexity', {
         evaluator: MeaningDirectnessEvaluator.metadata.id,

--- a/sdks/typescript/src/evaluators/meaning-directness.ts
+++ b/sdks/typescript/src/evaluators/meaning-directness.ts
@@ -30,8 +30,8 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/meaning-di
  * });
  *
  * const result = await evaluator.evaluate(text, "6");
- * console.log(result.score); // "Moderately complex"
- * console.log(result.reasoning);
+ * console.log(result.result.complexity_score); // "Moderately complex"
+ * console.log(result.result.reasoning);
  * ```
  */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
@@ -72,21 +72,23 @@ export class MeaningDirectnessEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: MeaningDirectnessInput): Promise<EvaluationResult<MeaningDirectnessInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Meaning Directness evaluation', {
-      evaluator: MeaningDirectnessEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
-      // Validate inputs — inside try so validation errors are telemetered.
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Meaning Directness evaluation', {
+        evaluator: MeaningDirectnessEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
 
       this.logger.debug('Evaluating conventionality complexity', {
         evaluator: MeaningDirectnessEvaluator.metadata.id,

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -71,20 +71,23 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: OrganizationalStructureInput): Promise<EvaluationResult<OrganizationalStructureInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Organizational Structure evaluation', {
-      evaluator: OrganizationalStructureEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Organizational Structure evaluation', {
+        evaluator: OrganizationalStructureEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
 
       const fkScore = OrganizationalStructureEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/organizational-structure.ts
@@ -8,6 +8,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/organizational-struct
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
@@ -34,6 +35,8 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: SUPPORTED_GRADES,
     defaultProviders: [Provider.Google] as const,
   };
@@ -68,6 +71,7 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: OrganizationalStructureInput): Promise<EvaluationResult<OrganizationalStructureInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Organizational Structure evaluation', {
@@ -81,7 +85,6 @@ export class OrganizationalStructureEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = OrganizationalStructureEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/purpose-clarity.ts
@@ -5,6 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/purpose-clarity/index
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
@@ -31,6 +32,8 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: SUPPORTED_GRADES,
     defaultProviders: [Provider.Google] as const,
   };
@@ -64,6 +67,7 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: PurposeClarityInput): Promise<EvaluationResult<PurposeClarityInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Purpose Clarity evaluation', {
@@ -77,7 +81,6 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = PurposeClarityEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/purpose-clarity.ts
@@ -67,20 +67,23 @@ export class PurposeClarityEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: PurposeClarityInput): Promise<EvaluationResult<PurposeClarityInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Purpose Clarity evaluation', {
-      evaluator: PurposeClarityEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text?.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Purpose Clarity evaluation', {
+        evaluator: PurposeClarityEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text?.length,
+      });
 
       const fkScore = PurposeClarityEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
@@ -5,6 +5,7 @@ import { getSystemPrompt, getUserPrompt } from '../prompts/reference-knowledge-d
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
 import CONFIG from '../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
@@ -31,6 +32,8 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: SUPPORTED_GRADES,
     defaultProviders: [Provider.Google] as const,
   };
@@ -65,6 +68,7 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: ReferenceKnowledgeDemandsInput): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Reference Knowledge Demands evaluation', {
@@ -78,7 +82,6 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
     const stageDetails: StageDetail[] = [];
 
     try {
-      validateInputs(input, INPUT_SCHEMA);
 
       const fkScore = ReferenceKnowledgeDemandsEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/reference-knowledge-demands.ts
@@ -68,20 +68,23 @@ export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: ReferenceKnowledgeDemandsInput): Promise<EvaluationResult<ReferenceKnowledgeDemandsInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Reference Knowledge Demands evaluation', {
-      evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Reference Knowledge Demands evaluation', {
+        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
 
       const fkScore = ReferenceKnowledgeDemandsEvaluator.computeFkScore(text);
       const promptInputs: Record<string, string> = {

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -16,6 +16,7 @@ import {
 import type { EvaluationResult, TextComplexityLevel } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/sentence-structure/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, LLMOutputProcessingError, wrapProviderError } from '../errors.js';
@@ -76,6 +77,8 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
     defaultProviders: [Provider.OpenAI] as const,
   };
@@ -102,6 +105,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: SentenceStructureInput): Promise<EvaluationResult<ComplexityClassification>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting sentence structure evaluation', {
@@ -116,7 +120,6 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
 
     try {
       // Validate inputs — inside try so validation errors are telemetered.
-      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Stage 1: Analyzing sentence structure', {
         evaluator: SentenceStructureEvaluator.metadata.id,
         operation: 'sentence_analysis',
@@ -195,7 +198,7 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
         evaluator: SentenceStructureEvaluator.metadata.id,
         operation: 'evaluate',
         gradeLevel,
-        score: complexityResponse.data.answer,
+        score: complexityResponse.data.complexity_score,
         processingTimeMs: latencyMs,
       });
 
@@ -306,20 +309,20 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
     });
 
     // Normalize label to handle LLM output variations
-    const normalizedAnswer = normalizeLabel(response.data.answer);
+    const normalizedAnswer = normalizeLabel(response.data.complexity_score);
 
     if (!normalizedAnswer) {
       throw new LLMOutputProcessingError(
-        `Failed to normalize complexity label. Received unexpected value: "${response.data.answer}". ` +
+        `Failed to normalize complexity label. Received unexpected value: "${response.data.complexity_score}". ` +
         `Expected one of: Slightly Complex, Moderately Complex, Very Complex, Exceedingly Complex, Extremely Complex.`,
-        [{ path: 'answer', received: response.data.answer }]
+        [{ path: 'complexity_score', received: response.data.complexity_score }]
       );
     }
 
     return {
       data: {
         ...response.data,
-        answer: normalizedAnswer,
+        complexity_score: normalizedAnswer,
       },
       usage: response.usage,
       latencyMs: response.latencyMs,

--- a/sdks/typescript/src/evaluators/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/sentence-structure.ts
@@ -63,8 +63,8 @@ function normalizeLabel(label: string | null | undefined): TextComplexityLevel |
  * });
  *
  * const result = await evaluator.evaluate(text, "3");
- * console.log(result.score); // "Moderately complex"
- * console.log(result.reasoning);
+ * console.log(result.result.complexity_score); // "Moderately complex"
+ * console.log(result.result.reasoning);
  * ```
  */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
@@ -105,21 +105,24 @@ export class SentenceStructureEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: SentenceStructureInput): Promise<EvaluationResult<ComplexityClassification>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting sentence structure evaluation', {
-      evaluator: SentenceStructureEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
 
     try {
-      // Validate inputs — inside try so validation errors are telemetered.
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting sentence structure evaluation', {
+        evaluator: SentenceStructureEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
+
       this.logger.debug('Stage 1: Analyzing sentence structure', {
         evaluator: SentenceStructureEvaluator.metadata.id,
         operation: 'sentence_analysis',

--- a/sdks/typescript/src/evaluators/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/vocabulary-complexity.ts
@@ -13,6 +13,7 @@ import {
 import type { EvaluationResult } from '../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from './base.js';
 import { validateInputs, type InputsOf } from './inputs.js';
+import { declaredCredentials } from './credentials.js';
 import INPUT_SCHEMA from '../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json';
 import type { StageDetail } from '../telemetry/index.js';
 import { EvaluatorError, wrapProviderError } from '../errors.js';
@@ -54,6 +55,8 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     idHistory: CONFIG.evaluator.id_history,
     name: CONFIG.evaluator.name,
     description: CONFIG.evaluator.description,
+    outcome: CONFIG.outcome,
+    requiredCredentials: declaredCredentials(CONFIG),
     supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
     defaultProviders: [Provider.Google, Provider.OpenAI] as const,
   };
@@ -94,6 +97,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: VocabularyComplexityInput): Promise<EvaluationResult<VocabularyComplexityInternal>> {
+    validateInputs(input, INPUT_SCHEMA);
     const { text, grade_level: gradeLevel } = input;
 
     this.logger.info('Starting Vocabulary Complexity evaluation', {
@@ -118,7 +122,6 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     try {
       // Validate inputs — inside try so validation errors are telemetered.
       // If partners consistently pass invalid grade levels/text, telemetry will surface documentation gaps.
-      validateInputs(input, INPUT_SCHEMA);
       this.logger.debug('Stage 1: Generating background knowledge', {
         evaluator: VocabularyComplexityEvaluator.metadata.id,
         operation: 'background_knowledge',

--- a/sdks/typescript/src/evaluators/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/vocabulary-complexity.ts
@@ -41,8 +41,8 @@ import CONFIG from '../../../../evals/student-facing-text/ela-reading/vocabulary
  * });
  *
  * const result = await evaluator.evaluate(text, "3");
- * console.log(result.score); // "Moderately complex"
- * console.log(result.reasoning);
+ * console.log(result.result.complexity_score); // "Moderately complex"
+ * console.log(result.result.reasoning);
  * ```
  */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
@@ -97,16 +97,8 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
    * @throws {LLMOutputProcessingError} If the model's response fails its output schema
    */
   async evaluate(input: VocabularyComplexityInput): Promise<EvaluationResult<VocabularyComplexityInternal>> {
-    validateInputs(input, INPUT_SCHEMA);
-    const { text, grade_level: gradeLevel } = input;
-
-    this.logger.info('Starting Vocabulary Complexity evaluation', {
-      evaluator: VocabularyComplexityEvaluator.metadata.id,
-      operation: 'evaluate',
-      gradeLevel,
-      textLength: text.length,
-    });
-
+    let text = '';
+    let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
     const complexityProvider = (gradeLevel === '3' || gradeLevel === '4')
@@ -120,7 +112,17 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
       : `${backgroundProviderLabel}+${complexityProviderLabel}`;
 
     try {
-      // Validate inputs — inside try so validation errors are telemetered.
+      // Inside the try so a validation failure is telemetered as an error event,
+      // and before the inputs are read so a non-object is reported as one.
+      validateInputs(input, INPUT_SCHEMA);
+      ({ text, grade_level: gradeLevel } = input);
+
+      this.logger.info('Starting Vocabulary Complexity evaluation', {
+        evaluator: VocabularyComplexityEvaluator.metadata.id,
+        operation: 'evaluate',
+        gradeLevel,
+        textLength: text.length,
+      });
       // If partners consistently pass invalid grade levels/text, telemetry will surface documentation gaps.
       this.logger.debug('Stage 1: Generating background knowledge', {
         evaluator: VocabularyComplexityEvaluator.metadata.id,

--- a/sdks/typescript/src/schemas/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/schemas/grade-level-appropriateness.ts
@@ -17,8 +17,10 @@ export const GradeLevelAppropriatenessOutputSchema = z.object({
     .describe(
       'Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis.'
     ),
-  grade: GradeBand.describe('The appropriate grade level for the text'),
-  alternative_grade: GradeBand.describe('An alternative grade level for the text'),
+  grade_band: GradeBand.describe('Target grade band for the text at independent reading.'),
+  alternative_grade_band: GradeBand.describe(
+    'A second grade band that could read and comprehend the text with the scaffolding named in scaffolding_needed, or as a read-aloud.',
+  ),
   scaffolding_needed: z
     .string()
     .describe('Scaffolding needed for the text to be appropriate for the alternative grade'),

--- a/sdks/typescript/src/schemas/outcome.ts
+++ b/sdks/typescript/src/schemas/outcome.ts
@@ -4,11 +4,17 @@
  * The result envelope carries the payload exactly as the registry declares it, so
  * there is no top-level score to read. Batch runs and reports still need a single
  * scalar per evaluation to sort, group and chart on, and this is where that is
- * derived — once, from the shape the contracts already share, rather than in a
- * per-evaluator table each SDK would have to keep in step.
+ * read from the evaluator's declared `outcome` block, so no SDK keeps a per-evaluator
+ * table of which field holds the verdict.
  */
 
 import type { EvaluationResult } from './outputs.js';
+
+/** The `outcome` block an evaluator's contract declares. */
+export interface DeclaredOutcome {
+  readonly score: string;
+  readonly reasoning: string;
+}
 
 /**
  * The scalar verdict and its rationale, as a report consumes them.
@@ -22,22 +28,6 @@ export interface Outcome {
   reasoning: string;
 }
 
-/**
- * Evaluators whose verdict is not a `*_score` field.
- *
- * Grade Level Appropriateness answers with a grade band rather than a complexity
- * level, so its verdict field is a band and there is no score to find. It will stay
- * listed here after the rename to `grade_band`.
- *
- * Sentence Structure is listed only until its Zod schema is generated from its
- * contract, which declares `complexity_score`; the SDK currently asks the model for
- * `answer`.
- */
-const VERDICT_FIELD_OVERRIDES: Readonly<Record<string, string>> = {
-  'student_facing_text.ela_reading.grade_level_appropriateness': 'grade',
-  'student_facing_text.ela_reading.sentence_structure': 'answer',
-};
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -45,28 +35,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Pick the verdict and reasoning out of an evaluation's payload.
  *
- * By convention every payload carries exactly one property ending in `_score`
- * (`complexity_score`, `quality_score`) plus `reasoning`; evaluators that break the
- * convention are listed above. A payload with no verdict field yields an
- * undefined score rather than throwing — a missing verdict is a reporting gap, not a
- * reason to fail an evaluation that already succeeded.
+ * `outcome` is the evaluator's declared `outcome` block, naming which payload
+ * properties hold them — so this reads the contract rather than guessing from a field
+ * suffix, and a new evaluator needs no registration here at all.
+ *
+ * An evaluator with no declared outcome, or a payload missing the declared property,
+ * yields an undefined score rather than throwing: a missing verdict is a reporting gap,
+ * not a reason to fail an evaluation that already succeeded.
  */
-export function readOutcome({ evaluator, result }: EvaluationResult): Outcome {
-  if (!isRecord(result)) return { score: undefined, reasoning: '' };
+export function readOutcome(
+  { result }: EvaluationResult,
+  outcome: DeclaredOutcome | undefined,
+): Outcome {
+  if (!isRecord(result) || !outcome) return { score: undefined, reasoning: '' };
 
-  // An override only wins while its field is actually present, so an evaluator that
-  // later adopts the convention starts working without anyone remembering to delete
-  // its entry — the alternative silently reports no verdict at all.
-  //
-  // `''` stands in for "no field": no payload declares an empty key, so both lookups
-  // below miss and the outcome comes back blank.
-  const declared = VERDICT_FIELD_OVERRIDES[evaluator] ?? '';
-  const field = declared in result
-    ? declared
-    : Object.keys(result).find((key) => key.endsWith('_score')) ?? '';
-
-  const score = result[field];
-  const reasoning = result['reasoning'];
+  const score = result[outcome.score];
+  const reasoning = result[outcome.reasoning];
 
   return {
     score: score === undefined || score === null ? undefined : String(score),

--- a/sdks/typescript/src/schemas/sentence-structure.ts
+++ b/sdks/typescript/src/schemas/sentence-structure.ts
@@ -69,7 +69,7 @@ export type SentenceAnalysis = z.infer<typeof SentenceAnalysisSchema>;
  */
 export const ComplexityClassificationSchema = z.object({
   reasoning: z.string().describe('Detailed pedagogically appropriate reasoning'),
-  answer: TextComplexityLevel,
+  complexity_score: TextComplexityLevel,
 });
 
 export type ComplexityClassification = z.infer<typeof ComplexityClassificationSchema>;

--- a/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
+++ b/sdks/typescript/tests/integration/anthropic-provider.integration.test.ts
@@ -47,7 +47,7 @@ function anthropicConfig(): BaseEvaluatorConfig {
 
 /** Per-entry `run` so each evaluator is called with its real arity — GLA takes only `text`. */
 const EVALUATORS: Array<{
-  metadata: { id: string; name: string };
+  metadata: { id: string; name: string; outcome?: { score: string; reasoning: string } };
   run: (config: BaseEvaluatorConfig) => Promise<EvaluationResult<unknown>>;
 }> = [
   {
@@ -71,7 +71,7 @@ describeIntegration('Anthropic provider — all text-complexity evaluators (live
         // readOutcome is the only generic way to reach a verdict now that the
         // envelope carries the payload as its contract declares it. Asserting
         // through it here covers every evaluator's payload shape at once.
-        const outcome = readOutcome(result);
+        const outcome = readOutcome(result, metadata.outcome);
 
         expect(outcome.score).toBeTruthy();
         expect(outcome.reasoning.length).toBeGreaterThan(0);

--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration('modelOverride — model validity (live API)', () => {
     });
 
     const result = await evaluator.evaluate({ text: SAMPLE_TEXT, grade_level: '5' });
-    expect(result.result.answer).toBeDefined();
+    expect(result.result.complexity_score).toBeDefined();
     expect(result.metadata.model).toMatch(/^openai:gpt-4o-mini/);
   }, TEST_TIMEOUT_MS);
 

--- a/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/anthropic-override.test.ts
@@ -87,7 +87,7 @@ describe('Anthropic modelOverride — plumbing', () => {
           modelOverride: { provider: Provider.Anthropic, model: ANTHROPIC_MODEL },
           telemetry: false,
         }),
-    ).toThrow(/Anthropic API key is required/);
+    ).toThrow(/Missing required credential: anthropicApiKey/);
   });
 });
 

--- a/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/background-knowledge-demands.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../src/telemetry/client.js', () => ({
 describe('BackgroundKnowledgeDemandsEvaluator - Constructor Validation', () => {
   it('should throw with specific message when Google API key is missing', () => {
     expect(() => new BackgroundKnowledgeDemandsEvaluator({ googleApiKey: '' })).toThrow(
-      `Google API key is required for ${BackgroundKnowledgeDemandsEvaluator.metadata.name}. Pass googleApiKey in config.`
+      `Missing required credential: googleApiKey. Required by ${BackgroundKnowledgeDemandsEvaluator.metadata.name}.`
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/credentials.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/credentials.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { declaredCredentials, configFieldFor } from '../../../src/evaluators/credentials.js';
+import { MathStandardsAlignmentEvaluator } from '../../../src/evaluators/index.js';
+import MATH_CONFIG from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json';
+
+describe('declaredCredentials', () => {
+  it('collects what the real contract declares', () => {
+    expect(declaredCredentials(MATH_CONFIG)).toEqual(['learning_commons_api_key']);
+  });
+
+  it('reaches an evaluator through its metadata', () => {
+    // How the declaration becomes load-bearing: without this the contract is inert.
+    expect(MathStandardsAlignmentEvaluator.metadata.requiredCredentials).toEqual([
+      'learning_commons_api_key',
+    ]);
+  });
+
+  it('returns nothing when a contract declares no non-LLM service', () => {
+    expect(declaredCredentials({ steps: [{ id: 'evaluate_x' }] })).toEqual([]);
+  });
+
+  it('excludes an optional step', () => {
+    // The reason this is declared per entry rather than per evaluator: an optional step
+    // runs only when a caller opts in, so requiring its credential up front would
+    // demand a key for a call that never happens.
+    const credentials = declaredCredentials({
+      steps: [
+        { id: 'always', required_credentials: ['learning_commons_api_key'] },
+        { id: 'opt_in', optional: true, required_credentials: ['some_other_api_key'] },
+      ],
+    });
+
+    expect(credentials).toEqual(['learning_commons_api_key']);
+  });
+
+  it('includes a non-optional step that declares one', () => {
+    expect(
+      declaredCredentials({ steps: [{ id: 's', required_credentials: ['learning_commons_api_key'] }] }),
+    ).toEqual(['learning_commons_api_key']);
+  });
+
+  it('reads preprocessing entries as well as steps', () => {
+    expect(
+      declaredCredentials({
+        preprocessing: [{ id: 'fetch', required_credentials: ['learning_commons_api_key'] }],
+        steps: [{ id: 's' }],
+      }),
+    ).toEqual(['learning_commons_api_key']);
+  });
+
+  it('reports each credential once, however many entries need it', () => {
+    expect(
+      declaredCredentials({
+        preprocessing: [
+          { id: 'a', required_credentials: ['learning_commons_api_key'] },
+          { id: 'b', required_credentials: ['learning_commons_api_key'] },
+        ],
+        steps: [{ id: 's', required_credentials: ['learning_commons_api_key'] }],
+      }),
+    ).toEqual(['learning_commons_api_key']);
+  });
+});
+
+describe('configFieldFor', () => {
+  // §3.1: rendering a canonical key is §2.1's mechanical casing map, so this is a
+  // formula and a provider added later needs no entry anywhere.
+  it.each([
+    ['openai_api_key', 'openaiApiKey'],
+    ['google_api_key', 'googleApiKey'],
+    ['anthropic_api_key', 'anthropicApiKey'],
+    ['learning_commons_api_key', 'learningCommonsApiKey'],
+  ])('%s -> %s', (canonical, field) => {
+    expect(configFieldFor(canonical)).toBe(field);
+  });
+
+  it('leaves an already-camelCase key alone', () => {
+    expect(configFieldFor('googleApiKey')).toBe('googleApiKey');
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/functional-api.test.ts
@@ -38,8 +38,8 @@ const RESPONSE = {
   data: {
     complexity_level: 'Very complex',
     complexity_score: 'very_complex',
-    grade: '6-8',
-    alternative_grade: '9-10',
+    grade_band: '6-8',
+    alternative_grade_band: '9-10',
     scaffolding_needed: 'none',
     reasoning: 'because',
     grade_context: 'above grade',
@@ -134,7 +134,7 @@ describe('functional API wrappers', () => {
   it('evaluateGradeLevelAppropriateness takes no gradeLevel', async () => {
     const result = await evaluateGradeLevelAppropriateness({ text: TEXT }, CONFIG);
 
-    expect(result.result.grade).toBe('6-8');
+    expect(result.result.grade_band).toBe('6-8');
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(1);
   });
 

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -73,8 +73,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       // Mock grade level response
       vi.mocked(mockProvider.generateStructured).mockResolvedValue({
         data: {
-          grade: '6-8',
-          alternative_grade: '4-5',
+          grade_band: '6-8',
+          alternative_grade_band: '4-5',
           scaffolding_needed: 'Pre-teach gravitational forces; Use visual diagrams of moon-sun-earth system',
           reasoning: 'The text discusses gravitational forces and celestial mechanics, which are appropriate for middle school science curriculum.',
         },
@@ -90,10 +90,10 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate({ text: testText });
 
       // Verify result structure
-      expect(result.result.grade).toBe('6-8');
+      expect(result.result.grade_band).toBe('6-8');
       expect(result.result).toBeDefined();
-      expect(result.result!.grade).toBe('6-8');
-      expect(result.result!.alternative_grade).toBe('4-5');
+      expect(result.result!.grade_band).toBe('6-8');
+      expect(result.result!.alternative_grade_band).toBe('4-5');
       expect(result.result!.scaffolding_needed).toContain('gravitational forces');
       expect(result.result.reasoning).toContain('gravitational forces');
       expect(result.metadata).toBeDefined();
@@ -140,8 +140,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
     it('should return correct result structure', async () => {
       vi.mocked(mockProvider.generateStructured).mockResolvedValue({
         data: {
-          grade: '9-10',
-          alternative_grade: '6-8',
+          grade_band: '9-10',
+          alternative_grade_band: '6-8',
           scaffolding_needed: 'Pre-teach advanced vocabulary; Provide background context',
           reasoning: 'Detailed reasoning about grade appropriateness',
         },
@@ -159,11 +159,11 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       expect(result).not.toHaveProperty('score');
 
       // Verify score is the grade string
-      expect(result.result.grade).toBe('9-10');
+      expect(result.result.grade_band).toBe('9-10');
 
       // Verify _internal structure (GradeLevelAppropriateness)
-      expect(result.result).toHaveProperty('grade');
-      expect(result.result).toHaveProperty('alternative_grade');
+      expect(result.result).toHaveProperty('grade_band');
+      expect(result.result).toHaveProperty('alternative_grade_band');
       expect(result.result).toHaveProperty('scaffolding_needed');
       expect(result.result).toHaveProperty('reasoning');
 
@@ -178,8 +178,8 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       expect(result.metadata.tokenUsage.outputTokens).toBe(150);
 
       // Verify _internal values
-      expect(result.result!.grade).toBe('9-10');
-      expect(result.result!.alternative_grade).toBe('6-8');
+      expect(result.result!.grade_band).toBe('9-10');
+      expect(result.result!.alternative_grade_band).toBe('6-8');
       expect(result.result!.scaffolding_needed).toBeTruthy();
     });
   });

--- a/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/llm-provider.test.ts
@@ -17,8 +17,8 @@ import type { LLMProvider } from '../../../src/providers/base.js';
  */
 
 const GLA_DATA = {
-  grade: '6-8',
-  alternative_grade: '4-5',
+  grade_band: '6-8',
+  alternative_grade_band: '4-5',
   scaffolding_needed: 'Pre-teach vocabulary; use diagrams',
   reasoning: 'Middle-school-appropriate science prose.',
 };
@@ -64,7 +64,7 @@ describe('llmProvider — bring-your-own-provider', () => {
     const result = await evaluator.evaluate({ text: SAMPLE_TEXT });
 
     expect(generateStructured).toHaveBeenCalledTimes(1);
-    expect(result.result.grade).toBe('6-8');
+    expect(result.result.grade_band).toBe('6-8');
     expect(result.metadata.model).toBe('vertex:gemini-2.5-pro');
     // The injected provider is the one in use, not a createProvider-built one.
     // @ts-expect-error accessing private property for testing

--- a/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/meaning-directness.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../../src/telemetry/client.js', () => ({
 describe('MeaningDirectnessEvaluator - Constructor Validation', () => {
   it('should throw with specific message when Google API key is missing', () => {
     expect(() => new MeaningDirectnessEvaluator({ googleApiKey: '' })).toThrow(
-      `Google API key is required for ${MeaningDirectnessEvaluator.metadata.name}. Pass googleApiKey in config.`
+      `Missing required credential: googleApiKey. Required by ${MeaningDirectnessEvaluator.metadata.name}.`
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -59,7 +59,7 @@ const MOCK_RESPONSE = {
 describe('OrganizationalStructureEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
     expect(() => new OrganizationalStructureEvaluator({ googleApiKey: '' })).toThrow(
-      /Google API key is required/,
+      /Missing required credential: googleApiKey/,
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
@@ -58,7 +58,7 @@ const MOCK_RESPONSE = {
 describe('PurposeClarityEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
     expect(() => new PurposeClarityEvaluator({ googleApiKey: '' })).toThrow(
-      /Google API key is required/,
+      /Missing required credential: googleApiKey/,
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
@@ -58,7 +58,7 @@ const MOCK_RESPONSE = {
 describe('ReferenceKnowledgeDemandsEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
     expect(() => new ReferenceKnowledgeDemandsEvaluator({ googleApiKey: '' })).toThrow(
-      /Google API key is required/,
+      /Missing required credential: googleApiKey/,
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/sentence-structure.test.ts
@@ -127,7 +127,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
         })
         .mockResolvedValueOnce({
           data: {
-            answer: 'Slightly complex',
+            complexity_score: 'Slightly complex',
             reasoning: 'The text uses simple sentence structures appropriate for third grade.',
           },
           model: 'gpt-4o',
@@ -139,7 +139,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
       const result = await evaluator.evaluate({ text: testText, grade_level: testGrade });
 
       // Verify result structure
-      expect(result.result.answer).toBe('Slightly complex');
+      expect(result.result.complexity_score).toBe('Slightly complex');
       expect(result.result.reasoning).toContain('simple sentence structures');
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe(EXPECTED_MODEL);
@@ -211,7 +211,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
         })
         .mockResolvedValueOnce({
           data: {
-            answer: 'Moderately complex',
+            complexity_score: 'Moderately complex',
             reasoning: 'Detailed reasoning here',
           },
           model: 'gpt-4o',
@@ -251,7 +251,7 @@ describe('SentenceStructureEvaluator - Evaluation Flow', () => {
           latencyMs: 1,
         })
         .mockResolvedValueOnce({
-          data: { answer: 'Moderately complex', reasoning: 'why' },
+          data: { complexity_score: 'Moderately complex', reasoning: 'why' },
           model: 'gpt-4o',
           usage: { inputTokens: 1, outputTokens: 1 },
           latencyMs: 1,

--- a/sdks/typescript/tests/unit/evaluators/validation-telemetry.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation-telemetry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeaningDirectnessEvaluator } from '../../../src/evaluators/meaning-directness.js';
+import { InputValidationError } from '../../../src/errors.js';
+
+/**
+ * §4: "Validation runs before every LLM call, inside the error-handling boundary, so
+ * failures are captured in telemetry as `error` events."
+ *
+ * Regression guard. Making the non-object guard reachable meant moving validation ahead
+ * of the input destructuring; done carelessly that also moves it outside the try, and
+ * validation failures stop being reported. Nothing caught that — the only evidence was
+ * a comment left describing the old control flow.
+ */
+
+const sent = vi.fn();
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class {
+    send = sent;
+  },
+}));
+
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createProvider: vi.fn(() => ({
+      label: 'google:stub',
+      generateStructured: vi.fn(),
+      generateText: vi.fn(),
+    })),
+  };
+});
+
+const evaluator = () => new MeaningDirectnessEvaluator({ googleApiKey: 'k' });
+
+beforeEach(() => {
+  sent.mockClear();
+  sent.mockResolvedValue(undefined);
+});
+
+describe('a validation failure is telemetered', () => {
+  it('reports an error event, naming the error class', async () => {
+    await expect(
+      evaluator().evaluate({ text: 'too short', grade_level: '5' }),
+    ).rejects.toThrow(InputValidationError);
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    expect(sent.mock.calls[0][0]).toMatchObject({
+      status: 'error',
+      error_code: 'InputValidationError',
+    });
+  });
+
+  it('reports an error event even when the input is not an object', async () => {
+    // The path that used to raise a bare TypeError before any telemetry ran.
+    await expect(evaluator().evaluate(null as never)).rejects.toThrow(InputValidationError);
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    expect(sent.mock.calls[0][0]).toMatchObject({
+      status: 'error',
+      error_code: 'InputValidationError',
+    });
+  });
+
+  it('makes no LLM call when validation fails', async () => {
+    await expect(evaluator().evaluate({ text: 'x', grade_level: '5' })).rejects.toThrow(
+      InputValidationError,
+    );
+
+    // §4 puts validation before every LLM call; a rejected input must cost nothing.
+    expect(sent.mock.calls[0][0].token_usage).toBeUndefined();
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { VocabularyComplexityEvaluator } from '../../../src/evaluators/vocabulary-complexity.js';
 import { BackgroundKnowledgeDemandsEvaluator } from '../../../src/evaluators/background-knowledge-demands.js';
+import { MeaningDirectnessEvaluator } from '../../../src/evaluators/meaning-directness.js';
 import { Provider, BaseEvaluator } from '../../../src/evaluators/base.js';
 import MD_INPUT_SCHEMA from '../../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
 
@@ -53,6 +54,21 @@ describe('Configuration Validation', () => {
       googleApiKey: 'test-google-key',
       openaiApiKey: '',
     })).toThrow(ConfigurationError);
+  });
+});
+
+describe('Input validation runs before anything reads the inputs', () => {
+  // Regression: the guard existed but every evaluator destructured `input` first, so a
+  // non-object raised a TypeError before validation ran. Testing validateInputs alone
+  // passed; nothing tested the path a caller actually takes.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'just some text'],
+  ])('rejects %s through evaluate() with a canonical error', async (_label, bad) => {
+    const evaluator = new MeaningDirectnessEvaluator({ googleApiKey: 'k', telemetry: false });
+
+    await expect(evaluator.evaluate(bad as never)).rejects.toThrow(InputValidationError);
   });
 });
 

--- a/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
@@ -41,14 +41,14 @@ describe('VocabularyComplexityEvaluator - Constructor Validation', () => {
     expect(() => new VocabularyComplexityEvaluator({
       googleApiKey: '',
       openaiApiKey: 'test-openai-key',
-    })).toThrow(`Google API key is required for ${VocabularyComplexityEvaluator.metadata.name}. Pass googleApiKey in config.`);
+    })).toThrow(`Missing required credential: googleApiKey. Required by ${VocabularyComplexityEvaluator.metadata.name}.`);
   });
 
   it('should throw error when OpenAI API key is missing', () => {
     expect(() => new VocabularyComplexityEvaluator({
       googleApiKey: 'test-google-key',
       openaiApiKey: '',
-    })).toThrow(`OpenAI API key is required for ${VocabularyComplexityEvaluator.metadata.name}. Pass openaiApiKey in config.`);
+    })).toThrow(`Missing required credential: openaiApiKey. Required by ${VocabularyComplexityEvaluator.metadata.name}.`);
   });
 
 });

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -207,14 +207,6 @@ const SDK_OUTPUT_SCHEMAS: Record<string, { shape: Record<string, unknown> }> = {
   [SentenceStructureEvaluator.metadata.id]: ComplexityClassificationSchema,
 };
 
-/** Evaluators whose sent schema does not match their contract's declared payload. */
-const SCHEMA_GAPS = new Set<string>([
-  // Sends `grade` / `alternative_grade`; the contract declares `grade_band` /
-  // `alternative_grade_band`, and its enum says `11-12` where the SDK says `11-CCR`.
-  GLA_ID,
-  // Sends `answer`; the contract declares `complexity_score`.
-  SENTENCE_ID,
-]);
 
 // ---------------------------------------------------------------------------
 // Contract loading
@@ -240,6 +232,7 @@ interface Contract {
       generation?: { temperature?: number };
       optional?: boolean;
     }>;
+    outcome?: { score: string; reasoning: string };
   };
   inputSchema: { properties: Record<string, Record<string, unknown>>; required?: string[] };
   outputSchema: {
@@ -345,21 +338,19 @@ describe('identity matches the contract', () => {
 
 describe('supported grades match the contract', () => {
   it.each(cases)('$name', ({ E }) => {
-    const { config, inputSchema } = contractFor(E.metadata.id);
+    const { inputSchema } = contractFor(E.metadata.id);
 
-    // A grade-free evaluator declares no `grade_level` input; its contract's
-    // supported_grades then describes output bands, not accepted input.
-    const takesGrade = 'grade_level' in inputSchema.properties;
-    const declared = takesGrade
-      ? ((inputSchema.properties.grade_level.enum as string[]) ??
-         config.evaluator.supported_grades)
-      : [];
+    // `supported_grades` states what the evaluator is built for; the accepted set is
+    // the grade input's own enum. Comparing against the enum is the whole point -- an
+    // evaluator taking no grade accepts none, and asserting that by hardcoding `[]`
+    // would just restate the assumption.
+    const accepted = (inputSchema.properties.grade_level?.enum as string[]) ?? [];
 
     expectAgainstContract(
       GRADE_GAPS.has(E.metadata.id),
       [...E.metadata.supportedGrades],
-      declared,
-      `${E.metadata.name} supportedGrades`,
+      accepted,
+      `${E.metadata.name} supportedGrades vs the grades its input schema accepts`,
     );
   });
 });
@@ -393,12 +384,7 @@ describe('the schema the SDK sends matches the contract', () => {
     const sentFields = Object.keys(SDK_OUTPUT_SCHEMAS[E.metadata.id].shape).sort();
     const declared = Object.keys(outputSchema.properties).sort();
 
-    expectAgainstContract(
-      SCHEMA_GAPS.has(E.metadata.id),
-      sentFields,
-      declared,
-      `${E.metadata.name} sent payload fields`,
-    );
+    expect(sentFields, `${E.metadata.name} sent payload fields`).toEqual(declared);
   });
 });
 
@@ -425,9 +411,13 @@ describe('readOutcome finds a verdict in the payload the SDK actually returns', 
       },
     } as EvaluationResult;
 
+    // Read from the contract, not from metadata: this asserts the declaration and the
+    // payload agree, which is exactly what would drift.
+    const { outcome } = contractFor(E.metadata.id).config;
+
     expect(
-      readOutcome(envelope).score,
-      `${E.metadata.name}: readOutcome found no verdict in the payload the SDK returns`,
+      readOutcome(envelope, outcome).score,
+      `${E.metadata.name}: the payload the SDK returns has no ${outcome?.score ?? 'declared verdict'}`,
     ).toBeDefined();
   });
 });

--- a/sdks/typescript/tests/unit/schemas/outcome.test.ts
+++ b/sdks/typescript/tests/unit/schemas/outcome.test.ts
@@ -1,20 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { readOutcome } from '../../../src/schemas/outcome.js';
+import { readOutcome, type DeclaredOutcome } from '../../../src/schemas/outcome.js';
 import type { EvaluationResult } from '../../../src/schemas/index.js';
-import {
-  MeaningDirectnessEvaluator,
-  GradeLevelAppropriatenessEvaluator,
-  SentenceStructureEvaluator,
-  PurposeClarityEvaluator,
-} from '../../../src/evaluators/index.js';
+import { MeaningDirectnessEvaluator } from '../../../src/evaluators/index.js';
 
-const COMPLEXITY_ID = MeaningDirectnessEvaluator.metadata.id;
-const GLA_ID = GradeLevelAppropriatenessEvaluator.metadata.id;
-const SENTENCE_ID = SentenceStructureEvaluator.metadata.id;
+/**
+ * `readOutcome` reads the evaluator's declared `outcome` block. There is no convention
+ * to fall back on and no per-evaluator table, so these cover the declaration being
+ * honoured, absent, or pointing at something the payload does not have.
+ */
 
-/** Minimal envelope — readOutcome reads only `evaluator` and `result`. */
-const envelope = (evaluator: string, result: unknown): EvaluationResult => ({
-  evaluator,
+const envelope = (result: unknown): EvaluationResult => ({
+  evaluator: MeaningDirectnessEvaluator.metadata.id,
   result,
   metadata: {
     model: 'stub:model',
@@ -23,130 +19,108 @@ const envelope = (evaluator: string, result: unknown): EvaluationResult => ({
   },
 });
 
-describe('readOutcome — by convention', () => {
-  it('reads the single *_score property', () => {
+const COMPLEXITY: DeclaredOutcome = { score: 'complexity_score', reasoning: 'reasoning' };
+
+describe('readOutcome — the declaration is honoured', () => {
+  it('reads the declared properties', () => {
     const outcome = readOutcome(
-      envelope(COMPLEXITY_ID, { complexity_score: 'slightly_complex', reasoning: 'because' }),
+      envelope({ complexity_score: 'slightly_complex', reasoning: 'because' }),
+      COMPLEXITY,
     );
 
     expect(outcome).toEqual({ score: 'slightly_complex', reasoning: 'because' });
   });
 
-  it('reads a *_score property it has never seen before', () => {
-    // The convention is what makes a new evaluator work with no registration.
+  it('reads whatever the declaration names, with no convention involved', () => {
+    // A grade band is a verdict too; nothing here recognises `_score` suffixes.
     const outcome = readOutcome(
-      envelope('feedback.ela_writing.revision_accuracy', {
-        quality_score: 1,
-        reasoning: 'meets the criterion',
-      }),
-    );
-
-    expect(outcome).toEqual({ score: '1', reasoning: 'meets the criterion' });
-  });
-
-  it('does not treat `reasoning` as the verdict', () => {
-    const outcome = readOutcome(envelope(COMPLEXITY_ID, { reasoning: 'no verdict here' }));
-
-    expect(outcome).toEqual({ score: undefined, reasoning: 'no verdict here' });
-  });
-});
-
-describe('readOutcome — declared exceptions', () => {
-  it('reads the grade band for Grade Level Appropriateness', () => {
-    const outcome = readOutcome(
-      envelope(GLA_ID, { grade: '4-5', alternative_grade: '6-8', reasoning: 'band fits' }),
+      envelope({ grade_band: '4-5', reasoning: 'band fits' }),
+      { score: 'grade_band', reasoning: 'reasoning' },
     );
 
     expect(outcome.score).toBe('4-5');
   });
 
-  it('prefers the declared field over a *_score property that happens to exist', () => {
-    // Guards the precedence: GLA's payload gains a *_score field and the band must
-    // still win, otherwise the report silently starts charting the wrong value.
+  it('ignores a *_score property the declaration does not name', () => {
+    // Guards against the old convention creeping back: only the declared field counts.
     const outcome = readOutcome(
-      envelope(GLA_ID, { grade: '4-5', confidence_score: 0.9, reasoning: 'band fits' }),
+      envelope({ grade_band: '4-5', confidence_score: 0.9, reasoning: 'r' }),
+      { score: 'grade_band', reasoning: 'reasoning' },
     );
 
     expect(outcome.score).toBe('4-5');
-  });
-
-  it('falls back to the convention once the declared field is gone', () => {
-    // Sentence Structure's schema will be regenerated to `complexity_score`. If the
-    // stale `answer` entry still took precedence the verdict would silently go empty;
-    // instead the convention takes over and the entry becomes inert.
-    const outcome = readOutcome(
-      envelope(SENTENCE_ID, { complexity_score: 'moderately_complex', reasoning: 'mixed' }),
-    );
-
-    expect(outcome.score).toBe('moderately_complex');
-  });
-
-  it('reads `answer` for Sentence Structure', () => {
-    const outcome = readOutcome(
-      envelope(SENTENCE_ID, { answer: 'Moderately complex', reasoning: 'mixed structures' }),
-    );
-
-    expect(outcome.score).toBe('Moderately complex');
-  });
-
-  it('applies no exception to an evaluator that follows the convention', () => {
-    const outcome = readOutcome(
-      envelope(PurposeClarityEvaluator.metadata.id, {
-        complexity_score: 'very_complex',
-        reasoning: 'implicit purpose',
-      }),
-    );
-
-    expect(outcome.score).toBe('very_complex');
-  });
-});
-
-describe('readOutcome — payloads with nothing to read', () => {
-  // An absent verdict is surfaced as undefined rather than rendered as an empty string:
-  // it is a reporting gap, and throwing would fail an evaluation that already succeeded.
-  it.each([
-    ['null', null],
-    ['undefined', undefined],
-    ['a string', 'not a payload'],
-    ['a number', 7],
-    ['an empty object', {}],
-    ['an array', [{ complexity_score: 'slightly_complex' }]],
-  ])('returns an undefined score for %s', (_label, payload) => {
-    expect(readOutcome(envelope(COMPLEXITY_ID, payload))).toEqual({
-      score: undefined,
-      reasoning: '',
-    });
-  });
-
-  it('returns an undefined score when the declared field is absent', () => {
-    expect(readOutcome(envelope(GLA_ID, { reasoning: 'no band' }))).toEqual({
-      score: undefined,
-      reasoning: 'no band',
-    });
   });
 
   it('coerces a non-string verdict to a string', () => {
     const outcome = readOutcome(
-      envelope('feedback.ela_writing.tone_appropriateness', { quality_score: 0 }),
+      envelope({ quality_score: 0, reasoning: 'r' }),
+      { score: 'quality_score', reasoning: 'reasoning' },
     );
 
     expect(outcome.score).toBe('0');
   });
 
+  it('reads a reasoning property under a different name', () => {
+    const outcome = readOutcome(
+      envelope({ complexity_score: 'x', rationale: 'why' }),
+      { score: 'complexity_score', reasoning: 'rationale' },
+    );
+
+    expect(outcome.reasoning).toBe('why');
+  });
+});
+
+describe('readOutcome — nothing to read', () => {
+  // A missing verdict is a reporting gap, not a reason to fail an evaluation that
+  // already succeeded, so these report absence rather than throwing.
+  it('returns an undefined score when no outcome is declared', () => {
+    const outcome = readOutcome(envelope({ complexity_score: 'slightly_complex' }), undefined);
+
+    expect(outcome).toEqual({ score: undefined, reasoning: '' });
+  });
+
+  it('returns an undefined score when the declared property is absent', () => {
+    const outcome = readOutcome(envelope({ reasoning: 'no verdict' }), COMPLEXITY);
+
+    expect(outcome).toEqual({ score: undefined, reasoning: 'no verdict' });
+  });
+
+  it('treats a null verdict as absent', () => {
+    const outcome = readOutcome(envelope({ complexity_score: null, reasoning: 'r' }), COMPLEXITY);
+
+    expect(outcome.score).toBeUndefined();
+  });
+
   it('ignores a non-string reasoning rather than coercing it', () => {
     // A report prints reasoning verbatim; "[object Object]" is worse than blank.
     const outcome = readOutcome(
-      envelope(COMPLEXITY_ID, { complexity_score: 'x', reasoning: { a: 1 } }),
+      envelope({ complexity_score: 'x', reasoning: { a: 1 } }),
+      COMPLEXITY,
     );
 
     expect(outcome).toEqual({ score: 'x', reasoning: '' });
   });
 
-  it('treats a null verdict as absent', () => {
-    const outcome = readOutcome(
-      envelope(COMPLEXITY_ID, { complexity_score: null, reasoning: 'r' }),
-    );
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'not a payload'],
+    ['a number', 7],
+    ['an array', [{ complexity_score: 'slightly_complex' }]],
+  ])('returns an undefined score for %s', (_label, payload) => {
+    expect(readOutcome(envelope(payload), COMPLEXITY)).toEqual({
+      score: undefined,
+      reasoning: '',
+    });
+  });
+});
 
-    expect(outcome.score).toBeUndefined();
+describe('every evaluator that declares an outcome exposes it', () => {
+  it('carries the declaration on metadata', () => {
+    // How the declaration reaches readOutcome: without this the contract is inert.
+    expect(MeaningDirectnessEvaluator.metadata.outcome).toEqual({
+      score: 'complexity_score',
+      reasoning: 'reasoning',
+    });
   });
 });


### PR DESCRIPTION
32 files, +394/−247.

#214 declared which output properties carry the verdict, and which non-LLM credentials each entry needs — precisely so no SDK would have to infer either. **Nothing read either declaration.** `grep` for `.outcome` and `required_credentials` across `src/` returned nothing, so the duplication that PR existed to remove was still sitting there. This wires both.

## `readOutcome` reads the contract

It now takes the evaluator's declared `outcome` block, reached through `metadata`, which every evaluator already builds from its own config. The `*_score` convention and its override table are **gone**.

That table had drifted to disagree with the contracts it replaced:

| | contract | table said |
|---|---|---|
| GLA | `grade_band` | `grade` |
| Sentence Structure | `complexity_score` | `answer` |

So regenerating either schema would have silently blanked that evaluator's score in every report — no error, just empty cells.

## Both payloads renamed to what the prompts already ask for

**GLA's pinned prompt literally instructs** `"grade_band"`, `"alternative_grade_band"`, `"scaffolding_needed"` (`system.txt:121`) while the schema asked for `grade`/`alternative_grade`. The model was told one thing and constrained to another. Sentence Structure's prompt names no field at all, so `answer` was purely the SDK's invention.

Enum **values** are untouched — `11-CCR` versus the contract's `11-12` has to be atomic with the report's band list, so it stays in `BAND_GAPS` for the regeneration PR.

## Credentials are derived

LLM keys from the providers the steps use; non-LLM ones from `required_credentials`. Three changes fall out:

- `validateApiKeys` **no longer returns early under `modelOverride`**, so an override can't skip a credential for a service the evaluator still calls (Appendix A gap 20)
- the three parallel per-provider tables collapse into §2.1's casing formula, which §3.1 asks for by name: *"SDKs do not maintain per-key lookup tables"*
- math's hand-rolled Knowledge Graph check is gone; its `_kgClient` seam is now a **declared** exception via `credentialsSatisfiedByInjection`, generalising the rule that already applied to an injected `llmProvider` rather than special-casing math

## Three bugs, all mine

**`evaluate(null)` raised a `TypeError`, not `InputValidationError`.** The guard I added last PR was unreachable — every evaluator destructured `input` before validating. Testing `validateInputs` directly passed, which is exactly why it survived: *nothing tested the path a caller takes.* Validation now runs first, with a regression test at the `evaluate()` level, verified by putting the destructure back in front.

**The conformance grade check hardcoded `[]`** for grade-free evaluators instead of comparing anything — asserting its own assumption, passing green, and contradicting the semantics #214 pinned. It now compares the accepted grade enum.

**Credential messages** adopt §3.1's canonical wording, which the removed tables had been paraphrasing.

## `SCHEMA_GAPS` deleted

Both entries demanded deletion once the payloads matched their contracts — the self-cleaning allowlist firing for the third time.

## Validation

- `tsc --noEmit`, `npm run lint`, `npm run test:unit` (836), `npm run build`, `scripts/check.py`
- **Mutation testing:** `outcome.ts` **100%** (33 killed, 0 survivors) — reading a declaration leaves far less to get wrong than inferring one. `credentials.ts` **73% → 93%**, after adding a test that pins the optional-step exclusion, which is the entire reason credentials are declared per entry rather than per evaluator.
- Load-bearing checks: reintroduced the destructure-first ordering (2 of 3 cases fail — a string destructures without throwing, so it still reaches validation); confirmed both `SCHEMA_GAPS` entries demand deletion.

## Still open, deliberately

`BAND_GAPS` (`11-12`), `MODEL_GAPS` and `TEMPERATURE_GAPS` (GLA's model and temperature), `GRADE_GAPS` (math's bulk-method grade domain), `ORDER_GAPS`, and the 7 `UNIMPLEMENTED` feedback contracts. The `outcome` block is still unconsumed for math, which declares none — its payload is alignment counts, not a single judgement.
