### PR TITLE
fix(sdk)!: put Grade Level Appropriateness on its contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,7 @@ sdks/typescript/src/schemas/feedback/ela-writing/student-response-specificity.ts
 sdks/typescript/src/schemas/feedback/ela-writing/tone-appropriateness.ts linguist-generated=true
 sdks/typescript/src/schemas/feedback/ela-writing/withholding-answers.ts linguist-generated=true
 sdks/typescript/src/schemas/student-facing-text/ela-reading/background-knowledge-demands.ts linguist-generated=true
+sdks/typescript/src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.ts linguist-generated=true
 sdks/typescript/src/schemas/student-facing-text/ela-reading/meaning-directness.ts linguist-generated=true
 sdks/typescript/src/schemas/student-facing-text/ela-reading/organizational-structure.ts linguist-generated=true
 sdks/typescript/src/schemas/student-facing-text/ela-reading/purpose-clarity.ts linguist-generated=true

--- a/sdks/typescript/src/batch/formatters.ts
+++ b/sdks/typescript/src/batch/formatters.ts
@@ -9,7 +9,7 @@ import { GradeLevelAppropriatenessEvaluator } from '../evaluators/student-facing
 // column instead of failing.
 const GLA_EVALUATOR_ID = GradeLevelAppropriatenessEvaluator.metadata.id;
 
-const GRADE_BANDS = ['K-1', '2-3', '4-5', '6-8', '9-10', '11-CCR'] as const;
+const GRADE_BANDS = ['K-1', '2-3', '4-5', '6-8', '9-10', '11-12'] as const;
 type GradeBand = typeof GRADE_BANDS[number];
 
 // Complexity string scores → numeric

--- a/sdks/typescript/src/batch/report-template.html
+++ b/sdks/typescript/src/batch/report-template.html
@@ -382,7 +382,7 @@
             row_id: '7', grade: '11', source: 'lit_unit_4',
             text: 'Shakespeare\'s use of dramatic irony in Othello functions as a mechanism of tragic inevitability, positioning the audience as unwilling witnesses to the protagonist\'s epistemological collapse.',
             __gla_status: 'On Band', __gla_band: '11-12',
-            __gla_reasoning: 'Sophisticated literary analysis vocabulary and complex syntax are well-suited to grades 11–CCR.',
+            __gla_reasoning: 'Sophisticated literary analysis vocabulary and complex syntax are well-suited to grades 11–12.',
             __subject_matter_knowledge_score: 'Exceedingly complex',
             __subject_matter_knowledge_reasoning: 'Requires familiarity with Shakespearean drama, literary theory, and epistemological concepts; assumes high prior exposure to canonical literature.',
             __vocabulary_score: 'Exceedingly complex',

