### PR TITLE
refactor(sdk): run single-step evaluators from one contract-driven flow

### DIFF
--- a/sdks/typescript/src/evaluators/single-step.ts
+++ b/sdks/typescript/src/evaluators/single-step.ts
@@ -1,0 +1,273 @@
+import type { ZodType } from 'zod';
+import type { LLMProvider } from '../providers/index.js';
+import type { EvaluationResult } from '../schemas/index.js';
+import type { StageDetail } from '../telemetry/index.js';
+import { EvaluatorError, wrapProviderError } from '../errors.js';
+import { runPreprocessingStep } from '../features/preprocessing.js';
+import {
+  BaseEvaluator,
+  Provider,
+  type BaseEvaluatorConfig,
+  type EvaluatorMetadata,
+} from './base.js';
+import { declaredCredentials, type CredentialDeclaringConfig } from './credentials.js';
+import { validateInputs, primaryTextField, type DeclaredInputSchema } from './inputs.js';
+
+/**
+ * The parts of a contract a single-step evaluator runs on. Everything the flow needs is
+ * declared, so the only per-evaluator code left is naming the four artefacts below.
+ */
+export interface SingleStepContract extends CredentialDeclaringConfig {
+  evaluator: {
+    id: string;
+    stable_id: string;
+    id_history: string[];
+    name: string;
+    description: string;
+  };
+  steps: Array<{
+    id: string;
+    model: { provider: string; name: string };
+    generation?: { temperature?: number };
+    required_credentials?: string[];
+    optional?: boolean;
+  }>;
+  preprocessing?: Array<{
+    id: string;
+    implementation: { typescript: { library: string; function: string; post_transform?: { type: string; precision?: number } } };
+    required_credentials?: string[];
+  }>;
+  outcome?: { score: string; reasoning: string };
+}
+
+export interface SingleStepDefinition<TResult> {
+  contract: SingleStepContract;
+  inputSchema: DeclaredInputSchema;
+  outputSchema: ZodType<TResult>;
+  prompts: {
+    getSystemPrompt(inputs: Record<string, string>): string;
+    getUserPrompt(inputs: Record<string, string>): string;
+  };
+}
+
+/**
+ * The class `defineSingleStepEvaluator` returns.
+ *
+ * Spelled out rather than inferred because an anonymous class cannot carry the base's
+ * protected members into the emitted declarations (TS4094).
+ */
+export interface SingleStepEvaluatorClass<TInput, TResult> {
+  new (config: BaseEvaluatorConfig): BaseEvaluator & {
+    evaluate(input: TInput): Promise<EvaluationResult<TResult>>;
+  };
+  readonly metadata: EvaluatorMetadata;
+}
+
+/** Step id convention: `evaluate_{slug}`, where slug is the last segment of the id. */
+function stepFor(contract: SingleStepContract) {
+  const id = `evaluate_${contract.evaluator.id.split('.').pop()}`;
+  const step = contract.steps.find((s) => s.id === id);
+  if (!step) {
+    throw new Error(`Step "${id}" not found in ${contract.evaluator.name} config.json`);
+  }
+  return step;
+}
+
+function vendorOf(step: { model: { provider: string } }, name: string): Provider {
+  const vendor = Object.values(Provider).find((p) => p === step.model.provider);
+  if (!vendor) {
+    throw new Error(
+      `Unsupported provider "${step.model.provider}" declared by ${name}. ` +
+        `Supported: ${Object.values(Provider).join(', ')}.`,
+    );
+  }
+  return vendor;
+}
+
+/**
+ * Builds the evaluator class for a contract with one model call.
+ *
+ * The flow below — validate, preprocess, render, call, envelope, telemetry, error wrap —
+ * was written out once per evaluator, which is how two copies of it came to disagree.
+ * Anything that varies is read from the contract rather than passed in, so an evaluator
+ * cannot drift from what its contract declares.
+ *
+ * @example
+ * ```typescript
+ * export class PurposeClarityEvaluator extends defineSingleStepEvaluator<
+ *   PurposeClarityInput,
+ *   PurposeClarityResult
+ * >({
+ *   contract: CONFIG,
+ *   inputSchema: INPUT_SCHEMA,
+ *   outputSchema: PurposeClarityOutputSchema,
+ *   prompts: { getSystemPrompt, getUserPrompt },
+ * }) {}
+ * ```
+ */
+export function defineSingleStepEvaluator<TInput extends Record<string, string>, TResult>(
+  definition: SingleStepDefinition<TResult>,
+): SingleStepEvaluatorClass<TInput, TResult> {
+  const { contract, inputSchema, outputSchema, prompts } = definition;
+
+  const STEP = stepFor(contract);
+  const VENDOR = vendorOf(STEP, contract.evaluator.name);
+  const PREPROCESSING = contract.preprocessing ?? [];
+  const TEXT_FIELD = primaryTextField(inputSchema);
+
+  // The contract names every evaluator "<Thing> Evaluator"; logs read as "<Thing>".
+  const LABEL = contract.evaluator.name.replace(/ Evaluator$/, '');
+
+  const METADATA = {
+    id: contract.evaluator.id,
+    stableId: contract.evaluator.stable_id,
+    idHistory: contract.evaluator.id_history,
+    name: contract.evaluator.name,
+    description: contract.evaluator.description,
+    outcome: contract.outcome,
+    requiredCredentials: declaredCredentials(contract),
+    supportedGrades: (inputSchema.properties.grade_level?.enum ?? []) as readonly string[],
+    defaultProviders: [VENDOR] as const,
+  };
+
+  return class SingleStepEvaluator extends BaseEvaluator {
+    static readonly metadata = METADATA;
+
+    protected provider: LLMProvider;
+
+    constructor(config: BaseEvaluatorConfig) {
+      super(config);
+      this.provider = this.createConfiguredProvider(VENDOR, STEP.model.name, this.keyFor(VENDOR, config));
+    }
+
+    private keyFor(vendor: Provider, config: BaseEvaluatorConfig): string | undefined {
+      const keys: Record<Provider, string | undefined> = {
+        [Provider.OpenAI]: config.openaiApiKey,
+        [Provider.Google]: config.googleApiKey,
+        [Provider.Anthropic]: config.anthropicApiKey,
+      };
+      return keys[vendor];
+    }
+
+    async evaluate(input: TInput): Promise<EvaluationResult<TResult>> {
+      let text = '';
+      let gradeLevel = '';
+      const startTime = Date.now();
+      const stageDetails: StageDetail[] = [];
+
+      try {
+        // Inside the try so a validation failure is telemetered as an error event,
+        // and before the inputs are read so a non-object is reported as one.
+        validateInputs(input, inputSchema);
+        const fields = input as Record<string, string>;
+        text = TEXT_FIELD ? fields[TEXT_FIELD] : '';
+        gradeLevel = fields.grade_level ?? '';
+
+        this.logger.info(`Starting ${LABEL} evaluation`, {
+          evaluator: METADATA.id,
+          operation: 'evaluate',
+          gradeLevel,
+          textLength: text.length,
+        });
+
+        // Each declared preprocessing step becomes a prompt input under its own id, so
+        // adding one to a contract needs no code here.
+        const promptInputs: Record<string, string> = { ...fields };
+        for (const step of PREPROCESSING) {
+          promptInputs[step.id] = String(runPreprocessingStep(text, step.implementation.typescript));
+        }
+
+        const response = await this.provider.generateStructured({
+          messages: [
+            { role: 'system', content: prompts.getSystemPrompt(promptInputs) },
+            { role: 'user', content: prompts.getUserPrompt(promptInputs) },
+          ],
+          schema: outputSchema,
+          temperature: STEP.generation?.temperature,
+        });
+
+        const latencyMs = Date.now() - startTime;
+        const tokenUsage = {
+          input_tokens: response.usage.inputTokens,
+          output_tokens: response.usage.outputTokens,
+        };
+
+        stageDetails.push({
+          stage: STEP.id,
+          provider: this.provider.label,
+          latency_ms: response.latencyMs,
+          token_usage: tokenUsage,
+        });
+
+        const result: EvaluationResult<TResult> = {
+          evaluator: METADATA.id,
+          result: response.data,
+          metadata: {
+            model: this.provider.label,
+            processingTimeMs: latencyMs,
+            tokenUsage: {
+              inputTokens: tokenUsage.input_tokens,
+              outputTokens: tokenUsage.output_tokens,
+            },
+          },
+        };
+
+        this.sendTelemetry({
+          status: 'success',
+          latencyMs,
+          textLength: text.length,
+          gradeLevel,
+          provider: this.provider.label,
+          tokenUsage,
+          metadata: { stage_details: stageDetails },
+          inputText: text,
+        }).catch(() => undefined);
+
+        this.logger.info(`${LABEL} evaluation completed successfully`, {
+          evaluator: METADATA.id,
+          operation: 'evaluate',
+          gradeLevel,
+          score: METADATA.outcome
+            ? (response.data as Record<string, unknown>)[METADATA.outcome.score]
+            : undefined,
+          processingTimeMs: latencyMs,
+        });
+
+        return result;
+      } catch (error) {
+        const latencyMs = Date.now() - startTime;
+
+        this.logger.error(`${LABEL} evaluation failed`, {
+          evaluator: METADATA.id,
+          operation: 'evaluate',
+          gradeLevel,
+          error: error instanceof Error ? error : undefined,
+          processingTimeMs: latencyMs,
+        });
+
+        const tokenUsage =
+          stageDetails.length > 0
+            ? {
+                input_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.input_tokens ?? 0), 0),
+                output_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.output_tokens ?? 0), 0),
+              }
+            : undefined;
+
+        this.sendTelemetry({
+          status: 'error',
+          latencyMs,
+          textLength: text.length,
+          gradeLevel,
+          provider: this.provider.label,
+          tokenUsage,
+          errorCode: error instanceof Error ? error.name : 'UnknownError',
+          metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
+          inputText: text,
+        }).catch(() => undefined);
+
+        if (error instanceof EvaluatorError) throw error;
+        throw wrapProviderError(error, this.providerContext(this.provider));
+      }
+    }
+  };
+}

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/organizational-structure.ts
@@ -1,197 +1,33 @@
-import type { LLMProvider } from '../../../providers/index.js';
-import {
-  OrganizationalStructureOutputSchema,
-  type OrganizationalStructureResult,
-} from '../../../schemas/student-facing-text/ela-reading/organizational-structure.js';
-import { runPreprocessingStep } from '../../../features/preprocessing.js';
+import { OrganizationalStructureOutputSchema, type OrganizationalStructureResult } from '../../../schemas/student-facing-text/ela-reading/organizational-structure.js';
 import { getSystemPrompt, getUserPrompt } from '../../../prompts/organizational-structure/index.js';
 import type { EvaluationResult } from '../../../schemas/index.js';
