### PR TITLE
feat(sdk): make the feedback family runnable in batch, with csv and json output

### DIFF
--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -355,7 +355,9 @@ async function main() {
           } }, reportMeta);
           fs.writeFileSync(path.join(outputDir, 'results-partial.csv'), bundle.csv);
           fs.writeFileSync(path.join(outputDir, 'results-partial.json'), bundle.json);
-          fs.writeFileSync(path.join(outputDir, 'results-partial.html'), bundle.html);
+          if (bundle.html) {
+            fs.writeFileSync(path.join(outputDir, 'results-partial.html'), bundle.html);
+          }
           console.log(`✓ Saved ${partial.length} partial results to ${outputDir}/\n`);
         } catch (error) {
           console.error('❌ Error saving partial results:', error instanceof Error ? error.message : String(error));
@@ -386,13 +388,18 @@ async function main() {
       const bundle = renderOutputs(family.id, output, reportMeta);
       fs.writeFileSync(path.join(outputDir, 'results.csv'), bundle.csv);
       fs.writeFileSync(path.join(outputDir, 'results.json'), bundle.json);
-      fs.writeFileSync(path.join(outputDir, 'results.html'), bundle.html);
+      if (bundle.html) {
+        fs.writeFileSync(path.join(outputDir, 'results.html'), bundle.html);
+      }
+
       console.log('\n📄 Output files:');
       console.log(`  ${outputDir}/`);
       console.log('    ├── results.csv');
-      console.log('    ├── results.json');
-      console.log('    └── results.html');
-      console.log(`\nOpen the report: ${path.join(outputDir, 'results.html')}`);
+      console.log(bundle.html ? '    ├── results.json' : '    └── results.json');
+      if (bundle.html) {
+        console.log('    └── results.html');
+        console.log(`\nOpen the report: ${path.join(outputDir, 'results.html')}`);
+      }
     } catch (error) {
       console.error('\n❌ Error writing output files:');
       if (error instanceof Error) console.error(`  ${error.message}`);

--- a/sdks/typescript/src/batch/families/feedback.ts
+++ b/sdks/typescript/src/batch/families/feedback.ts
@@ -13,6 +13,7 @@ import { readOutcome } from '../../schemas/outcome.js';
 import {
   type ColumnSpec,
   type EvaluatorFamily,
+  type FamilyMember,
   type FamilyRow,
   type FamilyRunContext,
   type FamilyRunner,
@@ -58,7 +59,7 @@ export const FEEDBACK_COLUMNS: ColumnSpec[] = [
 ];
 
 class FeedbackRunner implements FamilyRunner {
-  readonly members;
+  readonly members: FamilyMember[];
   private readonly instances = new Map<string, FeedbackEvaluator>();
 
   constructor(

--- a/sdks/typescript/src/batch/families/feedback.ts
+++ b/sdks/typescript/src/batch/families/feedback.ts
@@ -1,0 +1,126 @@
+import {
+  RevisionAccuracyEvaluator,
+  RevisionActionabilityEvaluator,
+  RevisionManageabilityEvaluator,
+  StrengthAcknowledgmentEvaluator,
+  StudentResponseSpecificityEvaluator,
+  ToneAppropriatenessEvaluator,
+  WithholdingAnswersEvaluator,
+} from '../../evaluators/index.js';
+import type { BaseEvaluatorConfig, ModelOverride, Provider } from '../../evaluators/base.js';
+import type { EvaluationResult } from '../../schemas/index.js';
+import { readOutcome } from '../../schemas/outcome.js';
+import {
+  type ColumnSpec,
+  type EvaluatorFamily,
+  type FamilyRow,
+  type FamilyRunContext,
+  type FamilyRunner,
+  type KeyKind,
+  type TaskOutcome,
+  resolveMembers,
+} from './family.js';
+
+/** The shape this family needs from an evaluator: named inputs in, envelope out. */
+interface FeedbackEvaluator {
+  evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
+}
+
+type EvaluatorClass = (new (config: BaseEvaluatorConfig) => FeedbackEvaluator) & {
+  metadata: {
+    id: string;
+    name: string;
+    defaultProviders: readonly Provider[];
+    outcome?: { score: string; reasoning: string };
+  };
+};
+
+/**
+ * The members, in report order. Everything else about them — id, display name, provider,
+ * which field holds the verdict — is read off the class, which reads it off the contract.
+ */
+const MEMBER_CLASSES: readonly EvaluatorClass[] = [
+  RevisionAccuracyEvaluator,
+  RevisionActionabilityEvaluator,
+  RevisionManageabilityEvaluator,
+  StrengthAcknowledgmentEvaluator,
+  StudentResponseSpecificityEvaluator,
+  ToneAppropriatenessEvaluator,
+  WithholdingAnswersEvaluator,
+];
+
+const BY_ID = new Map(MEMBER_CLASSES.map((E) => [E.metadata.id, E]));
+
+/** The columns a row must carry, matching what every member's input schema declares. */
+export const FEEDBACK_COLUMNS: ColumnSpec[] = [
+  { name: 'student_text', required: true },
+  { name: 'feedback_text', required: true },
+];
+
+class FeedbackRunner implements FamilyRunner {
+  readonly members;
+  private readonly instances = new Map<string, FeedbackEvaluator>();
+
+  constructor(
+    private readonly ctx: FamilyRunContext,
+    selectedMemberIds?: string[],
+  ) {
+    this.members = resolveMembers(FEEDBACK_FAMILY, selectedMemberIds);
+  }
+
+  private getEvaluator(memberId: string): FeedbackEvaluator {
+    let instance = this.instances.get(memberId);
+    if (!instance) {
+      const EvaluatorClass = BY_ID.get(memberId);
+      if (!EvaluatorClass) throw new Error(`Unknown feedback evaluator: ${memberId}`);
+      instance = new EvaluatorClass({
+        googleApiKey: this.ctx.googleApiKey,
+        openaiApiKey: this.ctx.openaiApiKey,
+        anthropicApiKey: this.ctx.anthropicApiKey,
+        maxRetries: this.ctx.maxRetries,
+        telemetry: this.ctx.telemetry,
+        modelOverride: this.ctx.modelOverride,
+        llmProvider: this.ctx.llmProvider,
+      });
+      this.instances.set(memberId, instance);
+    }
+    return instance;
+  }
+
+  async runTask(row: FamilyRow, memberId: string): Promise<TaskOutcome> {
+    // Built explicitly rather than passed through: a row carries every column in the CSV,
+    // and an evaluator rejects keys its schema does not declare.
+    const result = await this.getEvaluator(memberId).evaluate({
+      student_text: row.columns['student_text'],
+      feedback_text: row.columns['feedback_text'],
+    });
+
+    const { score, reasoning } = readOutcome(result, BY_ID.get(memberId)?.metadata.outcome);
+
+    // A report cell has to be a string, and the verdict here is the integer 0 or 1, which
+    // readOutcome has already stringified. An absent verdict renders blank.
+    return { score: score ?? '', reasoning };
+  }
+}
+
+export const FEEDBACK_FAMILY: EvaluatorFamily = {
+  id: 'feedback',
+  name: 'Teacher Feedback Quality',
+  description: "Evaluates written feedback on a student's writing against seven criteria",
+  members: MEMBER_CLASSES.map((E) => ({ id: E.metadata.id, name: E.metadata.name })),
+  columns: FEEDBACK_COLUMNS,
+  maxInputRows: 50,
+  requiredKeys(selectedMemberIds: string[], modelOverride?: ModelOverride): KeyKind[] {
+    if (modelOverride) return [modelOverride.provider];
+    const keys = new Set<KeyKind>();
+    for (const member of resolveMembers(FEEDBACK_FAMILY, selectedMemberIds)) {
+      for (const provider of BY_ID.get(member.id)?.metadata.defaultProviders ?? []) {
+        keys.add(provider);
+      }
+    }
+    return [...keys];
+  },
+  createRunner(ctx: FamilyRunContext, selectedMemberIds?: string[]): FamilyRunner {
+    return new FeedbackRunner(ctx, selectedMemberIds);
+  },
+};

--- a/sdks/typescript/src/batch/families/registry.ts
+++ b/sdks/typescript/src/batch/families/registry.ts
@@ -1,8 +1,9 @@
 import type { EvaluatorFamily } from './family.js';
 import { QTC_FAMILY } from './qtc.js';
 import { STANDARDS_FAMILY } from './standards.js';
+import { FEEDBACK_FAMILY } from './feedback.js';
 
-const FAMILIES: EvaluatorFamily[] = [QTC_FAMILY, STANDARDS_FAMILY];
+const FAMILIES: EvaluatorFamily[] = [QTC_FAMILY, STANDARDS_FAMILY, FEEDBACK_FAMILY];
 
 /** All evaluator families available to the batch tool. */
 export function getFamilies(): EvaluatorFamily[] {

--- a/sdks/typescript/src/batch/output.ts
+++ b/sdks/typescript/src/batch/output.ts
@@ -1,6 +1,7 @@
 import type { BatchOutput } from './types.js';
 import { formatAsCSV, formatAsHTML, formatAsJSON, type ReportMeta } from './formatters.js';
 import { STANDARDS_FAMILY } from './families/standards.js';
+import { QTC_FAMILY } from './families/qtc.js';
 import {
   formatStandardsCSV,
   formatStandardsHTML,
@@ -10,13 +11,17 @@ import {
 export interface OutputBundle {
   csv: string;
   json: string;
-  html: string;
+  /** Absent for families with no report of their own — see {@link renderOutputs}. */
+  html?: string;
 }
 
 /**
- * Render CSV + JSON + HTML for a completed batch, choosing the family's
- * projections. The standards family emits a verdict browser and joinable JSON;
- * every other family uses the text-complexity report shape.
+ * Render the outputs for a completed batch, choosing the family's projections.
+ *
+ * CSV and JSON are family-agnostic: original columns plus each evaluator's score,
+ * reasoning and status. HTML is not — a report is designed around what a family's
+ * verdict means. Standards emits a verdict browser and text-complexity a rubric report;
+ * a family without one gets no `html`, rather than a report built for other data.
  */
 export function renderOutputs(familyId: string, output: BatchOutput, meta: ReportMeta): OutputBundle {
   if (familyId === STANDARDS_FAMILY.id) {
@@ -32,9 +37,16 @@ export function renderOutputs(familyId: string, output: BatchOutput, meta: Repor
       html: formatStandardsHTML(output, sMeta),
     };
   }
-  return {
+  const bundle: OutputBundle = {
     csv: formatAsCSV(output),
     json: formatAsJSON(output, meta),
-    html: formatAsHTML(output, meta),
   };
+
+  // The text-complexity report averages a four-point complexity scale and charts
+  // grade-band alignment, so it only means anything for that family.
+  if (familyId === QTC_FAMILY.id) {
+    bundle.html = formatAsHTML(output, meta);
+  }
+
+  return bundle;
 }

--- a/sdks/typescript/tests/unit/batch/feedback-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/feedback-family.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FEEDBACK_FAMILY } from '../../../src/batch/families/feedback.js';
+import { getFamilies, getFamily } from '../../../src/batch/families/registry.js';
+import { validateRequiredColumns, normalizeRow } from '../../../src/batch/families/family.js';
+import { renderOutputs } from '../../../src/batch/output.js';
+import { Provider } from '../../../src/evaluators/base.js';
+import type { BatchOutput, BatchResult } from '../../../src/batch/types.js';
+import type { LLMProvider, LLMResponse } from '../../../src/providers/base.js';
+
+const STUDENT_TEXT = 'My dog is brown. He runs fast.';
+const FEEDBACK_TEXT = 'Try adding a topic sentence.';
+
+const RESPONSE: LLMResponse<{ quality_score: number; reasoning: string }> = {
+  data: { quality_score: 1, reasoning: 'Names a concrete next step.' },
+  model: 'gpt-5.4-2026-03-05',
+  usage: { inputTokens: 9, outputTokens: 3 },
+  latencyMs: 5,
+};
+
+function llmProvider(): LLMProvider {
+  return {
+    label: 'openai:gpt-5.4-2026-03-05',
+    generateStructured: vi.fn().mockResolvedValue(RESPONSE),
+    generateText: vi.fn(),
+  };
+}
+
+describe('the feedback family is selectable', () => {
+  it('is registered', () => {
+    expect(getFamilies().map((f) => f.id)).toContain(FEEDBACK_FAMILY.id);
+    expect(getFamily('feedback')).toBe(FEEDBACK_FAMILY);
+  });
+
+  it('has all seven criteria as members', () => {
+    expect(FEEDBACK_FAMILY.members).toHaveLength(7);
+    expect(FEEDBACK_FAMILY.members.map((m) => m.id).every((id) => id.startsWith('feedback.'))).toBe(
+      true,
+    );
+  });
+
+  it('requires the two text columns', () => {
+    expect(FEEDBACK_FAMILY.columns.map((c) => c.name)).toEqual(['student_text', 'feedback_text']);
+    // Both directions: each column is required, so neither can be quietly optional.
+    expect(() => validateRequiredColumns(FEEDBACK_FAMILY, ['student_text'])).toThrow(
+      /feedback_text/,
+    );
+    expect(() => validateRequiredColumns(FEEDBACK_FAMILY, ['feedback_text'])).toThrow(
+      /student_text/,
+    );
+    expect(() =>
+      validateRequiredColumns(FEEDBACK_FAMILY, ['student_text', 'feedback_text']),
+    ).not.toThrow();
+  });
+
+  it('asks only for the key its members declare', () => {
+    // Read off each evaluator's contract rather than restated here, so a contract that
+    // moves to another vendor changes this without a code edit.
+    expect(FEEDBACK_FAMILY.requiredKeys(FEEDBACK_FAMILY.members.map((m) => m.id))).toEqual([
+      Provider.OpenAI,
+    ]);
+  });
+
+  it('honours a model override for the key it needs', () => {
+    const keys = FEEDBACK_FAMILY.requiredKeys([], {
+      provider: Provider.Google,
+      model: 'gemini-3-flash-preview',
+    });
+
+    expect(keys).toEqual([Provider.Google]);
+  });
+});
+
+describe('the feedback family runs a row', () => {
+  const columns = { student_text: STUDENT_TEXT, feedback_text: FEEDBACK_TEXT };
+  const row = normalizeRow({ rowIndex: 0, columns, originalRow: columns }, FEEDBACK_FAMILY);
+
+  it('passes both texts to the evaluator and reports the verdict', async () => {
+    const provider = llmProvider();
+    const runner = FEEDBACK_FAMILY.createRunner({ llmProvider: provider, telemetry: false });
+    const memberId = FEEDBACK_FAMILY.members[0].id;
+
+    const outcome = await runner.runTask(row, memberId);
+
+    const prompts = vi
+      .mocked(provider.generateStructured)
+      .mock.calls.flatMap((c) => c[0].messages.map((m) => m.content))
+      .join('\n');
+    expect(prompts).toContain(STUDENT_TEXT);
+    expect(prompts).toContain(FEEDBACK_TEXT);
+
+    // readOutcome stringifies, so the integer verdict arrives as '1'.
+    expect(outcome).toEqual({ score: '1', reasoning: 'Names a concrete next step.' });
+  });
+
+  it('reports a zero verdict rather than treating it as absent', async () => {
+    const provider = llmProvider();
+    vi.mocked(provider.generateStructured).mockResolvedValue({
+      ...RESPONSE,
+      data: { quality_score: 0, reasoning: 'No next step given.' },
+    });
+    const runner = FEEDBACK_FAMILY.createRunner({ llmProvider: provider, telemetry: false });
+
+    const outcome = await runner.runTask(row, FEEDBACK_FAMILY.members[0].id);
+
+    // '0' is a verdict. Rendering it blank would read as "not evaluated".
+    expect(outcome.score).toBe('0');
+  });
+
+  it('names an unknown member rather than failing obscurely', () => {
+    const runner = FEEDBACK_FAMILY.createRunner({ llmProvider: llmProvider(), telemetry: false });
+
+    expect(runner.runTask(row, 'feedback.ela_writing.not_a_member')).rejects.toThrow(
+      /Unknown feedback evaluator/,
+    );
+  });
+
+  it('builds one evaluator per member, not one per row', async () => {
+    // Each construction validates credentials and builds a provider adapter, so a runner
+    // that rebuilt per row would pay that on every row of a 50-row batch.
+    const provider = llmProvider();
+    const runner = FEEDBACK_FAMILY.createRunner({ llmProvider: provider, telemetry: false });
+    const memberId = FEEDBACK_FAMILY.members[0].id;
+
+    const secondRow = normalizeRow(
+      { rowIndex: 1, columns, originalRow: columns },
+      FEEDBACK_FAMILY,
+    );
+    await runner.runTask(row, memberId);
+    await runner.runTask(secondRow, memberId);
+
+    const instances = (runner as unknown as { instances: Map<string, unknown> }).instances;
+    expect(instances.size).toBe(1);
+  });
+
+  it('runs only the members selected', () => {
+    const [first] = FEEDBACK_FAMILY.members;
+    const runner = FEEDBACK_FAMILY.createRunner(
+      { llmProvider: llmProvider(), telemetry: false },
+      [first.id],
+    );
+
+    expect(runner.members.map((m) => m.id)).toEqual([first.id]);
+  });
+});
+
+describe('a family without a report of its own emits no HTML', () => {
+  // A report is designed around what a family's verdict means, so a family without one
+  // gets CSV and JSON — which are family-agnostic — rather than a report built for other
+  // data. Feedback scores 0/1 with no grade, and the text-complexity report averages a
+  // four-point scale and charts grade bands.
+  function bundleFor(familyId: string) {
+    const result: BatchResult = {
+      rowIndex: 0,
+      text: STUDENT_TEXT,
+      gradeLevel: '',
+      evaluatorId: FEEDBACK_FAMILY.members[0].id,
+      status: 'success',
+      score: '1',
+      reasoning: 'ok',
+      processingTimeMs: 1,
+      columns: { student_text: STUDENT_TEXT, feedback_text: FEEDBACK_TEXT },
+      originalRow: { student_text: STUDENT_TEXT, feedback_text: FEEDBACK_TEXT },
+    };
+    const output: BatchOutput = {
+      results: [result],
+      summary: {
+        totalTasks: 1,
+        successful: 1,
+        failed: 0,
+        durationMs: 1,
+        resultsPerEvaluator: {},
+      },
+    };
+    return renderOutputs(familyId, output, {
+      csvPath: 'in.csv',
+      groupId: familyId,
+      reportId: 'r1',
+      generatedAt: new Date('2026-08-29T00:00:00Z'),
+      totalInputRows: 1,
+    });
+  }
+
+  it('gives the feedback family csv and json but no html', () => {
+    const bundle = bundleFor(FEEDBACK_FAMILY.id);
+
+    expect(bundle.html).toBeUndefined();
+    expect(bundle.csv).not.toBe('');
+    expect(JSON.parse(bundle.json).results).toHaveLength(1);
+  });
+
+  it('still carries both texts and the verdict in the csv', () => {
+    const csv = bundleFor(FEEDBACK_FAMILY.id).csv;
+
+    expect(csv).toContain(STUDENT_TEXT);
+    expect(csv).toContain(FEEDBACK_TEXT);
+    expect(csv.split('\n')[0]).toContain('student_text');
+  });
+
+  it('still gives the text-complexity family its report', () => {
+    expect(bundleFor('text-complexity').html).toBeTypeOf('string');
+  });
+});

--- a/sdks/typescript/tests/unit/batch/feedback-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/feedback-family.test.ts
@@ -106,10 +106,10 @@ describe('the feedback family runs a row', () => {
     expect(outcome.score).toBe('0');
   });
 
-  it('names an unknown member rather than failing obscurely', () => {
+  it('names an unknown member rather than failing obscurely', async () => {
     const runner = FEEDBACK_FAMILY.createRunner({ llmProvider: llmProvider(), telemetry: false });
 
-    expect(runner.runTask(row, 'feedback.ela_writing.not_a_member')).rejects.toThrow(
+    await expect(runner.runTask(row, 'feedback.ela_writing.not_a_member')).rejects.toThrow(
       /Unknown feedback evaluator/,
     );
   });

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -329,11 +329,15 @@ describe('standards CSV — escaping, header contract, and blank handling', () =
 
 describe('standards HTML — payload escaping', () => {
   function htmlFor(question: string): string {
-    return renderOutputs(
+    const { html } = renderOutputs(
       'math-standards-alignment',
       output([standardsResult({ payload: { statementCode: '4.OA.A.1', question, jurisdiction: 'Multi-State', alignedCount: 1, totalCount: 2, learningComponents: [] } })]),
       meta,
-    ).html;
+    );
+    // The standards family has a report of its own; a bundle without one here would mean
+    // the dispatch stopped finding it, which the assertions below could not distinguish.
+    if (!html) throw new Error('standards family emitted no HTML report');
+    return html;
   }
 
   it('escapes angle brackets and ampersands so the payload cannot close the script tag', () => {

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -28,6 +28,7 @@ import { StrengthAcknowledgmentOutputSchema } from '../../src/schemas/feedback/e
 import { StudentResponseSpecificityOutputSchema } from '../../src/schemas/feedback/ela-writing/student-response-specificity.js';
 import { ToneAppropriatenessOutputSchema } from '../../src/schemas/feedback/ela-writing/tone-appropriateness.js';
 import { WithholdingAnswersOutputSchema } from '../../src/schemas/feedback/ela-writing/withholding-answers.js';
+import { QTC_FAMILY } from '../../src/batch/families/qtc.js';
 import { InputValidationError } from '../../src/errors.js';
 import { readOutcome } from '../../src/schemas/outcome.js';
 import { runPreprocessingStep } from '../../src/features/preprocessing.js';
@@ -185,8 +186,6 @@ const ORDER_GAPS = new Set<string>([
   PurposeClarityEvaluator.metadata.id,
   OrganizationalStructureEvaluator.metadata.id,
   ReferenceKnowledgeDemandsEvaluator.metadata.id,
-  // The standards family has its own report, which does not use this ordering.
-  MathStandardsAlignmentEvaluator.metadata.id,
 ]);
 
 /**
@@ -742,7 +741,11 @@ describe('the report can order every family member', () => {
 
   const declared = at === -1 ? '' : template.slice(at, template.indexOf(']', at));
 
-  const members = getFamilies().flatMap((f) => f.members.map((m) => ({ family: f.id, id: m.id })));
+  // Only the text-complexity family renders this template: standards has its own report
+  // and the feedback family has none yet, so neither consults this ordering.
+  const members = getFamilies()
+    .filter((f) => f.id === QTC_FAMILY.id)
+    .flatMap((f) => f.members.map((m) => ({ family: f.id, id: m.id })));
 
   it.each(members)('$family / $id', ({ id }) => {
     expectAgainstContract(


### PR DESCRIPTION
Makes the seven feedback evaluators runnable from the batch tool:

```
evaluators-batch feedback.csv --family feedback
```

Columns are `student_text` and `feedback_text`. Output is `results.csv` and `results.json`.

## No HTML report for this family, deliberately

A report is designed around what a family's verdict *means*, and the existing one is built for text complexity: it averages a four-point complexity scale and charts grade-band alignment. Feedback has neither — its verdict is a pass or fail per criterion, and there is no grade at all. Handing it that template would produce a page of empty averages, which reads as "nothing was found" rather than "this chart does not apply".

So `renderOutputs` now returns `html` only for the families that have a report of their own. CSV and JSON were already family-agnostic — original columns plus each evaluator's score, reasoning and status — so they need nothing.

The CLI writes and announces the report only when there is one:

```
📄 Output files:
  /tmp/out/
    ├── results.csv
    └── results.json
```

Text complexity and standards are untouched, including the "Open the report" line. Designed reports for the other families come later.

## The family

Its members, display names, providers and verdict field all come off each evaluator class, which reads them from its contract — so one array of classes is the only list:

```ts
const MEMBER_CLASSES = [RevisionAccuracyEvaluator, /* … */];
const BY_ID = new Map(MEMBER_CLASSES.map((E) => [E.metadata.id, E]));
members: MEMBER_CLASSES.map((E) => ({ id: E.metadata.id, name: E.metadata.name })),
```

`requiredKeys` reads `defaultProviders`, so a contract moving to another vendor changes which key the run asks for with no code edit. The text-complexity family spells its eight members out three times over; worth collapsing the same way when it is next touched.

## A conformance test that was asking the wrong question

`the report can order every family member` checks every member of every family appears in `EVALUATOR_ORDER` inside `report-template.html`. But only text complexity renders that template — standards has its own report and feedback has none — so it was failing for seven evaluators over an ordering they never consult.

Scoped to the family that uses the template. That also retires math's `ORDER_GAPS` entry, which existed only to encode "standards has its own report"; the remaining three entries are a real gap and stay.

## Validation

- `typecheck`, `lint`, `test:unit` (1037), `build`, `scripts/check.py`
- Ran the built CLI end to end against a real CSV: all seven members dispatched, and the output directory contains `results.csv` and `results.json` and no `results.html`
- Ran text complexity the same way and confirmed `results.html` is still written and still announced
- Mutation testing: `output.ts` **100%** (12/12), so the dispatch change is fully covered; `feedback.ts` 82.6% on covered lines
- Mutation testing found two untested properties, now asserted: that each column is required in *both* directions — I had only tested that a missing `feedback_text` is rejected — and that the runner builds one evaluator per member rather than one per row, which on a 50-row batch is 7 constructions versus 350

Remaining survivors are `?.` guards on a member lookup that `getEvaluator` has already thrown on, so they are unreachable rather than untested.
