### PR TITLE
fix(sdk)!: report the complexity model that actually ran for grades 3-4

### DIFF
--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -70,6 +70,16 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
   private otherGradesComplexityProvider: LLMProvider;
   private backgroundKnowledgeProvider: LLMProvider;
 
+  /**
+   * The complexity model for a grade. Grades 3-4 and 5-12 use different models, so
+   * every caller must agree on the choice — including the one that reports it.
+   */
+  private complexityProviderFor(gradeLevel: string): LLMProvider {
+    return gradeLevel === '3' || gradeLevel === '4'
+      ? this.grades34ComplexityProvider
+      : this.otherGradesComplexityProvider;
+  }
+
   constructor(config: BaseEvaluatorConfig) {
     // Call base constructor for common setup (telemetry, API key validation, etc.)
     super(config);
@@ -106,21 +116,21 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     let gradeLevel = '';
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
-    const complexityProvider = (gradeLevel === '3' || gradeLevel === '4')
-      ? this.grades34ComplexityProvider
-      : this.otherGradesComplexityProvider;
-    const complexityProviderLabel = complexityProvider.label;
     const backgroundProviderLabel = this.backgroundKnowledgeProvider.label;
-    // When override is active all providers resolve to the same model — show a single label.
-    const modelLabel = this.config.modelOverride
-      ? backgroundProviderLabel
-      : `${backgroundProviderLabel}+${complexityProviderLabel}`;
+    // Only the background model is known before the grade is read; if validation fails
+    // no complexity model runs, so the error event reports just this one.
+    let modelLabel = backgroundProviderLabel;
 
     try {
       // Inside the try so a validation failure is telemetered as an error event,
       // and before the inputs are read so a non-object is reported as one.
       validateInputs(input, INPUT_SCHEMA);
       ({ text, grade_level: gradeLevel } = input);
+
+      // When override is active all providers resolve to the same model — show a single label.
+      modelLabel = this.config.modelOverride
+        ? backgroundProviderLabel
+        : `${backgroundProviderLabel}+${this.complexityProviderFor(gradeLevel).label}`;
 
       this.logger.info('Starting Vocabulary Complexity evaluation', {
         evaluator: VocabularyComplexityEvaluator.metadata.id,
@@ -159,7 +169,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
 
       stageDetails.push({
         stage: 'complexity_evaluation',
-        provider: complexityProviderLabel,
+        provider: this.complexityProviderFor(gradeLevel).label,
         latency_ms: complexityResponse.latencyMs,
         token_usage: {
           input_tokens: complexityResponse.usage.inputTokens,
@@ -256,7 +266,9 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
       // failed; otherwise it completed and stage 2 (complexity) did. Attribute
       // to the provider that actually failed rather than a combined label.
       const failed =
-        stageDetails.length === 0 ? this.backgroundKnowledgeProvider : complexityProvider;
+        stageDetails.length === 0
+          ? this.backgroundKnowledgeProvider
+          : this.complexityProviderFor(gradeLevel);
       throw wrapProviderError(error, this.providerContext(failed));
     }
   }
@@ -303,9 +315,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     const systemPrompt = getSystemPrompt(gradeLevel);
     const userPrompt = getUserPrompt(text, gradeLevel, backgroundKnowledge, fkLevel);
 
-    const provider = (gradeLevel === '3' || gradeLevel === '4')
-      ? this.grades34ComplexityProvider
-      : this.otherGradesComplexityProvider;
+    const provider = this.complexityProviderFor(gradeLevel);
 
     const response = await provider.generateStructured({
       messages: [

--- a/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
@@ -280,3 +280,65 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
     });
   });
 });
+
+describe('VocabularyComplexityEvaluator - complexity model per grade', () => {
+  // The grade picks the complexity model, and the reported label has to name the one that
+  // ran. Every other test in this file uses grade 5+, so the grades 3-4 branch went
+  // unexercised and reported the grade 5-12 model for a year.
+  const BACKGROUND = 'openai:gpt-4o-2024-11-20';
+
+  const CASES = [
+    { grade: '3', provider: 'grades34ComplexityProvider', model: 'google:gemini-2.5-pro' },
+    { grade: '4', provider: 'grades34ComplexityProvider', model: 'google:gemini-2.5-pro' },
+    { grade: '5', provider: 'otherGradesComplexityProvider', model: 'openai:gpt-4.1-2025-04-14' },
+    { grade: '12', provider: 'otherGradesComplexityProvider', model: 'openai:gpt-4.1-2025-04-14' },
+  ] as const;
+
+  it.each(CASES)(
+    'grade $grade runs $model and reports it',
+    async ({ grade, provider, model }) => {
+      const evaluator = new VocabularyComplexityEvaluator({
+        googleApiKey: 'test-google-key',
+        openaiApiKey: 'test-openai-key',
+        telemetry: false,
+      });
+
+      const providers = evaluator as unknown as Record<string, LLMProvider>;
+      const background = providers.backgroundKnowledgeProvider;
+      const complexity = providers[provider];
+      const unused =
+        providers[
+          provider === 'grades34ComplexityProvider'
+            ? 'otherGradesComplexityProvider'
+            : 'grades34ComplexityProvider'
+        ];
+
+      vi.mocked(background.generateText).mockResolvedValue({
+        text: 'Students know weather words.',
+        usage: { inputTokens: 10, outputTokens: 5 },
+        latencyMs: 1,
+      });
+      vi.mocked(complexity.generateStructured).mockResolvedValue({
+        data: {
+          tier_2_words: 'gather',
+          tier_3_words: 'none',
+          archaic_words: 'none',
+          other_complex_words: 'none',
+          complexity_score: 'moderately_complex',
+          reasoning: 'Grade-appropriate vocabulary.',
+        },
+        model: 'whatever-the-provider-says',
+        usage: { inputTokens: 20, outputTokens: 10 },
+        latencyMs: 1,
+      });
+
+      const result = await evaluator.evaluate({ text: 'The storm gathered offshore.', grade_level: grade });
+
+      // The model that ran.
+      expect(complexity.generateStructured).toHaveBeenCalledTimes(1);
+      expect(unused.generateStructured).not.toHaveBeenCalled();
+      // The model that is reported. These two disagreeing is the bug.
+      expect(result.metadata.model).toBe(`${BACKGROUND}+${model}`);
+    },
+  );
+});

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -688,6 +688,48 @@ describe('the report can order every family member', () => {
   });
 });
 
