### PR TITLE
ci: run TypeScript SDK checks on any eval corpus change

### DIFF
--- a/.github/workflows/test-sdk-typescript.yml
+++ b/.github/workflows/test-sdk-typescript.yml
@@ -6,14 +6,18 @@ on:
       - main
     paths:
       - 'sdks/typescript/**'
-      - 'evals/prompts/**'
-      - 'evals/student-facing-text/**'
+      # The whole corpus: the SDK compiles every contract's config.json and prompt .txt
+      # into dist/, so any of them can change what the package does. Listing domains
+      # individually meant a new one silently ran no TypeScript CI at all.
+      - 'evals/**'
       - '.github/workflows/test-sdk-typescript.yml'
   pull_request:
     paths:
       - 'sdks/typescript/**'
-      - 'evals/prompts/**'
-      - 'evals/student-facing-text/**'
+      # The whole corpus: the SDK compiles every contract's config.json and prompt .txt
+      # into dist/, so any of them can change what the package does. Listing domains
+      # individually meant a new one silently ran no TypeScript CI at all.
+      - 'evals/**'
       - '.github/workflows/test-sdk-typescript.yml'
 
 permissions:


### PR DESCRIPTION
The TypeScript SDK's CI watched two eval paths:

```yaml
- 'evals/prompts/**'
- 'evals/student-facing-text/**'
```

`evals/prompts/` contains `__init__.py` and `CHANGELOG.md` — **no prompts**. All 42 prompt `.txt` files and all 16 `config.json` files live under the domain directories. So the only eval path that actually reached the SDK was `student-facing-text`, and changes under `academic-standards-alignment/` (math) or `feedback/` (7 contracts) ran no TypeScript job at all.

The SDK compiles those files into `dist/` — `src/prompts/*/index.ts` imports `system.txt`, `user.txt` and `config.json` straight from `evals/` — so a contract change alters what the published package does.

Now `evals/**`, in both triggers. A domain list has to be edited every time a domain is added, and forgetting is silent; the cost of the wider filter is an occasional extra run when a notebook changes.

## Scope of what was actually missed

Narrower than it first looks, and worth being precise: **`checks.yml` has no path filter**, so `eval-config`, `eval-schemas` and `eval-fixtures` ran on every PR regardless. Contract *validity* was never unguarded.

What didn't run for math and feedback contracts was the TypeScript side: `lint`, `typecheck`, `test:unit`, `build`, and — since #218 — `generate:schemas:check`, the check that catches a generated Zod schema drifting from its contract. That last one is the reason this matters now: six schema modules are generated from contracts, and the check that compares them wasn't firing for two of three domains.

## Known adjacent gap, not fixed here

`test-sdk-python.yml` watches `sdks/python/**` and `sdks/settings/**` — the stale directory slated for deletion — and no `evals/` path at all. Same hole. Left alone deliberately: Python is out of scope for this work, and switching on a trigger there could surface failures unrelated to this change. Worth a decision separately.

## Validation

- Parsed the workflow with `yaml.safe_load` and confirmed both `push` and `pull_request` resolve to `['sdks/typescript/**', 'evals/**', '.github/workflows/test-sdk-typescript.yml']`
- Confirmed by listing that `evals/prompts/` holds only `__init__.py` and `CHANGELOG.md`, and that the 42 prompt files sit under the three domain directories
- Confirmed `checks.yml` is unfiltered, so this changes what runs for the SDK only