-import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
-import { validateInputs, type InputsOf } from '../../inputs.js';
-import { declaredCredentials } from '../../credentials.js';
-import type { StageDetail } from '../../../telemetry/index.js';
-import { EvaluatorError, wrapProviderError } from '../../../errors.js';
+import type { BaseEvaluatorConfig } from '../../base.js';
+import { defineSingleStepEvaluator } from '../../single-step.js';
+import type { InputsOf } from '../../inputs.js';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json';
-
-// Step ID convention: "evaluate_{slug}" where slug is the last segment of evaluator.id.
-const STEP_ID = `evaluate_${CONFIG.evaluator.id.split('.').pop()}`;
-const _step = CONFIG.steps.find(s => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in organizational-structure config.json`);
-const STEP = _step;
-
-// Supported grades from input_schema — needed for static metadata, so defined at
-// module level. The enum is the declared set, so it is used verbatim rather than
-// reconstructed from bounds; that also admits non-numeric tokens such as "K".
-const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
 export type OrganizationalStructureInput = InputsOf<typeof INPUT_SCHEMA>;
 
-export class OrganizationalStructureEvaluator extends BaseEvaluator {
-  static readonly metadata = {
-    id: CONFIG.evaluator.id,
-    stableId: CONFIG.evaluator.stable_id,
-    idHistory: CONFIG.evaluator.id_history,
-    name: CONFIG.evaluator.name,
-    description: CONFIG.evaluator.description,
-    outcome: CONFIG.outcome,
-    requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: SUPPORTED_GRADES,
-    defaultProviders: [Provider.Google] as const,
-  };
-
-  private static readonly TEMPERATURE = STEP.generation.temperature;
-
-  private static computeFkScore(text: string): number {
-    const fkStep = CONFIG.preprocessing.find(p => p.id === 'fk_score');
-    if (!fkStep) throw new Error('fk_score preprocessing step not found in organizational-structure config.json');
-    return runPreprocessingStep(text, fkStep.implementation.typescript);
-  }
-
-  private provider: LLMProvider;
-
-  constructor(config: BaseEvaluatorConfig) {
-    super(config);
-
-    this.provider = this.createConfiguredProvider(
-      Provider.Google, STEP.model.name, config.googleApiKey
-    );
-  }
-
-  /**
-   * Evaluate organizational structure complexity for a given text and grade level
-   *
-   * @param text - The text to evaluate
-   * @param gradeLevel - The target grade level (3-12)
-   * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
-   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
-   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
-   */
-  async evaluate(input: OrganizationalStructureInput): Promise<EvaluationResult<OrganizationalStructureResult>> {
-    let text = '';
-    let gradeLevel = '';
-    const startTime = Date.now();
-    const stageDetails: StageDetail[] = [];
-
-    try {
-      // Inside the try so a validation failure is telemetered as an error event,
-      // and before the inputs are read so a non-object is reported as one.
-      validateInputs(input, INPUT_SCHEMA);
-      ({ text, grade_level: gradeLevel } = input);
-
-      this.logger.info('Starting Organizational Structure evaluation', {
-        evaluator: OrganizationalStructureEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        textLength: text.length,
-      });
-
-      const fkScore = OrganizationalStructureEvaluator.computeFkScore(text);
-      const promptInputs: Record<string, string> = {
-        ...input,
-        fk_score: String(fkScore),
-      };
-      const response = await this.callLLM(promptInputs);
-
-      const latencyMs = Date.now() - startTime;
-      const tokenUsage = {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-      };
-
-      stageDetails.push({
-        stage: STEP.id,
-        provider: this.provider.label,
-        latency_ms: response.latencyMs,
-        token_usage: tokenUsage,
-      });
-
-      const result: EvaluationResult<OrganizationalStructureResult> = {
-        evaluator: OrganizationalStructureEvaluator.metadata.id,
-        result: response.data,
-        metadata: {
-          model: this.provider.label,
-          processingTimeMs: latencyMs,
-          tokenUsage: {
-            inputTokens: tokenUsage.input_tokens,
-            outputTokens: tokenUsage.output_tokens,
-          },
-        },
-      };
-
-      this.sendTelemetry({
-        status: 'success',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel,
-        provider: this.provider.label,
-        tokenUsage,
-        metadata: { stage_details: stageDetails },
-        inputText: text,
-      }).catch(() => undefined);
-
-      this.logger.info('Organizational Structure evaluation completed successfully', {
-        evaluator: OrganizationalStructureEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        score: response.data.complexity_score,
-        processingTimeMs: latencyMs,
-      });
-
-      return result;
-    } catch (error) {
-      const latencyMs = Date.now() - startTime;
-
-      this.logger.error('Organizational Structure evaluation failed', {
-        evaluator: OrganizationalStructureEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        error: error instanceof Error ? error : undefined,
-        processingTimeMs: latencyMs,
-      });
-
-      const tokenUsage = stageDetails.length > 0
-        ? {
-            input_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.input_tokens ?? 0), 0),
-            output_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.output_tokens ?? 0), 0),
-          }
-        : undefined;
-
-      this.sendTelemetry({
-        status: 'error',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel: String(gradeLevel),
-        provider: this.provider.label,
-        tokenUsage,
-        errorCode: error instanceof Error ? error.name : 'UnknownError',
-        metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: text,
-      }).catch(() => undefined);
-
-      if (error instanceof EvaluatorError) throw error;
-      throw wrapProviderError(error, this.providerContext(this.provider));
-    }
-  }
-
-  private async callLLM(
-    inputs: Record<string, string>,
-  ): Promise<{ data: OrganizationalStructureResult; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const response = await this.provider.generateStructured({
-      messages: [
-        { role: 'system', content: getSystemPrompt(inputs) },
-        { role: 'user', content: getUserPrompt(inputs) },
-      ],
-      schema: OrganizationalStructureOutputSchema,
-      temperature: OrganizationalStructureEvaluator.TEMPERATURE,
-    });
-
-    return { data: response.data, usage: response.usage, latencyMs: response.latencyMs };
-  }
-}
+/**
+ * Evaluates organizational structure in student-facing text.
+ *
+ * One model call, so the flow comes from {@link defineSingleStepEvaluator} and
+ * everything that varies — model, temperature, grades, preprocessing, prompt inputs —
+ * is read from `config.json`.
+ *
+ * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
+ * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
+ * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+ * @throws {LLMOutputProcessingError} If the model's response fails its output schema
+ */
+export class OrganizationalStructureEvaluator extends defineSingleStepEvaluator<OrganizationalStructureInput, OrganizationalStructureResult>({
+  contract: CONFIG,
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: OrganizationalStructureOutputSchema,
+  prompts: { getSystemPrompt, getUserPrompt },
+}) {}
 
 export async function evaluateOrganizationalStructure(
   input: OrganizationalStructureInput,

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/purpose-clarity.ts
@@ -1,193 +1,33 @@
-import type { LLMProvider } from '../../../providers/index.js';
 import { PurposeClarityOutputSchema, type PurposeClarityResult } from '../../../schemas/student-facing-text/ela-reading/purpose-clarity.js';
-import { runPreprocessingStep } from '../../../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../../../prompts/purpose-clarity/index.js';
 import type { EvaluationResult } from '../../../schemas/index.js';
-import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
-import { validateInputs, type InputsOf } from '../../inputs.js';
-import { declaredCredentials } from '../../credentials.js';
-import type { StageDetail } from '../../../telemetry/index.js';
-import { EvaluatorError, wrapProviderError } from '../../../errors.js';
+import type { BaseEvaluatorConfig } from '../../base.js';
+import { defineSingleStepEvaluator } from '../../single-step.js';
+import type { InputsOf } from '../../inputs.js';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/input_schema.json';
-
-// Step ID convention: "evaluate_{slug}" where slug is the last segment of evaluator.id.
-const STEP_ID = `evaluate_${CONFIG.evaluator.id.split('.').pop()}`;
-const _step = CONFIG.steps.find(s => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in purpose-clarity config.json`);
-const STEP = _step;
-
-// Supported grades from input_schema — needed for static metadata, so defined at
-// module level. The enum is the declared set, so it is used verbatim rather than
-// reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
-const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
 export type PurposeClarityInput = InputsOf<typeof INPUT_SCHEMA>;
 
