### PR TITLE
feat(evals): require every fixture to pin the outcome score its contract declares

### DIFF
--- a/scripts/checks/eval_fixtures.py
+++ b/scripts/checks/eval_fixtures.py
@@ -1,12 +1,15 @@
 """Validate each evaluator's fixtures.json.
 
-Two layers, mirroring eval-config:
+Three layers, the first two mirroring eval-config:
   - shared structure: every case is {id, input, expected} per the shared
     evals/_schemas/fixtures.schema.json.
   - per-evaluator binding: each case's `input` must satisfy that evaluator's own
     input_schema.json, and each field in `expected` must satisfy the matching
     property in its output_schema.json. (`expected` is a subset of the full
     output — just the label(s) — so we validate present fields, not requireds.)
+  - outcome coverage: if the config declares `outcome.score`, every case must pin
+    that field. It is the only part of the output stable enough to assert, so a
+    fixture that omits it asserts nothing a caller depends on.
 """
 
 from __future__ import annotations
@@ -64,8 +67,12 @@ class EvalFixtures(Check):
             return  # per-case binding below assumes well-formed cases
 
         # Layer 2: bind input/expected to this evaluator's own schemas.
+        # Layer 3: every case pins the declared outcome score.
         input_validator = self._validator_for(config, base, "input_schema")
         expected_validator = self._expected_validator(config, base)
+        # Absent for evaluators whose payload has no single verdict field, such as
+        # Math Standards Alignment; `outcome` is optional in the config schema.
+        score_field = (config.get("outcome") or {}).get("score")
         for case in fixtures:
             cid = case.get("id", "?")
             if input_validator:
@@ -74,6 +81,11 @@ class EvalFixtures(Check):
             if expected_validator:
                 for err in expected_validator.iter_errors(case.get("expected", {})):
                     fail(f"{rel}[{cid}].expected: {self._loc(err)}: {err.message}")
+            if score_field and score_field not in case.get("expected", {}):
+                fail(
+                    f"{rel}[{cid}].expected: missing {score_field!r}, "
+                    f"the outcome score declared in config.json"
+                )
 
     def _validator_for(self, config: dict, base: str, key: str):
         ref = config.get(key, {})


### PR DESCRIPTION
A fixture records what the model returned for a real input. Only the verdict is stable enough to assert — reasoning and details are prose that varies per call — so the verdict is the one field a fixture has to carry. Nothing checked that it did.

`eval-fixtures` gains a third layer: if a config declares `outcome.score`, every case must pin that field.

```
evals/.../tone-appropriateness/config.json — fixtures.json[1].expected:
  missing 'quality_score', the outcome score declared in config.json
```

## Why it belongs in the harness

The rule is about contract quality, not SDK behaviour, so it holds regardless of language — putting it here means the Python SDK doesn't reproduce it later. It also reaches all 16 contracts, including the seven feedback evaluators that have no SDK module yet and so can't be covered by any SDK-side check.

## What it catches today

Nothing — all 16 contracts already comply. That was the point of checking before writing it: the convention was real but incidental.

| Contracts | `outcome.score` | fixture `expected` keys |
|---|---|---|
| 7 feedback | `quality_score` | `quality_score` |
| 6 complexity + sentence-structure | `complexity_score` | `complexity_score` |
| grade-level-appropriateness | `grade_band` | `grade_band`, `alternative_grade_band` |
| math-standards-alignment | *none declared* | `aligned`, `note` |

Math is exempt by construction: its payload is assembled from per-component results with no single verdict field, and `outcome` is optional in `config.schema.json`.

Worth noting what was previously legal: a fixture with `"expected": {}` passed every layer. It satisfies the shared schema and vacuously satisfies the per-field binding, so it asserted nothing at all.

## Validation

- `python scripts/check.py` — all 6 checks pass
- Load-bearing, two ways: deleted `quality_score` from a tone-appropriateness fixture, and separately emptied a meaning-directness fixture's `expected` entirely. Both fail with the message above; restored both and confirmed the tree is clean.
- Confirmed math still passes, so the `outcome`-absent path is exercised by a real contract rather than assumed

No unit test: `scripts/checks/` has no test suite, and CI runs the harness only via `python scripts/check.py`. Adding pytest plus a CI job for it is a larger change than this rule and worth its own discussion — flagging rather than smuggling it in here.