+describe('the reported model matches the contract steps that apply', () => {
+  // A step can be conditional on an input, so which model runs depends on that input and
+  // the reported model has to follow. Every other invocation in this suite passes
+  // grade_level '5', which is why a conditional branch reporting the wrong model survived.
+  //
+  // Derived from the contract, so an evaluator that gains a conditional step is covered
+  // without touching this test.
+  const perGrade = cases.flatMap(({ name, E }) => {
+    if (!INVOKE[E.metadata.id]) return [];
+    const { config } = contractFor(E.metadata.id);
+    const grades = [
+      ...new Set(config.steps.flatMap((step) => (step.condition?.in ?? []).map(String))),
+    ];
+    return grades.map((grade) => ({ name, E, grade }));
+  });
+
+  it('finds at least one conditional step to exercise', () => {
+    // If this fails the suite below is vacuous — either the contracts lost their
+    // conditions or the derivation above stopped matching them.
+    expect(perGrade.length).toBeGreaterThan(0);
+  });
+
+  it.each(perGrade)('$name at grade $grade', async ({ E, grade }) => {
+    const { config } = contractFor(E.metadata.id);
+    const applies = (step: (typeof config.steps)[number]) =>
+      !step.condition ||
+      (step.condition.input === 'grade_level' && step.condition.in.map(String).includes(grade));
+
+    const expected = config.steps
+      .filter(applies)
+      .map((step) => `${step.model.provider}:${step.model.name}`)
+      .join('+');
+
+    const result = (await construct(E).evaluate({
+      text: 'The storm gathered offshore and the harbour emptied before dusk.',
+      grade_level: grade,
+    })) as { metadata: { model: string } };
+
+    expect(result.metadata.model, `${E.metadata.name} at grade ${grade}`).toBe(expected);
+  });
+});
+
 describe('the temperature sent matches the contract', () => {
   beforeEach(() => {
     llmCalls.length = 0;


### PR DESCRIPTION
For grades 3–4, Vocabulary Complexity ran `google:gemini-2.5-pro` but reported `openai:gpt-4.1-2025-04-14` in `metadata.model`, in telemetry, and in per-stage error attribution. Grades 5–12 were correct.

## Cause

`evaluate()` selected the complexity provider from `gradeLevel` **before** `gradeLevel` was assigned:

```ts
let gradeLevel = '';
const complexityProvider = (gradeLevel === '3' || gradeLevel === '4')   // always '' here
  ? this.grades34ComplexityProvider
  : this.otherGradesComplexityProvider;
```

So the ternary always took the else branch. A second copy of the same selection, inside the stage-2 helper, read the real grade — which is why the right model ran while the wrong one was reported.

Introduced in #216. Before it, `gradeLevel` was destructured on the first line of `evaluate`; hoisting it so `validateInputs` could move inside the try left this read above the assignment. I checked all nine evaluators — this is the only one affected.

The fix puts the selection in one place, `complexityProviderFor(gradeLevel)`, used by all three call sites, and builds the label after the grade is read. Two copies of a decision are what let them disagree.

Error attribution was wrong too, not just reporting: the catch block chose the provider to blame from the same stale variable.

## Why no test caught it

Both categories, in two layers.

**Untested branch.** Every Vocabulary Complexity unit test uses grade 5 or 6:

```
5 × grade 5
1 × grade 6
```

The test harness said so explicitly — `// Tests use grade 5+, which routes to otherGradesComplexityProvider (GPT-4.1)`. The grades 3–4 path had no coverage at all, so the fix changes behaviour only where nothing was looking. All 881 tests passed before and after the code fix.

**The conformance suite pinned the same grade.** Its `INVOKE` map hardcodes `grade_level: '5'` for all eight text evaluators, so no conditional branch was ever exercised there either. And `MODEL_GAPS` compares the models providers are *constructed* with, never the model reported for a given input — both models are constructed, so it passed.

## What now guards it

**Per-grade unit test** over grades 3, 4, 5 and 12, asserting both halves: which provider was invoked, and what `metadata.model` says. Those two disagreeing *is* the bug.

**A config-driven conformance check.** The contract already declares the branch:

```json
{ "id": "vocab_complexity_grades_3_4", "condition": { "input": "grade_level", "in": ["3", "4"] },
  "model": { "provider": "google", "name": "gemini-2.5-pro" } }
```

So the expected label is derivable: the steps whose condition matches the grade, joined. The test enumerates each contract's condition values and asserts the reported model for each. Vocabulary Complexity is the only evaluator with a conditional step today, and an evaluator that gains one is covered without editing the test. A sanity assertion fails if the derivation ever stops finding conditions, so it can't go quietly vacuous.

## Validation

- `typecheck`, `lint`, `test:unit`, `build`, `scripts/check.py`, `generate:schemas:check`
- Load-bearing, both guards: restored the pre-fix file and confirmed the unit test fails at grades 3 and 4 with `+openai:gpt-4.1-2025-04-14` where `+google:gemini-2.5-pro` was expected, and the conformance check fails on the same two grades. Grades 5 and 12 pass either way, matching the blast radius.
- Confirmed the sanity assertion is what stops the conformance suite silently covering nothing