-export class PurposeClarityEvaluator extends BaseEvaluator {
-  static readonly metadata = {
-    id: CONFIG.evaluator.id,
-    stableId: CONFIG.evaluator.stable_id,
-    idHistory: CONFIG.evaluator.id_history,
-    name: CONFIG.evaluator.name,
-    description: CONFIG.evaluator.description,
-    outcome: CONFIG.outcome,
-    requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: SUPPORTED_GRADES,
-    defaultProviders: [Provider.Google] as const,
-  };
-
-  private static readonly TEMPERATURE = STEP.generation.temperature;
-
-  private static computeFkScore(text: string): number {
-    const fkStep = CONFIG.preprocessing.find(p => p.id === 'fk_score');
-    if (!fkStep) throw new Error('fk_score preprocessing step not found in purpose-clarity config.json');
-    return runPreprocessingStep(text, fkStep.implementation.typescript);
-  }
-
-  private provider: LLMProvider;
-
-  constructor(config: BaseEvaluatorConfig) {
-    super(config);
-
-    this.provider = this.createConfiguredProvider(
-      Provider.Google, STEP.model.name, config.googleApiKey
-    );
-  }
-
-  /**
-   * Evaluate purpose complexity for a given text and grade level
-   *
-   * @param input - The inputs declared in this evaluator's `input_schema.json`
-   * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
-   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
-   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
-   */
-  async evaluate(input: PurposeClarityInput): Promise<EvaluationResult<PurposeClarityResult>> {
-    let text = '';
-    let gradeLevel = '';
-    const startTime = Date.now();
-    const stageDetails: StageDetail[] = [];
-
-    try {
-      // Inside the try so a validation failure is telemetered as an error event,
-      // and before the inputs are read so a non-object is reported as one.
-      validateInputs(input, INPUT_SCHEMA);
-      ({ text, grade_level: gradeLevel } = input);
-
-      this.logger.info('Starting Purpose Clarity evaluation', {
-        evaluator: PurposeClarityEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        textLength: text?.length,
-      });
-
-      const fkScore = PurposeClarityEvaluator.computeFkScore(text);
-      const promptInputs: Record<string, string> = {
-        ...input,
-        fk_score: String(fkScore),
-      };
-      const response = await this.callLLM(promptInputs);
-
-      const latencyMs = Date.now() - startTime;
-      const tokenUsage = {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-      };
-
-      stageDetails.push({
-        stage: STEP.id,
-        provider: this.provider.label,
-        latency_ms: response.latencyMs,
-        token_usage: tokenUsage,
-      });
-
-      const result: EvaluationResult<PurposeClarityResult> = {
-        evaluator: PurposeClarityEvaluator.metadata.id,
-        result: response.data,
-        metadata: {
-          model: this.provider.label,
-          processingTimeMs: latencyMs,
-          tokenUsage: {
-            inputTokens: tokenUsage.input_tokens,
-            outputTokens: tokenUsage.output_tokens,
-          },
-        },
-      };
-
-      this.sendTelemetry({
-        status: 'success',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel,
-        provider: this.provider.label,
-        tokenUsage,
-        metadata: { stage_details: stageDetails },
-        inputText: text,
-      }).catch(() => undefined);
-
-      this.logger.info('Purpose Clarity evaluation completed successfully', {
-        evaluator: PurposeClarityEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        score: response.data.complexity_score,
-        processingTimeMs: latencyMs,
-      });
-
-      return result;
-    } catch (error) {
-      const latencyMs = Date.now() - startTime;
-
-      this.logger.error('Purpose Clarity evaluation failed', {
-        evaluator: PurposeClarityEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        error: error instanceof Error ? error : undefined,
-        processingTimeMs: latencyMs,
-      });
-
-      const tokenUsage = stageDetails.length > 0
-        ? {
-            input_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.input_tokens ?? 0), 0),
-            output_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.output_tokens ?? 0), 0),
-          }
-        : undefined;
-
-      this.sendTelemetry({
-        status: 'error',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel,
-        provider: this.provider.label,
-        tokenUsage,
-        errorCode: error instanceof Error ? error.name : 'UnknownError',
-        metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: text,
-      }).catch(() => undefined);
-
-      if (error instanceof EvaluatorError) throw error;
-      throw wrapProviderError(error, this.providerContext(this.provider));
-    }
-  }
-
-  private async callLLM(
-    inputs: Record<string, string>,
-  ): Promise<{ data: PurposeClarityResult; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const response = await this.provider.generateStructured({
-      messages: [
-        { role: 'system', content: getSystemPrompt(inputs) },
-        { role: 'user', content: getUserPrompt(inputs) },
-      ],
-      schema: PurposeClarityOutputSchema,
-      temperature: PurposeClarityEvaluator.TEMPERATURE,
-    });
-
-    return { data: response.data, usage: response.usage, latencyMs: response.latencyMs };
-  }
-}
+/**
+ * Evaluates purpose clarity in student-facing text.
+ *
+ * One model call, so the flow comes from {@link defineSingleStepEvaluator} and
+ * everything that varies — model, temperature, grades, preprocessing, prompt inputs —
+ * is read from `config.json`.
+ *
+ * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
+ * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
+ * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+ * @throws {LLMOutputProcessingError} If the model's response fails its output schema
+ */
+export class PurposeClarityEvaluator extends defineSingleStepEvaluator<PurposeClarityInput, PurposeClarityResult>({
+  contract: CONFIG,
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: PurposeClarityOutputSchema,
+  prompts: { getSystemPrompt, getUserPrompt },
+}) {}
 
 export async function evaluatePurposeClarity(
   input: PurposeClarityInput,

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.ts
@@ -1,194 +1,33 @@
-import type { LLMProvider } from '../../../providers/index.js';
 import { ReferenceKnowledgeDemandsOutputSchema, type ReferenceKnowledgeDemandsResult } from '../../../schemas/student-facing-text/ela-reading/reference-knowledge-demands.js';
-import { runPreprocessingStep } from '../../../features/preprocessing.js';
 import { getSystemPrompt, getUserPrompt } from '../../../prompts/reference-knowledge-demands/index.js';
 import type { EvaluationResult } from '../../../schemas/index.js';
-import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
-import { validateInputs, type InputsOf } from '../../inputs.js';
-import { declaredCredentials } from '../../credentials.js';
-import type { StageDetail } from '../../../telemetry/index.js';
-import { EvaluatorError, wrapProviderError } from '../../../errors.js';
+import type { BaseEvaluatorConfig } from '../../base.js';
+import { defineSingleStepEvaluator } from '../../single-step.js';
+import type { InputsOf } from '../../inputs.js';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/input_schema.json';
-
-// Step ID convention: "evaluate_{slug}" where slug is the last segment of evaluator.id.
-const STEP_ID = `evaluate_${CONFIG.evaluator.id.split('.').pop()}`;
-const _step = CONFIG.steps.find(s => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in reference-knowledge-demands config.json`);
-const STEP = _step;
-
-// Supported grades from input_schema — needed for static metadata, so defined at
-// module level. The enum is the declared set, so it is used verbatim rather than
-// reconstructed from bounds; that admits gaps and non-numeric tokens such as "K".
-const SUPPORTED_GRADES: readonly string[] = INPUT_SCHEMA.properties.grade_level.enum;
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
 export type ReferenceKnowledgeDemandsInput = InputsOf<typeof INPUT_SCHEMA>;
 
-export class ReferenceKnowledgeDemandsEvaluator extends BaseEvaluator {
-  static readonly metadata = {
-    id: CONFIG.evaluator.id,
-    stableId: CONFIG.evaluator.stable_id,
-    idHistory: CONFIG.evaluator.id_history,
-    name: CONFIG.evaluator.name,
-    description: CONFIG.evaluator.description,
-    outcome: CONFIG.outcome,
-    requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: SUPPORTED_GRADES,
-    defaultProviders: [Provider.Google] as const,
-  };
-
-  private static readonly TEMPERATURE = STEP.generation.temperature;
-
-  private static computeFkScore(text: string): number {
-    const fkStep = CONFIG.preprocessing.find(p => p.id === 'fk_score');
-    if (!fkStep) throw new Error('fk_score preprocessing step not found in reference-knowledge-demands config.json');
-    return runPreprocessingStep(text, fkStep.implementation.typescript);
-  }
-
-  private provider: LLMProvider;
-
-  constructor(config: BaseEvaluatorConfig) {
-    super(config);
-
-    this.provider = this.createConfiguredProvider(
-      Provider.Google, STEP.model.name, config.googleApiKey
-    );
-  }
-
-  /**
-   * Evaluate reference knowledge demands complexity for a given text and grade level
-   *
-   * @param text - The text to evaluate
-   * @param gradeLevel - The target grade level (3-12)
-   * @returns Evaluation result with complexity score and detailed analysis
-   * @throws {InputValidationError} If text is empty, too short/long, or gradeLevel is invalid
-   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
-   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
-   */
-  async evaluate(input: ReferenceKnowledgeDemandsInput): Promise<EvaluationResult<ReferenceKnowledgeDemandsResult>> {
-    let text = '';
-    let gradeLevel = '';
-    const startTime = Date.now();
-    const stageDetails: StageDetail[] = [];
-
-    try {
-      // Inside the try so a validation failure is telemetered as an error event,
-      // and before the inputs are read so a non-object is reported as one.
-      validateInputs(input, INPUT_SCHEMA);
-      ({ text, grade_level: gradeLevel } = input);
-
-      this.logger.info('Starting Reference Knowledge Demands evaluation', {
-        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        textLength: text.length,
-      });
-
-      const fkScore = ReferenceKnowledgeDemandsEvaluator.computeFkScore(text);
-      const promptInputs: Record<string, string> = {
-        ...input,
-        fk_score: String(fkScore),
-      };
-      const response = await this.callLLM(promptInputs);
-
-      const latencyMs = Date.now() - startTime;
-      const tokenUsage = {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-      };
-
-      stageDetails.push({
-        stage: STEP.id,
-        provider: this.provider.label,
-        latency_ms: response.latencyMs,
-        token_usage: tokenUsage,
-      });
-
-      const result: EvaluationResult<ReferenceKnowledgeDemandsResult> = {
-        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
-        result: response.data,
-        metadata: {
-          model: this.provider.label,
-          processingTimeMs: latencyMs,
-          tokenUsage: {
-            inputTokens: tokenUsage.input_tokens,
-            outputTokens: tokenUsage.output_tokens,
-          },
-        },
-      };
-
-      this.sendTelemetry({
-        status: 'success',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel,
-        provider: this.provider.label,
-        tokenUsage,
-        metadata: { stage_details: stageDetails },
-        inputText: text,
-      }).catch(() => undefined);
-
-      this.logger.info('Reference Knowledge Demands evaluation completed successfully', {
-        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        score: response.data.complexity_score,
-        processingTimeMs: latencyMs,
-      });
-
-      return result;
-    } catch (error) {
-      const latencyMs = Date.now() - startTime;
-
-      this.logger.error('Reference Knowledge Demands evaluation failed', {
-        evaluator: ReferenceKnowledgeDemandsEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel,
-        error: error instanceof Error ? error : undefined,
-        processingTimeMs: latencyMs,
-      });
-
-      const tokenUsage = stageDetails.length > 0
-        ? {
-            input_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.input_tokens ?? 0), 0),
-            output_tokens: stageDetails.reduce((s, d) => s + (d.token_usage?.output_tokens ?? 0), 0),
-          }
-        : undefined;
-
-      this.sendTelemetry({
-        status: 'error',
-        latencyMs,
-        textLength: text.length,
-        gradeLevel,
-        provider: this.provider.label,
-        tokenUsage,
-        errorCode: error instanceof Error ? error.name : 'UnknownError',
-        metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: text,
-      }).catch(() => undefined);
-
-      if (error instanceof EvaluatorError) throw error;
-      throw wrapProviderError(error, this.providerContext(this.provider));
-    }
-  }
-
-  private async callLLM(
-    inputs: Record<string, string>,
-  ): Promise<{ data: ReferenceKnowledgeDemandsResult; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
-    const response = await this.provider.generateStructured({
-      messages: [
-        { role: 'system', content: getSystemPrompt(inputs) },
-        { role: 'user', content: getUserPrompt(inputs) },
-      ],
-      schema: ReferenceKnowledgeDemandsOutputSchema,
-      temperature: ReferenceKnowledgeDemandsEvaluator.TEMPERATURE,
-    });
-
-    return { data: response.data, usage: response.usage, latencyMs: response.latencyMs };
-  }
-}
+/**
+ * Evaluates reference knowledge demands in student-facing text.
+ *
+ * One model call, so the flow comes from {@link defineSingleStepEvaluator} and
+ * everything that varies — model, temperature, grades, preprocessing, prompt inputs —
+ * is read from `config.json`.
+ *
+ * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
+ * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
+ * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+ * @throws {LLMOutputProcessingError} If the model's response fails its output schema
+ */
+export class ReferenceKnowledgeDemandsEvaluator extends defineSingleStepEvaluator<ReferenceKnowledgeDemandsInput, ReferenceKnowledgeDemandsResult>({
+  contract: CONFIG,
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: ReferenceKnowledgeDemandsOutputSchema,
+  prompts: { getSystemPrompt, getUserPrompt },
+}) {}
 
 export async function evaluateReferenceKnowledgeDemands(
   input: ReferenceKnowledgeDemandsInput,

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import { createHash } from 'node:crypto';
 import { OrganizationalStructureEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/organizational-structure.js';
 import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
-import CONFIG from '../../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import INPUT_SCHEMA from '../../../../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json';
 import { getSystemPrompt, getUserPrompt } from '../../../src/prompts/organizational-structure/index.js';
 
@@ -55,6 +56,8 @@ const MOCK_RESPONSE = {
 };
 
 // --- Constructor ---
+
+const FK_TEXT = 'The quick brown fox jumps over the lazy dog.';
 
 describe('OrganizationalStructureEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
@@ -186,10 +189,16 @@ describe('OrganizationalStructureEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
+    await evaluator.evaluate({ text: FK_TEXT, grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
-    expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
+    // The value the contract's own preprocessing produces, not just "some number" — the
+    // grade level alone satisfied that, so the assertion held with preprocessing off.
+    const fkStep = CONFIG.preprocessing.find((p) => p.id === 'fk_score')!;
+    const expected = String(runPreprocessingStep(FK_TEXT, fkStep.implementation.typescript));
+
+    expect(call.messages[1].content).toContain(expected);
+    expect(call.messages[1].content).not.toContain('{fk_score}');
   });
 
   it('maps LLM response to result shape', async () => {

--- a/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
 import { createHash } from 'node:crypto';
 import { PurposeClarityEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/purpose-clarity.js';
 import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
-import CONFIG from '../../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
 import { getSystemPrompt, getUserPrompt } from '../../../src/prompts/purpose-clarity/index.js';
 
 const STEP = CONFIG.steps[0];
@@ -54,6 +55,8 @@ const MOCK_RESPONSE = {
 };
 
 // --- Constructor ---
+
+const FK_TEXT = 'The quick brown fox jumps over the lazy dog.';
 
 describe('PurposeClarityEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
@@ -177,10 +180,16 @@ describe('PurposeClarityEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
+    await evaluator.evaluate({ text: FK_TEXT, grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
-    expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
+    // The value the contract's own preprocessing produces, not just "some number" — the
+    // grade level alone satisfied that, so the assertion held with preprocessing off.
+    const fkStep = CONFIG.preprocessing.find((p) => p.id === 'fk_score')!;
+    const expected = String(runPreprocessingStep(FK_TEXT, fkStep.implementation.typescript));
+
+    expect(call.messages[1].content).toContain(expected);
+    expect(call.messages[1].content).not.toContain('{fk_score}');
   });
 
   it('maps LLM response to result shape', async () => {

--- a/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
 import { createHash } from 'node:crypto';
 import { ReferenceKnowledgeDemandsEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.js';
 import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
-import CONFIG from '../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
 import { getSystemPrompt, getUserPrompt } from '../../../src/prompts/reference-knowledge-demands/index.js';
 
 const STEP = CONFIG.steps[0];
@@ -54,6 +55,8 @@ const MOCK_RESPONSE = {
 };
 
 // --- Constructor ---
+
+const FK_TEXT = 'The quick brown fox jumps over the lazy dog.';
 
 describe('ReferenceKnowledgeDemandsEvaluator - Constructor', () => {
   it('throws when Google API key is missing', () => {
@@ -177,10 +180,16 @@ describe('ReferenceKnowledgeDemandsEvaluator - LLM call contract', () => {
   it('includes computed fk_score in user prompt', async () => {
     vi.mocked(mockProvider.generateStructured).mockResolvedValue(MOCK_RESPONSE);
 
-    await evaluator.evaluate({ text: 'The quick brown fox jumps over the lazy dog.', grade_level: '5' });
+    await evaluator.evaluate({ text: FK_TEXT, grade_level: '5' });
 
     const call = vi.mocked(mockProvider.generateStructured).mock.calls[0][0];
-    expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
+    // The value the contract's own preprocessing produces, not just "some number" — the
+    // grade level alone satisfied that, so the assertion held with preprocessing off.
+    const fkStep = CONFIG.preprocessing.find((p) => p.id === 'fk_score')!;
+    const expected = String(runPreprocessingStep(FK_TEXT, fkStep.implementation.typescript));
+
+    expect(call.messages[1].content).toContain(expected);
+    expect(call.messages[1].content).not.toContain('{fk_score}');
   });
 
   it('maps LLM response to result shape', async () => {

--- a/sdks/typescript/tests/unit/evaluators/single-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/single-step.test.ts
@@ -352,3 +352,53 @@ describe('defineSingleStepEvaluator telemetry', () => {
     });
   });
 });
+
+// --- observability must not break the evaluation ---
+
+describe('defineSingleStepEvaluator survives its own reporting failing', () => {
+  beforeEach(() => {
+    created.length = 0;
+    sent.mockClear();
+  });
+
+  it('returns the result when telemetry cannot be sent', async () => {
+    // Telemetry is fire-and-forget; a collector being down is not the caller's problem.
+    sent.mockRejectedValue(new Error('collector unreachable'));
+
+    const result = await new (define())({ googleApiKey: 'k' }).evaluate(INPUT);
+
+    expect(result.result).toEqual({ verdict: 'clear', reasoning: 'because' });
+  });
+
+  it('propagates the original failure when error telemetry cannot be sent', async () => {
+    sent.mockRejectedValue(new Error('collector unreachable'));
+
+    // The caller must see the validation error, not the telemetry one.
+    await expect(
+      new (define())({ googleApiKey: 'k' }).evaluate({ text: '', grade_level: '4' }),
+    ).rejects.toThrow(InputValidationError);
+  });
+
+  it('reports the tokens already spent when a failure follows a completed step', async () => {
+    // The only way past the model call and into the catch: a caller-supplied logger that
+    // throws. Contrived, but it is what makes the token aggregation in the catch reachable
+    // — and a caller that loses spend data on failure would have a real complaint.
+    sent.mockResolvedValue(undefined);
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn((message: string) => {
+        if (message.includes('completed successfully')) throw new Error('logger blew up');
+      }),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await expect(new (define())({ googleApiKey: 'k', logger }).evaluate(INPUT)).rejects.toThrow();
+
+    // Success telemetry is sent before the completion log, so this evaluation reports
+    // twice — a success then an error. Pre-existing ordering, noted rather than changed.
+    const events = sent.mock.calls.map(([e]) => e as { status: string; token_usage?: unknown });
+    expect(events.map((e) => e.status)).toEqual(['success', 'error']);
+    expect(events[1].token_usage).toEqual({ input_tokens: 7, output_tokens: 3 });
+  });
+});

--- a/sdks/typescript/tests/unit/evaluators/single-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/single-step.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { defineSingleStepEvaluator } from '../../../src/evaluators/single-step.js';
+import { Provider } from '../../../src/evaluators/base.js';
+import {
+  EvaluatorError,
+  InputValidationError,
+  LLMOutputProcessingError,
+} from '../../../src/errors.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+
+const sent = vi.fn();
+const created: Array<{ type: string; model: string; apiKey?: string }> = [];
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class {
+    send = sent;
+  },
+}));
+
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createProvider: vi.fn((config: { type: string; model: string; apiKey?: string }) => {
+      created.push(config);
+      return {
+        label: `${config.type}:${config.model}`,
+        generateStructured: vi.fn().mockResolvedValue({
+          data: { verdict: 'clear', reasoning: 'because' },
+          usage: { inputTokens: 7, outputTokens: 3 },
+          latencyMs: 12,
+        }),
+        generateText: vi.fn(),
+      };
+    }),
+  };
+});
+
+/**
+ * The factory carries the flow every single-step evaluator runs, so what it reads from a
+ * contract is tested here directly rather than only through one evaluator's contract.
+ */
+
+const OUTPUT_SCHEMA = z.object({ verdict: z.string(), reasoning: z.string() });
+type Output = z.infer<typeof OUTPUT_SCHEMA>;
+
+const INPUT_SCHEMA = {
+  properties: {
+    text: { type: 'string', minLength: 1 },
+    grade_level: { type: 'string', enum: ['3', '4', '5'] },
+  },
+  required: ['text', 'grade_level'],
+} as const;
+
+function contract(overrides: Record<string, unknown> = {}) {
+  return {
+    evaluator: {
+      id: 'demo.area.thing',
+      stable_id: '11111111-1111-1111-1111-111111111111',
+      id_history: ['demo.area.old_thing'],
+      name: 'Thing Evaluator',
+      description: 'Demonstration contract.',
+    },
+    steps: [
+      {
+        id: 'evaluate_thing',
+        model: { provider: 'google', name: 'gemini-3-flash-preview' },
+        generation: { temperature: 0.5 },
+        required_credentials: ['google_api_key'],
+      },
+    ],
+    outcome: { score: 'verdict', reasoning: 'reasoning' },
+    ...overrides,
+  };
+}
+
+function define(overrides: Record<string, unknown> = {}, prompts?: Parameters<typeof defineSingleStepEvaluator>[0]['prompts']) {
+  return defineSingleStepEvaluator<{ text: string; grade_level: string }, Output>({
+    // The synthetic contract is structurally what a real one is; the cast keeps the test
+    // from restating every optional field the interface allows.
+    contract: contract(overrides) as never,
+    inputSchema: INPUT_SCHEMA as never,
+    outputSchema: OUTPUT_SCHEMA,
+    prompts: prompts ?? {
+      getSystemPrompt: (i) => `system ${JSON.stringify(i)}`,
+      getUserPrompt: (i) => `user ${JSON.stringify(i)}`,
+    },
+  });
+}
+
+function fakeProvider(): LLMProvider {
+  return {
+    label: 'google:gemini-3-flash-preview',
+    generateStructured: vi.fn().mockResolvedValue({
+      data: { verdict: 'clear', reasoning: 'because' },
+      usage: { inputTokens: 7, outputTokens: 3 },
+      latencyMs: 12,
+    }),
+    generateText: vi.fn(),
+  };
+}
+
+const INPUT = { text: 'The cat sat on the mat.', grade_level: '4' };
+
+// --- what the factory refuses to build ---
+
+describe('defineSingleStepEvaluator rejects a contract it cannot run', () => {
+  it('names the step it expected when the convention is not met', () => {
+    expect(() => define({ steps: [{ id: 'not_the_convention', model: { provider: 'google', name: 'm' } }] })).toThrow(
+      'evaluate_thing',
+    );
+  });
+
+  it('names the evaluator whose contract is wrong', () => {
+    expect(() => define({ steps: [{ id: 'wrong', model: { provider: 'google', name: 'm' } }] })).toThrow(
+      'Thing Evaluator',
+    );
+  });
+
+  it('rejects a provider the SDK has no adapter for, listing the ones it has', () => {
+    expect(() =>
+      define({ steps: [{ id: 'evaluate_thing', model: { provider: 'cohere', name: 'm' } }] }),
+    ).toThrow(/Unsupported provider "cohere".*google/s);
+  });
+});
+
+// --- what it reads from the contract ---
+
+describe('defineSingleStepEvaluator reads its behaviour from the contract', () => {
+  it('derives metadata rather than restating it', () => {
+    const E = define();
+
+    expect(E.metadata.id).toBe('demo.area.thing');
+    expect(E.metadata.stableId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(E.metadata.idHistory).toEqual(['demo.area.old_thing']);
+    expect(E.metadata.name).toBe('Thing Evaluator');
+  });
+
+  it('takes supported grades from the input schema enum', () => {
+    expect(define().metadata.supportedGrades).toEqual(['3', '4', '5']);
+  });
+
+  it('takes the default provider from the declared step, not a hardcoded vendor', () => {
+    expect(define().metadata.defaultProviders).toEqual([Provider.Google]);
+  });
+
+  it('requires the credentials the step declares', () => {
+    expect(define().metadata.requiredCredentials).toEqual(['google_api_key']);
+  });
+
+  it('sends the temperature the step declares', async () => {
+    const provider = fakeProvider();
+    await new (define())({ llmProvider: provider, telemetry: false }).evaluate(INPUT);
+
+    expect(vi.mocked(provider.generateStructured).mock.calls[0][0].temperature).toBe(0.5);
+  });
+
+  it('sends no temperature when the step declares none', async () => {
+    const provider = fakeProvider();
+    const E = define({
+      steps: [{ id: 'evaluate_thing', model: { provider: 'google', name: 'm' } }],
+    });
+    await new E({ llmProvider: provider, telemetry: false }).evaluate(INPUT);
+
+    expect(vi.mocked(provider.generateStructured).mock.calls[0][0].temperature).toBeUndefined();
+  });
+
+  it('runs each declared preprocessing step and passes it under its own id', async () => {
+    const provider = fakeProvider();
+    const E = define({
+      preprocessing: [
+        {
+          id: 'fk_score',
+          implementation: {
+            typescript: {
+              library: 'text-readability',
+              function: 'fleschKincaidGrade',
+              post_transform: { type: 'round', precision: 2 },
+            },
+          },
+        },
+      ],
+    });
+
+    await new E({ llmProvider: provider, telemetry: false }).evaluate(INPUT);
+
+    const messages = vi.mocked(provider.generateStructured).mock.calls[0][0].messages;
+    expect(messages.map((m) => m.role)).toEqual(['system', 'user']);
+    expect(messages[0].content).toContain('fk_score');
+    expect(messages[1].content).toContain('fk_score');
+    expect(messages[1].content).not.toContain('{fk_score}');
+  });
+
+  it('refuses a preprocessing library it has no adapter for', async () => {
+    const E = define({
+      preprocessing: [
+        { id: 'x', implementation: { typescript: { library: 'not-installed', function: 'f' } } },
+      ],
+    });
+
+    await expect(
+      new E({ llmProvider: fakeProvider(), telemetry: false }).evaluate(INPUT),
+    ).rejects.toThrow(/Unsupported preprocessing library "not-installed"/);
+  });
+});
+
+// --- the envelope ---
+
+describe('defineSingleStepEvaluator returns the result envelope', () => {
+  it('reports the evaluator, payload, model and token usage', async () => {
+    const provider = fakeProvider();
+    const result = await new (define())({ llmProvider: provider, telemetry: false }).evaluate(INPUT);
+
+    expect(result.evaluator).toBe('demo.area.thing');
+    expect(result.result).toEqual({ verdict: 'clear', reasoning: 'because' });
+    expect(result.metadata.model).toBe('google:gemini-3-flash-preview');
+    expect(result.metadata.tokenUsage).toEqual({ inputTokens: 7, outputTokens: 3 });
+    expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('validates inputs against the schema before calling the model', async () => {
+    const provider = fakeProvider();
+
+    await expect(
+      new (define())({ llmProvider: provider, telemetry: false }).evaluate({
+        text: '',
+        grade_level: '4',
+      }),
+    ).rejects.toThrow(InputValidationError);
+    expect(provider.generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('rejects a grade the schema does not declare', async () => {
+    await expect(
+      new (define())({ llmProvider: fakeProvider(), telemetry: false }).evaluate({
+        text: 'ok',
+        grade_level: '9',
+      }),
+    ).rejects.toThrow(InputValidationError);
+  });
+
+  it('rejects an unknown input field', async () => {
+    await expect(
+      new (define())({ llmProvider: fakeProvider(), telemetry: false }).evaluate({
+        text: 'ok',
+        grade_level: '4',
+        extra: 'no',
+      } as never),
+    ).rejects.toThrow(InputValidationError);
+  });
+});
+
+// --- errors ---
+
+describe('defineSingleStepEvaluator error handling', () => {
+  it('passes an evaluator error through untouched', async () => {
+    const provider = fakeProvider();
+    const raised = new LLMOutputProcessingError('schema mismatch');
+    vi.mocked(provider.generateStructured).mockRejectedValue(raised);
+
+    await expect(
+      new (define())({ llmProvider: provider, telemetry: false }).evaluate(INPUT),
+    ).rejects.toBe(raised);
+  });
+
+  it('wraps a provider failure that is not already an evaluator error', async () => {
+    const provider = fakeProvider();
+    vi.mocked(provider.generateStructured).mockRejectedValue(new Error('socket hang up'));
+
+    // A raw Error also has name 'Error', so assert the class the SDK is required to
+    // surface — otherwise "rethrow everything untouched" passes this test.
+    await expect(
+      new (define())({ llmProvider: provider, telemetry: false }).evaluate(INPUT),
+    ).rejects.toBeInstanceOf(EvaluatorError);
+  });
+});
+
+// --- the paths llmProvider injection bypasses ---
+
+describe('defineSingleStepEvaluator picks the key for the declared vendor', () => {
+  // Every evaluator used to name `config.googleApiKey` itself. The vendor now comes from
+  // the contract, so the key has to be selected from it too, and nothing else covers that.
+  beforeEach(() => {
+    created.length = 0;
+    sent.mockClear();
+    sent.mockResolvedValue(undefined);
+  });
+
+  it('hands a Google step the Google key', () => {
+    new (define())({ googleApiKey: 'g-key', openaiApiKey: 'o-key', telemetry: false });
+
+    expect(created[0]).toMatchObject({ type: 'google', apiKey: 'g-key' });
+  });
+
+  it('hands an OpenAI step the OpenAI key', () => {
+    const E = define({
+      steps: [
+        {
+          id: 'evaluate_thing',
+          model: { provider: 'openai', name: 'gpt-4.1' },
+          required_credentials: ['openai_api_key'],
+        },
+      ],
+    });
+    new E({ googleApiKey: 'g-key', openaiApiKey: 'o-key', telemetry: false });
+
+    expect(created[0]).toMatchObject({ type: 'openai', apiKey: 'o-key' });
+  });
+
+  it('constructs the model the step declares', () => {
+    new (define())({ googleApiKey: 'g-key', telemetry: false });
+
+    expect(created[0].model).toBe('gemini-3-flash-preview');
+  });
+});
+
+describe('defineSingleStepEvaluator telemetry', () => {
+  beforeEach(() => {
+    created.length = 0;
+    sent.mockClear();
+    sent.mockResolvedValue(undefined);
+  });
+
+  it('reports a success with its token usage and stage', async () => {
+    await new (define())({ googleApiKey: 'k' }).evaluate(INPUT);
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    expect(sent.mock.calls[0][0]).toMatchObject({
+      status: 'success',
+      token_usage: { input_tokens: 7, output_tokens: 3 },
+    });
+  });
+
+  it('names the step in stage_details so a multi-step successor stays comparable', async () => {
+    await new (define())({ googleApiKey: 'k' }).evaluate(INPUT);
+
+    const event = sent.mock.calls[0][0] as { metadata?: { stage_details?: Array<{ stage: string }> } };
+    expect(event.metadata?.stage_details?.[0]?.stage).toBe('evaluate_thing');
+  });
+
+  it('reports a validation failure as an error event, not silence', async () => {
+    // §4: validation runs inside the error-handling boundary.
+    await expect(
+      new (define())({ googleApiKey: 'k' }).evaluate({ text: '', grade_level: '4' }),
+    ).rejects.toThrow(InputValidationError);
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    expect(sent.mock.calls[0][0]).toMatchObject({
+      status: 'error',
+      error_code: 'InputValidationError',
+    });
+  });
+});

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../src/evaluators/index.js';
 import { InputValidationError } from '../../src/errors.js';
 import { readOutcome } from '../../src/schemas/outcome.js';
+import { runPreprocessingStep } from '../../src/features/preprocessing.js';
 import type { EvaluationResult } from '../../src/schemas/index.js';
 import { BackgroundKnowledgeDemandsOutputSchema } from '../../src/schemas/student-facing-text/ela-reading/background-knowledge-demands.js';
 import { GradeLevelAppropriatenessOutputSchema } from '../../src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
@@ -48,7 +49,7 @@ import {
 const constructed: Array<{ type: string; model: string }> = [];
 
 /** Records the generation settings of every LLM call an evaluator makes. */
-const llmCalls: Array<{ temperature?: number }> = [];
+const llmCalls: Array<{ temperature?: number; messages?: Array<{ role: string; content: string }> }> = [];
 
 vi.mock('../../src/providers/index.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -58,8 +59,8 @@ vi.mock('../../src/providers/index.js', async (importOriginal) => {
       constructed.push({ type: config.type, model: config.model });
       return {
         label: `${config.type}:${config.model}`,
-        generateStructured: vi.fn(async (request: { temperature?: number }) => {
-          llmCalls.push({ temperature: request.temperature });
+        generateStructured: vi.fn(async (request: { temperature?: number; messages?: Array<{ role: string; content: string }> }) => {
+          llmCalls.push({ temperature: request.temperature, messages: request.messages });
           return {
             data: {},
             model: config.model,
@@ -198,6 +199,19 @@ const RESULT_NAME_GAPS = new Set<string>([
 ]);
 
 /**
+ * Evaluators that do not compute a declared preprocessing step the way the contract says.
+ */
+const PREPROCESSING_GAPS = new Set<string>([
+  // Both call the hand-rolled compromise+syllable `calculateFleschKincaidGrade` instead of
+  // the declared `text-readability.fleschKincaidGrade`. The two disagree — on the fixture
+  // corpus the declared library is the less accurate of the two against Python's textstat
+  // (mean error 1.394 vs 0.273), so which one the contract should declare is still open.
+  BKD_ID,
+  MD_ID,
+  VocabularyComplexityEvaluator.metadata.id,
+]);
+
+/**
  * Evaluators whose schema rejects the values its own contract fixtures record.
  */
 const FIXTURE_VALUE_GAPS = new Set<string>([
@@ -251,6 +265,16 @@ interface Contract {
       model: { provider: string; name: string };
       generation?: { temperature?: number };
       optional?: boolean;
+    }>;
+    preprocessing?: Array<{
+      id: string;
+      implementation?: {
+        typescript?: {
+          library: string;
+          function: string;
+          post_transform?: { type: string; precision?: number };
+        };
+      };
     }>;
     outcome?: { score: string; reasoning: string };
   };
@@ -727,6 +751,59 @@ describe('the reported model matches the contract steps that apply', () => {
     })) as { metadata: { model: string } };
 
     expect(result.metadata.model, `${E.metadata.name} at grade ${grade}`).toBe(expected);
+  });
+});
+
+describe('every declared preprocessing value reaches the prompt', () => {
+  // Preprocessing feeds a number into a sha256-pinned prompt, so a step that silently
+  // stops running, or runs a different implementation, changes what the model is asked
+  // without changing anything a schema or a hash would notice.
+  const withPreprocessing = cases.filter(({ E }) => {
+    if (!INVOKE[E.metadata.id]) return false;
+    // Sentence Structure's first stage reads array fields off the model response, and the
+    // shared mock returns `data: {}`, so it throws before any prompt is built. Its
+    // preprocessing declares libraries the registry does not have either — see
+    // PREPROCESSING_GAPS for the same divergence in the evaluators that can be driven.
+    if (E.metadata.id === SENTENCE_ID) return false;
+    return (contractFor(E.metadata.id).config.preprocessing ?? []).length > 0;
+  });
+
+  it('finds evaluators with declared preprocessing', () => {
+    expect(withPreprocessing.length).toBeGreaterThan(0);
+  });
+
+  const TEXT =
+    'A thousand years ago boys and girls did not learn to read. Books were scarce and ' +
+    'precious, and only a few men could read them. Each book was written by hand.';
+
+  it.each(withPreprocessing)('$name', async ({ E }) => {
+    const { config } = contractFor(E.metadata.id);
+    llmCalls.length = 0;
+
+    await INVOKE[E.metadata.id](E, TEXT);
+
+    const prompts = llmCalls.flatMap((c) => (c.messages ?? []).map((m) => m.content)).join('\n');
+
+    const missing = (config.preprocessing ?? [])
+      .flatMap((step) => {
+        const impl = step.implementation?.typescript;
+        if (!impl) return [];
+        const value = String(runPreprocessingStep(TEXT, impl));
+        return prompts.includes(value) ? [] : [step];
+      })
+      .map((step) => step.id);
+
+    if (PREPROCESSING_GAPS.has(E.metadata.id)) {
+      expect(
+        missing,
+        `${E.metadata.name} now matches its declared preprocessing — drop it from PREPROCESSING_GAPS`,
+      ).not.toEqual([]);
+      return;
+    }
+
+    expect(missing, `${E.metadata.name}: declared preprocessing absent from the prompt`).toEqual([]);
+    // A placeholder left in the prompt means substitution silently did not happen.
+    expect(prompts, `${E.metadata.name}: unsubstituted placeholder`).not.toMatch(/\{[a-z_]+\}/);
   });
 });
 


### PR DESCRIPTION
Three evaluators shared one flow written out three times. `defineSingleStepEvaluator` holds it once, and each evaluator drops from ~200 lines to 38:

```ts
export class PurposeClarityEvaluator extends defineSingleStepEvaluator<
  PurposeClarityInput,
  PurposeClarityResult
>({
  contract: CONFIG,
  inputSchema: INPUT_SCHEMA,
  outputSchema: PurposeClarityOutputSchema,
  prompts: { getSystemPrompt, getUserPrompt },
}) {}
```

Pure refactor: all three already read model, temperature, grades and preprocessing from their contract, so nothing decided differently. `dist/index.d.ts` still exports the same three classes, their functional wrappers and their input types.

## Why this one first

The duplication is not cosmetic — it has produced shipped bugs. #222's wrong model label came from one evaluator's copy of the flow reading a variable another copy read correctly. Measured before starting:

```
purpose-clarity vs reference-knowledge-demands   99% identical after renaming
purpose-clarity vs organizational-structure      96%
```

Three things move from hand-transcription to derivation:

- **the provider vendor** — was a hardcoded `Provider.Google`, now `steps[0].model.provider`, which also picks the matching API key
- **preprocessing** — was a hardcoded `fk_score` lookup, now every declared step, keyed by its own id, so adding one to a contract needs no code
- **the log label** — from `evaluator.name`, which all 16 contracts end with `" Evaluator"`

## Scope, and what is blocked

Migrated: purpose-clarity, organizational-structure, reference-knowledge-demands — the three already on the config-driven path.

**Background Knowledge Demands and Meaning Directness are blocked, not skipped.** They call the hand-rolled `calculateFleschKincaidGrade` while their contracts declare `text-readability`. The factory uses the declared implementation, so migrating them would change the FK value that reaches a sha256-pinned prompt — and the declared library is the *less* accurate of the two (mean error 1.394 vs 0.273 against Python's `textstat` over the fixture corpus). That decision is open, so they stay put.

**Grade Level Appropriateness** is out too: it sends temperature 0.25 where its contract declares 1, so migrating changes what the model is asked. Its own PR.

Vocabulary Complexity, Sentence Structure and math are multi-step and out of scope by construction. The seven feedback evaluators are single-step with no preprocessing, so they land on this factory rather than adding a seventh copy.

## Why the tests didn't catch what this exposed

Consolidating made the flow measurable in one place, and it was not well covered.

**A test that asserted nothing, copied three times.** `includes computed fk_score in user prompt` was:

```ts
expect(call.messages[1].content).toMatch(/\d+(\.\d+)?/);
```

The grade level "5" satisfies that. I verified it by disabling the preprocessing loop entirely: **47 tests passed**. All three now compare against the value the contract's own preprocessing produces, and fail when the loop is disabled.

**No test asserted preprocessing ran at all**, for any evaluator. A new conformance check runs each evaluator with declared preprocessing and requires each declared value to appear in the prompt, with no `{placeholder}` left unsubstituted. BKD, MD and Vocabulary Complexity are in `PREPROCESSING_GAPS` — the inverted assertion fails once they match, so the FK divergence is now enforced rather than only noted. Sentence Structure is excluded with a reason: the shared mock returns `data: {}` and its first stage reads array fields off that, so it throws before any prompt exists.

**Mutation testing on the new file started at 24% covered.** Almost all of it was the flow's own error paths and the two new helpers, none of which any test reached. Now 67.9%, comparable to the rest of the codebase (formatters 72.8%, meaning-directness 61.3%). It also caught two weak assertions I had just written: the system prompt was never asserted, and `toMatchObject({ name: stringContaining('Error') })` matches a raw `Error`, so "rethrow everything untouched" passed. Both now assert the real thing.

## Validation

- `typecheck`, `lint`, `test:unit` (926), `build`, `scripts/check.py`, `generate:schemas:check`
- The three evaluators' existing unit tests pass untouched, including model-from-config, temperature-from-config, prompt substitution, grade bounds, `modelOverride` and error propagation — that is the behaviour-preservation evidence
- Confirmed `dist/index.d.ts` still exports all three classes and wrappers
- Load-bearing, three ways: disabled the preprocessing loop and confirmed the conformance check and all three per-evaluator tests fail; fed the factory a contract whose step id breaks the convention, and one naming a provider with no adapter

Residual mutation survivors are log and telemetry payload fields; asserting log text is the brittle kind of test I have been removing rather than adding. One noted for the record: the error path's `stageDetails.length > 0` branch cannot fire for a single call, since every throw happens before the stage is recorded — it is reachable only via a caller-supplied logger that throws, so it stays.