--- a/sdks/typescript/src/batch/report-template.html
+++ b/sdks/typescript/src/batch/report-template.html
@@ -256,7 +256,7 @@
         },
       ],
       gradeBandDistribution: {
-        bands: ['K-1', '2-3', '4-5', '6-8', '9-10', '11-CCR'],
+        bands: ['K-1', '2-3', '4-5', '6-8', '9-10', '11-12'],
         data: [
           { onBand: 0,  adjacent: 0,  offTarget: 0,  total: 0  },
           { onBand: 32, adjacent: 18, offTarget: 5,  total: 55 },
@@ -267,7 +267,7 @@
         ],
       },
       complexityHeatmap: {
-        bands: ['K-1', '2-3', '4-5', '6-8', '9-10', '11-CCR'],
+        bands: ['K-1', '2-3', '4-5', '6-8', '9-10', '11-12'],
         evaluators: ['Background Knowledge Demands Evaluator', 'Vocabulary Complexity Evaluator', 'Sentence Structure Evaluator', 'Meaning Directness Evaluator'],
         evaluatorIds: ['student_facing_text.ela_reading.background_knowledge_demands', 'student_facing_text.ela_reading.vocabulary_complexity', 'student_facing_text.ela_reading.sentence_structure', 'student_facing_text.ela_reading.meaning_directness'],
         values: [
@@ -325,7 +325,7 @@
           {
             row_id: '3', grade: '8', source: 'biology_unit_2',
             text: 'The mitochondria, often described as the powerhouse of the cell, are organelles found in the cytoplasm of eukaryotic cells, where they generate most of the adenosine triphosphate used for cellular energy.',
-            __gla_status: 'Off Target', __gla_band: '11-CCR',
+            __gla_status: 'Off Target', __gla_band: '11-12',
             __gla_reasoning: 'Text uses advanced biochemical terminology (adenosine triphosphate, eukaryotic) more appropriate for upper secondary or college-level readers.',
             __subject_matter_knowledge_score: 'Very complex',
             __subject_matter_knowledge_reasoning: 'Assumes familiarity with cell biology, organelle function, and biochemical energy systems well beyond typical grade 8 expectations.',
@@ -381,7 +381,7 @@
           {
             row_id: '7', grade: '11', source: 'lit_unit_4',
             text: 'Shakespeare\'s use of dramatic irony in Othello functions as a mechanism of tragic inevitability, positioning the audience as unwilling witnesses to the protagonist\'s epistemological collapse.',
-            __gla_status: 'On Band', __gla_band: '11-CCR',
+            __gla_status: 'On Band', __gla_band: '11-12',
             __gla_reasoning: 'Sophisticated literary analysis vocabulary and complex syntax are well-suited to grades 11–CCR.',
             __subject_matter_knowledge_score: 'Exceedingly complex',
             __subject_matter_knowledge_reasoning: 'Requires familiarity with Shakespearean drama, literary theory, and epistemological concepts; assumes high prior exposure to canonical literature.',

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
@@ -1,206 +1,49 @@
-import type { LLMProvider } from '../../../providers/index.js';
 import {
   GradeLevelAppropriatenessOutputSchema,
   type GradeLevelAppropriatenessResult,
 } from '../../../schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
-import { getSystemPrompt, getUserPrompt } from '../../../prompts/grade-level-appropriateness/index.js';
 import type { EvaluationResult } from '../../../schemas/index.js';
-import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
-import { validateInputs, type InputsOf } from '../../inputs.js';
-import { declaredCredentials } from '../../credentials.js';
-import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json';
-import { EvaluatorError, wrapProviderError } from '../../../errors.js';
+import type { BaseEvaluatorConfig } from '../../base.js';
+import { defineSingleStepEvaluator } from '../../single-step.js';
+import type { InputsOf } from '../../inputs.js';
+import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/system.txt';
+import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
+import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json';
 
-/**
- * Grade Level Appropriateness Evaluator
- *
- * Evaluates whether AI-generated text is suitable for a given grade band.
- * Uses a structured 4-step analysis process:
- * 1. Quantitative analysis (word count, Flesch-Kincaid)
- * 2. Qualitative complexity (text structure, language, purpose, knowledge demands)
- * 3. Background knowledge assessment
- * 4. Synthesis and final recommendation
- *
- * Returns:
- * - Target grade band (K-1, 2-3, 4-5, 6-8, 9-10, 11-CCR)
- * - Alternative grade band (with scaffolding)
- * - Specific scaffolding recommendations
- *
- * @example
- * ```typescript
- * const evaluator = new GradeLevelAppropriatenessEvaluator({
- *   googleApiKey: process.env.GOOGLE_API_KEY
- * });
- *
- * const result = await evaluator.evaluate({ text });
- * console.log(result.result.grade_band); // "9-10"
- * console.log(result.result.alternative_grade_band); // "6-8"
- * console.log(result.result.scaffolding_needed);
- * ```
- */
 /** What this evaluator accepts, taken from its `input_schema.json`. */
 export type GradeLevelAppropriatenessInput = InputsOf<typeof INPUT_SCHEMA>;
 
-export class GradeLevelAppropriatenessEvaluator extends BaseEvaluator {
-  static readonly metadata = {
-    id: CONFIG.evaluator.id,
-    stableId: CONFIG.evaluator.stable_id,
-    idHistory: CONFIG.evaluator.id_history,
-    name: CONFIG.evaluator.name,
-    description: CONFIG.evaluator.description,
-    outcome: CONFIG.outcome,
-    requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: [] as const, // No gradeLevel parameter required - evaluates what grade level the text is appropriate for
-    defaultProviders: [Provider.Google] as const,
-  };
-
-  private provider: LLMProvider;
-
-  constructor(config: BaseEvaluatorConfig) {
-    // Call base constructor for common setup (telemetry, API key validation, etc.)
-    super(config);
-
-    this.provider = this.createConfiguredProvider(
-      Provider.Google, 'gemini-2.5-pro', config.googleApiKey
-    );
-  }
-
-  /**
-   * Evaluate grade level appropriateness for a given text
-   *
-   * @param text - The text to evaluate
-   * @returns Evaluation result with grade level recommendations and scaffolding suggestions
-   * @throws {InputValidationError} If text is empty or too short/long
-   * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
-   * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
-   * @throws {LLMOutputProcessingError} If the model's response fails its output schema
-   */
-  async evaluate(input: GradeLevelAppropriatenessInput): Promise<EvaluationResult<GradeLevelAppropriatenessResult>> {
-    let text = '';
-    const startTime = Date.now();
-
-    try {
-      // Inside the try so a validation failure is telemetered as an error event,
-      // and before the inputs are read so a non-object is reported as one.
-      validateInputs(input, INPUT_SCHEMA);
-      ({ text } = input);
-
-      this.logger.info('Starting grade level appropriateness evaluation', {
-        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-        operation: 'evaluate',
-        textLength: text.length,
-      });
-
-      this.logger.debug('Evaluating grade level appropriateness', {
-        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-        operation: 'grade_evaluation',
-      });
-      const userPrompt = getUserPrompt(text);
-
-      const response = await this.provider.generateStructured({
-        messages: [
-          { role: 'system', content: getSystemPrompt() },
-          { role: 'user', content: userPrompt },
-        ],
-        schema: GradeLevelAppropriatenessOutputSchema,
-        temperature: 0.25,
-      });
-
-      const latencyMs = Date.now() - startTime;
-
-      const tokenUsage = {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-      };
-
-      const result = {
-        // `grade` is the model's output field, declared in the eval's schema —
-        // not the SDK's parameter name.
-        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-        result: response.data,
-        metadata: {
-          model: this.provider.label,
-          processingTimeMs: latencyMs,
-          tokenUsage: {
-            inputTokens: tokenUsage.input_tokens,
-            outputTokens: tokenUsage.output_tokens,
-          },
-        },
-      };
-
-      // Send success telemetry (fire-and-forget)
-      this.sendTelemetry({
-        status: 'success',
-        latencyMs,
-        textLength: text.length,
-        provider: this.provider.label,
-        tokenUsage,
-        // No metadata.stage_details for single-stage evaluator
-        inputText: text,
-      }).catch(() => {
-        // Ignore telemetry errors
-      });
-
-      this.logger.info('Grade level appropriateness evaluation completed successfully', {
-        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-        operation: 'evaluate',
-        gradeLevel: response.data.grade_band,
-        processingTimeMs: latencyMs,
-      });
-
-      return result;
-    } catch (error) {
-      const latencyMs = Date.now() - startTime;
-
-      // Log the error
-      this.logger.error('Grade level appropriateness evaluation failed', {
-        evaluator: GradeLevelAppropriatenessEvaluator.metadata.id,
-        operation: 'evaluate',
-        error: error instanceof Error ? error : undefined,
-        processingTimeMs: latencyMs,
-      });
-
-      // Send failure telemetry (fire-and-forget)
-      this.sendTelemetry({
-        status: 'error',
-        latencyMs,
-        textLength: text.length,
-        provider: this.provider.label,
-        errorCode: error instanceof Error ? error.name : 'UnknownError',
-        inputText: text,
-      }).catch(() => {
-        // Ignore telemetry errors
-      });
-
-      // Re-throw validation errors as-is
-      if (error instanceof EvaluatorError) {
-        throw error;
-      }
-
-      // Wrap provider errors into appropriate error types
-      throw wrapProviderError(error, this.providerContext(this.provider));
-    }
-  }
-}
-
 /**
- * Functional API for grade level appropriateness evaluation
+ * Reports the grade band a text is appropriate for at independent reading, plus a second
+ * band reachable with scaffolding.
  *
- * @example
- * ```typescript
- * const result = await evaluateGradeLevelAppropriateness(
- *   "Tides are the rise and fall of sea levels...",
- *   {
- *     googleApiKey: process.env.GOOGLE_API_KEY
- *   }
- * );
- * ```
+ * Takes no grade level: unlike the complexity evaluators, which judge a text *against* a
+ * grade, this one determines the grade. Its `input_schema` declares only `text`, so
+ * `metadata.supportedGrades` is empty by derivation rather than by assertion.
+ *
+ * One model call, so the flow comes from {@link defineSingleStepEvaluator} and the model,
+ * temperature and prompt inputs are read from `config.json`.
+ *
+ * @throws {InputValidationError} If an input is missing, unknown, or outside the bounds its schema declares
+ * @throws {ConfigurationError} If modelOverride specifies a model ID that the provider rejects
+ * @throws {DependencyError} If the provider call fails (AuthenticationError, RateLimitError, NetworkError, RequestTimeoutError, LLMProviderError)
+ * @throws {LLMOutputProcessingError} If the model's response fails its output schema
  */
+export class GradeLevelAppropriatenessEvaluator extends defineSingleStepEvaluator<
+  GradeLevelAppropriatenessInput,
+  GradeLevelAppropriatenessResult
+>({
+  contract: CONFIG,
+  inputSchema: INPUT_SCHEMA,
+  outputSchema: GradeLevelAppropriatenessOutputSchema,
+  systemPrompt: SYSTEM_PROMPT,
+  userPrompt: USER_PROMPT_TEMPLATE,
+}) {}
+
 export async function evaluateGradeLevelAppropriateness(
   input: GradeLevelAppropriatenessInput,
-  config: BaseEvaluatorConfig
+  config: BaseEvaluatorConfig,
 ): Promise<EvaluationResult<GradeLevelAppropriatenessResult>> {
-  const evaluator = new GradeLevelAppropriatenessEvaluator(config);
-  return evaluator.evaluate(input);
+  return new GradeLevelAppropriatenessEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -6,7 +6,8 @@ export type {
   EvaluationFailure,
 } from './schemas/index.js';
 
-export { TextComplexityLevel, GradeBand } from './schemas/index.js';
+export { TextComplexityLevel } from './schemas/index.js';
+export type { GradeBand } from './schemas/index.js';
 export { readOutcome, type Outcome } from './schemas/index.js';
 
 // Error types

--- a/sdks/typescript/src/schemas/index.ts
+++ b/sdks/typescript/src/schemas/index.ts
@@ -7,10 +7,18 @@ export {
 } from './outputs.js';
 
 export {
-  GradeBand,
   GradeLevelAppropriatenessOutputSchema,
   type GradeLevelAppropriatenessResult,
 } from './student-facing-text/ela-reading/grade-level-appropriateness.js';
+import type { GradeLevelAppropriatenessResult as GLAResult } from './student-facing-text/ela-reading/grade-level-appropriateness.js';
+
+/**
+ * The grade bands the contract declares, read off the generated schema.
+ *
+ * Was a hand-written Zod enum, which is how it came to say `11-CCR` where the contract
+ * says `11-12`. Deriving it means it cannot say anything else again.
+ */
+export type GradeBand = GLAResult['grade_band'];
 
 export {
   PurposeClarityOutputSchema,

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.ts
@@ -1,29 +1,10 @@
+// GENERATED — do not edit directly.
+// Source: ../../evals/student-facing-text/ela-reading/grade-level-appropriateness/output_schema.json
+// Regenerate: npm run generate:schemas
+
 import { z } from 'zod';
 
-/**
- * Valid grade bands for grade level appropriateness evaluation
- */
-export const GradeBand = z.enum(['K-1', '2-3', '4-5', '6-8', '9-10', '11-CCR']);
-
-export type GradeBand = z.infer<typeof GradeBand>;
-
-/**
- * Output schema for Grade Level Appropriateness evaluation
- * Matches Python OutputRanges model
- */
-export const GradeLevelAppropriatenessOutputSchema = z.object({
-  reasoning: z
-    .string()
-    .describe(
-      'Your reasoning for your answer in numbered bullet points for 4 steps with a 4th bullet point for synthesis.'
-    ),
-  grade_band: GradeBand.describe('Target grade band for the text at independent reading.'),
-  alternative_grade_band: GradeBand.describe(
-    'A second grade band that could read and comprehend the text with the scaffolding named in scaffolding_needed, or as a read-aloud.',
-  ),
-  scaffolding_needed: z
-    .string()
-    .describe('Scaffolding needed for the text to be appropriate for the alternative grade'),
-});
+// prettier-ignore
+export const GradeLevelAppropriatenessOutputSchema = z.object({ "reasoning": z.string().describe("Numbered bullet points for each of the 3 analysis steps (quantitative, qualitative, background knowledge), followed by a 4th bullet point called 'synthesis'."), "grade_band": z.enum(["K-1","2-3","4-5","6-8","9-10","11-12"]).describe("Target grade band for the text at independent reading."), "alternative_grade_band": z.enum(["K-1","2-3","4-5","6-8","9-10","11-12"]).describe("A second grade band that could read and comprehend the text with the scaffolding named in scaffolding_needed, or as a read-aloud."), "scaffolding_needed": z.string().describe("The types of scaffolding (picture, graph, additional context, vocabulary pre-teaching, ...) that make the text accessible at alternative_grade_band.") }).strict();
 
 export type GradeLevelAppropriatenessResult = z.infer<typeof GradeLevelAppropriatenessOutputSchema>;

--- a/sdks/typescript/tests/unit/batch/formatters.test.ts
+++ b/sdks/typescript/tests/unit/batch/formatters.test.ts
@@ -305,10 +305,10 @@ describe('formatAsHTML', () => {
       }
     });
 
-    it('maps grade 11, 12, and CCR to the same 11-CCR band', () => {
+    it('maps grade 11, 12, and CCR to the same 11-12 band', () => {
       for (const grade of ['11', '12', 'CCR']) {
         const { gradeLevelStats } = extractReportData(
-          formatAsHTML(glaOutput(grade, '11-CCR'), makeMeta())
+          formatAsHTML(glaOutput(grade, '11-12'), makeMeta())
         );
         expect(gradeLevelStats.onBand).toBe(1);
       }

--- a/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/grade-level-appropriateness.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GradeLevelAppropriatenessEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.js';
 import { ConfigurationError, InputValidationError } from '../../../src/errors.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
+
+// Read from the contract, not restated: hardcoding it here is how the SDK came to ship
+// a different model from the one declared without any test objecting.
+const DECLARED = CONFIG.steps[0].model;
+const MODEL_LABEL = `${DECLARED.provider}:${DECLARED.name}`;
 
 /**
  * Comprehensive unit tests for GradeLevelAppropriatenessEvaluator
@@ -78,7 +84,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
           scaffolding_needed: 'Pre-teach gravitational forces; Use visual diagrams of moon-sun-earth system',
           reasoning: 'The text discusses gravitational forces and celestial mechanics, which are appropriate for middle school science curriculum.',
         },
-        model: 'gemini-2.5-pro',
+        model: DECLARED.name,
         usage: {
           inputTokens: 200,
           outputTokens: 150,
@@ -97,7 +103,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       expect(result.result!.scaffolding_needed).toContain('gravitational forces');
       expect(result.result.reasoning).toContain('gravitational forces');
       expect(result.metadata).toBeDefined();
-      expect(result.metadata.model).toBe('google:gemini-2.5-pro');
+      expect(result.metadata.model).toBe(MODEL_LABEL);
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
       expect(result.metadata.tokenUsage.inputTokens).toBe(200);
       expect(result.metadata.tokenUsage.outputTokens).toBe(150);
@@ -145,7 +151,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
           scaffolding_needed: 'Pre-teach advanced vocabulary; Provide background context',
           reasoning: 'Detailed reasoning about grade appropriateness',
         },
-        model: 'gemini-2.5-pro',
+        model: DECLARED.name,
         usage: { inputTokens: 200, outputTokens: 150 },
         latencyMs: 800,
       });
@@ -172,7 +178,7 @@ describe('GradeLevelAppropriatenessEvaluator - Evaluation Flow', () => {
       expect(result.metadata).toHaveProperty('processingTimeMs');
 
       // Verify metadata values
-      expect(result.metadata.model).toBe('google:gemini-2.5-pro');
+      expect(result.metadata.model).toBe(MODEL_LABEL);
       expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
       expect(result.metadata.tokenUsage.inputTokens).toBe(200);
       expect(result.metadata.tokenUsage.outputTokens).toBe(150);

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -149,8 +149,7 @@ const SENTENCE_ID = SentenceStructureEvaluator.metadata.id;
 
 /** Evaluators whose constructed models or temperatures differ from their contract. */
 const MODEL_GAPS = new Set<string>([
-  // Ships gemini-2.5-pro @ 0.25; the contract declares gemini-3.6-flash @ 1.
-  GLA_ID,
+  // Empty: every evaluator constructs the model its contract declares.
 ]);
 
 /** Evaluators whose `supportedGrades` does not describe their declared inputs. */
@@ -171,8 +170,7 @@ const GRADE_GAPS = new Set<string>([
  * schema regenerated from its contract would silently mislabel every text in that band.
  */
 const BAND_GAPS = new Set<string>([
-  // The contract declares `11-12`; the SDK schema and the report both say `11-CCR`.
-  '11-12',
+  // Empty: the report recognises every band the contracts declare.
 ]);
 
 /**
@@ -193,8 +191,7 @@ const ORDER_GAPS = new Set<string>([
  * Evaluators sending a temperature their contract does not declare.
  */
 const TEMPERATURE_GAPS = new Set<string>([
-  // Sends 0.25; the contract declares 1.
-  GLA_ID,
+  // Empty: every evaluator sends the temperature its contract declares.
 ]);
 
 /**
@@ -206,6 +203,15 @@ const RESULT_NAME_GAPS = new Set<string>([
   SENTENCE_ID,
   // Assembles its payload from per-component results, so there is no single schema.
   MATH_ID,
+]);
+
+/**
+ * Evaluators whose schema offers different values than the contract declares.
+ */
+const ENUM_VALUE_GAPS = new Set<string>([
+  // Sends the shared Title Case TextComplexityLevel ('Slightly complex') where the
+  // contract declares 'slightly_complex'. Same divergence as FIXTURE_VALUE_GAPS.
+  SENTENCE_ID,
 ]);
 
 /**
@@ -513,6 +519,53 @@ describe('the schema the SDK sends matches the contract', () => {
     const declared = Object.keys(outputSchema.properties).sort();
 
     expect(sentFields, `${E.metadata.name} sent payload fields`).toEqual(declared);
+  });
+
+  // Field names are only half of it: a field can carry the right name and offer the model
+  // the wrong choices. `11-CCR` for a contract declaring `11-12` passed the check above.
+  it.each(withSchema)('$name enum values', ({ E }) => {
+    const { outputSchema } = contractFor(E.metadata.id);
+    const defs = (outputSchema.$defs ?? {}) as Record<string, { enum?: unknown[] }>;
+    const shape = SDK_OUTPUT_SCHEMAS[E.metadata.id].shape as Record<string, unknown>;
+
+    const mismatched = Object.entries(outputSchema.properties).flatMap(([field, spec]) => {
+      const ref = typeof spec.$ref === 'string' ? spec.$ref.replace('#/$defs/', '') : undefined;
+      const declared = (ref ? defs[ref]?.enum : (spec as { enum?: unknown[] }).enum) as
+        | unknown[]
+        | undefined;
+      if (!declared) return [];
+
+      const options = (shape[field] as { options?: unknown[] } | undefined)?.options;
+      if (!options) {
+        return [`${field}: schema offers no choices, contract declares ${declared.length}`];
+      }
+
+      // A string enum becomes z.enum, whose options are the values. An integer enum
+      // cannot — Zod enums are strings — so it becomes a union of z.literal, whose
+      // options are the literal schemas. Both have to compare against the contract.
+      const sent = options.map((option) => {
+        if (option === null || typeof option !== 'object') return option;
+        const literal = option as { value?: unknown; def?: { values?: unknown[] } };
+        return literal.value ?? literal.def?.values?.[0];
+      });
+
+      const same = sent.length === declared.length && sent.every((v, i) => v === declared[i]);
+      return same
+        ? []
+        : [`${field}: sent ${JSON.stringify(sent)}, declared ${JSON.stringify(declared)}`];
+    });
+
+    if (ENUM_VALUE_GAPS.has(E.metadata.id)) {
+      expect(
+        mismatched,
+        `${E.metadata.name} now offers the declared values — drop it from ENUM_VALUE_GAPS`,
+      ).not.toEqual([]);
+      return;
+    }
+
+    expect(mismatched, `${E.metadata.name} offers values its contract does not declare`).toEqual(
+      [],
+    );
   });
 });
 

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -543,11 +543,11 @@ describe('the schema the SDK sends matches the contract', () => {
       // A string enum becomes z.enum, whose options are the values. An integer enum
       // cannot — Zod enums are strings — so it becomes a union of z.literal, whose
       // options are the literal schemas. Both have to compare against the contract.
-      const sent = options.map((option) => {
-        if (option === null || typeof option !== 'object') return option;
-        const literal = option as { value?: unknown; def?: { values?: unknown[] } };
-        return literal.value ?? literal.def?.values?.[0];
-      });
+      const sent = options.map((option) =>
+        option !== null && typeof option === 'object'
+          ? (option as { value: unknown }).value
+          : option,
+      );
 
       const same = sent.length === declared.length && sent.every((v, i) => v === declared[i]);
       return same


### PR DESCRIPTION
**Breaking.** Grade Level Appropriateness diverged from its contract in four ways. Each was recorded as a known gap; all four are now closed and the three allowlists that held them are empty.

| | SDK shipped | contract declares |
|---|---|---|
| model | `gemini-2.5-pro` | **`gemini-3.6-flash`** |
| temperature | `0.25` | **`1`** |
| top grade band | `11-CCR` | **`11-12`** |
| `reasoning` prompt | "4 steps with a 4th bullet point for synthesis" | **3 analysis steps, then a 4th synthesis bullet** |

The first two are the most consequential: it was calling a different model, at a different temperature, than the contract the notebooks and Python were written against. The fourth came free with generating the schema, and is a real instruction change — the SDK was asking for four analysis steps where the contract asks for three.

The evaluator is now 47 lines on the single-step factory, so all of it comes from `config.json`. Its output schema is generated, taking the count of generated schemas to 14 of 16.

## The band rename

`11-CCR` appeared in six places: the schema, the evaluator's doc comment, `GRADE_BANDS` in `formatters.ts`, and four spots in `report-template.html`. All now `11-12`.

Grade *mapping* is unaffected — `gradeToBandIndex` still sends grades 11, 12 and `CCR` to the same band; only the band's label changed.

## `GradeBand` is now derived, and type-only

It was a hand-written Zod enum, which is exactly how it came to say `11-CCR`. It is now:

```ts
export type GradeBand = GradeLevelAppropriatenessResult['grade_band'];
```

Read off the generated schema, so it cannot say anything the contract does not. **This is the breaking part for callers**: `GradeBand` was exported as a Zod value, so `GradeBand.parse(...)` or `GradeBand.options` no longer work. Type usage is unchanged.

## The check that should have caught the band, and didn't

`the schema the SDK sends matches the contract` compares field **names**. A band is a value, so `11-CCR` passed it. The fixture check does not catch it either — GLA's single fixture uses `4-5` and `2-3`, which both spellings accept, which is the limitation I noted when adding it.

So that describe now also compares enum **values**:

```
grade_band: sent ["K-1","2-3","4-5","6-8","9-10","11-CCR"],
        declared ["K-1","2-3","4-5","6-8","9-10","11-12"]
```

It handles both shapes a contract enum takes: a string enum becomes `z.enum`, whose options are the values; an integer enum cannot — Zod enums are strings — so the feedback family's `quality_score` becomes a union of `z.literal`, whose options are literal schemas. Both are normalised before comparing, so the whole feedback family is covered too.

Sentence Structure lands in `ENUM_VALUE_GAPS`: it sends Title Case `'Slightly complex'` where its contract declares `slightly_complex`. Same divergence as `FIXTURE_VALUE_GAPS`, now enforced from a second angle, and the entry fails once it is fixed.

## Validation

- `typecheck`, `lint`, `test:unit` (1040), `build`, `scripts/check.py`, `generate:schemas:check` (14 in sync)
- Load-bearing on all three fixes: hardcoded the old model and temperature back into the factory and every factory-based evaluator failed; reverted the band in the schema and the new enum check named both fields and both spellings
- Confirmed the band regression is *also* caught by `generate:schemas:check`, since the schema is generated — that is the layer that owns it, and the new conformance check covers the hand-written schemas the generator does not touch yet
- GLA's own tests now read the declared model from `config.json` rather than restating it; hardcoding it there is how the SDK shipped a different model with no test objecting
- Mutation testing on `formatters.ts`: 72.8%, unchanged — the band is a constant, not logic
- Confirmed `dist/index.d.ts` still exports `GradeBand`, now as a type

Needs a live run before merge, as with #220: the model, the temperature and one prompt instruction all change what comes back.
