### PR TITLE
fix(sdk): stop evaluated text from splicing the text-complexity report template

### DIFF
--- a/sdks/typescript/src/batch/families/standards-output.ts
+++ b/sdks/typescript/src/batch/families/standards-output.ts
@@ -1,6 +1,7 @@
 import type { BatchOutput, BatchResult } from '../types.js';
 import { STANDARDS_COLUMNS, type StandardsVerdict } from './standards.js';
 import standardsReportTemplate from './standards-report.html';
+import { injectReportData, toInlineJson } from '../report-injection.js';
 
 /** Metadata shared by every output projection. */
 export interface StandardsOutputMeta {
@@ -186,8 +187,6 @@ export function formatStandardsCSV(output: BatchOutput): string {
 
 // --- HTML ------------------------------------------------------------------
 
-const INJECTION_MARKER = 'var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__';
-
 /**
  * Self-contained verdict browser: per-item aligned/total with expandable
  * per-component reasoning/feedback, filterable by standard and grade level. Reports
@@ -210,25 +209,5 @@ export function formatStandardsHTML(output: BatchOutput, meta: StandardsOutputMe
     items: rows,
   };
 
-  const safeJson = JSON.stringify(reportData)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026')
-    // U+2028/U+2029 are valid JSON but break inline <script> parsing pre-ES2019.
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-
-  return injectReportData(standardsReportTemplate, safeJson);
-}
-
-/** Takes the template as a parameter so the corruption guard is reachable in tests. */
-export function injectReportData(template: string, payload: string): string {
-  if (!template.includes(INJECTION_MARKER)) {
-    throw new Error('Standards report template injection marker not found — template may be corrupted');
-  }
-  // Replacer function, not a string: as a string, `$$`/`$&`/`` $` ``/`$'` in the
-  // payload are substitution patterns. `$$x^2$$` in a question would render as
-  // `$x^2$`, and `$'` splices the template tail — including `</script>` — into the
-  // inline script, defeating the escaping applied to the payload.
-  return template.replace(INJECTION_MARKER, () => `var REPORT_DATA = ${payload};`);
+  return injectReportData(standardsReportTemplate, toInlineJson(reportData), 'Standards');
 }

--- a/sdks/typescript/src/batch/formatters.ts
+++ b/sdks/typescript/src/batch/formatters.ts
@@ -1,5 +1,6 @@
 import type { BatchOutput, BatchResult } from './types.js';
 import reportTemplate from './report-template.html';
+import { injectReportData, toInlineJson } from './report-injection.js';
 import { GradeLevelAppropriatenessEvaluator } from '../evaluators/student-facing-text/ela-reading/grade-level-appropriateness.js';
 
 // ---- Constants ----
@@ -394,18 +395,5 @@ export function formatAsHTML(output: BatchOutput, meta: ReportMeta): string {
     },
   };
 
-  // Inject serialized data into the template.
-  // Unicode-escape < > & so the JSON is safe inside a <script> tag even if
-  // the data contains HTML-like strings (prevents </script> injection).
-  const safeJson = JSON.stringify(reportData)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026');
-
-  const INJECTION_MARKER = 'var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__';
-  if (!reportTemplate.includes(INJECTION_MARKER)) {
-    throw new Error('Report template injection marker not found — template may be corrupted');
-  }
-
-  return reportTemplate.replace(INJECTION_MARKER, `var REPORT_DATA = ${safeJson};`);
+  return injectReportData(reportTemplate, toInlineJson(reportData), 'Text complexity');
 }

--- a/sdks/typescript/src/batch/report-injection.ts
+++ b/sdks/typescript/src/batch/report-injection.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared machinery for the self-contained HTML reports a family can emit.
+ *
+ * A report is one file: a static template with its data spliced into an inline `<script>`.
+ * Both steps below are load-bearing for that to be safe, and both were previously written
+ * per family — one of the two copies without the replacer-function guard, which made
+ * evaluated text able to terminate the script early.
+ */
+
+const INJECTION_MARKER = 'var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__';
+
+/**
+ * Serialise report data for embedding in an inline `<script>`.
+ *
+ * `<`, `>` and `&` are escaped so evaluated text cannot close the script element, and
+ * U+2028/U+2029 — valid in JSON but line terminators to a pre-ES2019 parser — are escaped
+ * so they cannot break the script.
+ */
+export function toInlineJson(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
+ * Splice a payload into a report template.
+ *
+ * `label` names the family in the failure, so a corrupted template says which report is
+ * broken. The template is a parameter so that failure is reachable from a test.
+ */
+export function injectReportData(template: string, payload: string, label: string): string {
+  if (!template.includes(INJECTION_MARKER)) {
+    throw new Error(
+      `${label} report template injection marker not found — template may be corrupted`,
+    );
+  }
+  // A replacer function, not a string. As a string, `$$`, `$&`, `` $` `` and `$'` in the
+  // payload are substitution patterns: `$'` inserts everything after the match, which
+  // splices the template tail — including its literal `</script>` — into the inline
+  // script, defeating the escaping above. Evaluated text reaches this payload, so a
+  // passage containing `$'` was enough to corrupt the report.
+  return template.replace(INJECTION_MARKER, () => `var REPORT_DATA = ${payload};`);
+}

--- a/sdks/typescript/src/batch/report-injection.ts
+++ b/sdks/typescript/src/batch/report-injection.ts
@@ -15,8 +15,13 @@ const INJECTION_MARKER = 'var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__';
  * `<`, `>` and `&` are escaped so evaluated text cannot close the script element, and
  * U+2028/U+2029 — valid in JSON but line terminators to a pre-ES2019 parser — are escaped
  * so they cannot break the script.
+ *
+ * Takes an object rather than `unknown` because `JSON.stringify` returns `undefined` for
+ * `undefined`, a function or a symbol, which would make the chained `.replace` throw. A
+ * report payload is always an object, so the compiler enforces that instead of a runtime
+ * guard on a path no caller can reach.
  */
-export function toInlineJson(data: unknown): string {
+export function toInlineJson(data: Record<string, unknown>): string {
   return JSON.stringify(data)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')

--- a/sdks/typescript/tests/unit/batch/output.test.ts
+++ b/sdks/typescript/tests/unit/batch/output.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderOutputs } from '../../../src/batch/output.js';
-import { injectReportData } from '../../../src/batch/families/standards-output.js';
+import { injectReportData } from '../../../src/batch/report-injection.js';
 import type { BatchOutput, BatchResult, ReportMeta } from '../../../src/batch/index.js';
 
 const meta: ReportMeta = {
@@ -164,13 +164,17 @@ describe('renderOutputs — empty result sets', () => {
 
 describe('injectReportData', () => {
   it('replaces the marker with the payload assignment', () => {
-    const out = injectReportData('before var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__ after', '{"a":1}');
+    const out = injectReportData(
+      'before var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__ after',
+      '{"a":1}',
+      'Standards',
+    );
     expect(out).toContain('var REPORT_DATA = {"a":1};');
     expect(out).not.toContain('__REPLACED_BY_FORMATTER__');
   });
 
   it('throws rather than emitting a report with no data when the marker is missing', () => {
-    expect(() => injectReportData('<html>no marker here</html>', '{}')).toThrow(/marker not found/);
+    expect(() => injectReportData('<html>no marker here</html>', '{}', 'Standards')).toThrow(/marker not found/);
   });
 
   // As a replacement *string*, `$$`/`$&`/`$'` are substitution patterns: `$$x^2$$`
@@ -183,7 +187,7 @@ describe('injectReportData', () => {
     ['$` (prefix)', '{"q":"a $` b"}'],
   ])('inserts %s verbatim instead of expanding it', (_label, payload) => {
     const template = `<script>\nvar REPORT_DATA = null; // __REPLACED_BY_FORMATTER__\n</script>\n<div>TAIL</div>`;
-    const out = injectReportData(template, payload);
+    const out = injectReportData(template, payload, 'Standards');
 
     expect(out).toContain(`var REPORT_DATA = ${payload};`);
     // Exactly one closing script tag: the tail was not spliced into the script.

--- a/sdks/typescript/tests/unit/batch/report-injection.test.ts
+++ b/sdks/typescript/tests/unit/batch/report-injection.test.ts
@@ -89,10 +89,10 @@ describe('the text-complexity report survives hostile evaluated text', () => {
 
   it('keeps the payload parseable when text carries a line separator', () => {
     // U+2028 is valid JSON but a line terminator to a pre-ES2019 parser.
-    const html = reportFor('A passage with   inside.');
+    const html = reportFor('A passage with \u2028 inside.');
 
     expect(html).toContain('\\u2028');
-    expect(html).not.toContain(' ');
+    expect(html).not.toContain('\u2028');
   });
 });
 

--- a/sdks/typescript/tests/unit/batch/report-injection.test.ts
+++ b/sdks/typescript/tests/unit/batch/report-injection.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { formatAsHTML } from '../../../src/batch/formatters.js';
+import { injectReportData, toInlineJson } from '../../../src/batch/report-injection.js';
+import type { BatchOutput, BatchResult } from '../../../src/batch/types.js';
+
+/**
+ * Evaluated text and model reasoning both reach the report payload, so anything a caller
+ * can put in a CSV cell ends up inside an inline `<script>`. These guard the two ways that
+ * has broken: `$`-patterns in a replacement string, and characters that terminate a script.
+ *
+ * Counting `</script>` rather than measuring the payload's length: the spliced template
+ * tail contains newlines, so a length check on the payload line misses it entirely.
+ */
+
+const MARKER_TEMPLATE = 'head var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__ tail</script>end';
+
+function reportFor(text: string): string {
+  const result: BatchResult = {
+    rowIndex: 0,
+    text,
+    gradeLevel: '5',
+    evaluatorId: 'student_facing_text.ela_reading.purpose_clarity',
+    status: 'success',
+    score: 'slightly_complex',
+    reasoning: text,
+    processingTimeMs: 1,
+    columns: { text, grade_level: '5' },
+    originalRow: { text, grade_level: '5' },
+  };
+
+  return formatAsHTML(
+    {
+      results: [result],
+      summary: { totalTasks: 1, successful: 1, failed: 0, durationMs: 1, resultsPerEvaluator: {} },
+    } satisfies BatchOutput,
+    {
+      csvPath: 'in.csv',
+      groupId: 'text-complexity',
+      reportId: 'r1',
+      generatedAt: new Date('2026-08-29T00:00:00Z'),
+      totalInputRows: 1,
+    },
+  );
+}
+
+const closingTags = (html: string) => (html.match(/<\/script>/g) ?? []).length;
+
+/**
+ * The injected payload, parsed back.
+ *
+ * Tag counting alone is not enough: `$&` and `` $` `` corrupt the JSON without adding a
+ * closing tag, so a report can be structurally intact and still carry unparseable data —
+ * which renders as an empty report rather than an obvious failure.
+ */
+function injectedPayload(html: string): unknown {
+  const line = html.split('\n').find((l) => l.trimStart().startsWith('var REPORT_DATA = {'));
+  if (!line) throw new Error('no injected REPORT_DATA assignment found');
+  const json = line.slice(line.indexOf('{'), line.lastIndexOf('}') + 1);
+  return JSON.parse(json.replace(/\\u003c/g, '<').replace(/\\u003e/g, '>').replace(/\\u0026/g, '&'));
+}
+
+describe('the text-complexity report survives hostile evaluated text', () => {
+  const baseline = closingTags(reportFor('An ordinary passage.'));
+
+  it.each([
+    ["$' — inserts everything after the match", "A passage containing $' a quote."],
+    ['$` — inserts everything before it', 'A passage containing $` a quote.'],
+    ['$& — inserts the match itself', 'A passage containing $& a quote.'],
+    ['$$ — an escaped dollar', 'A passage costing $$5.'],
+  ])('%s does not splice the template', (_name, text) => {
+    // A string replacement treats these as substitution patterns; `$'` alone took this
+    // report from one closing tag to three, and the others corrupt the JSON silently.
+    const html = reportFor(text);
+
+    expect(closingTags(html)).toBe(baseline);
+    const payload = injectedPayload(html) as { items?: unknown[] };
+    expect(payload).toBeTypeOf('object');
+    // The text survives intact rather than being partly replaced by template fragments.
+    // injectedPayload already reverses the unicode escaping, so compare verbatim.
+    expect(JSON.stringify(payload)).toContain(text);
+  });
+
+  it('escapes markup so evaluated text cannot close the script element', () => {
+    const html = reportFor('</script><img src=x onerror=alert(1)>');
+
+    expect(closingTags(html)).toBe(baseline);
+    expect(html).toContain('\\u003c');
+  });
+
+  it('keeps the payload parseable when text carries a line separator', () => {
+    // U+2028 is valid JSON but a line terminator to a pre-ES2019 parser.
+    const html = reportFor('A passage with   inside.');
+
+    expect(html).toContain('\\u2028');
+    expect(html).not.toContain(' ');
+  });
+});
+
+describe('injectReportData', () => {
+  it('treats the payload as literal text, not a replacement pattern', () => {
+    const out = injectReportData(MARKER_TEMPLATE, `{"t":"$'"}`, 'Test');
+
+    // With a string replacement, `$'` would have inserted ` tail</script>end` here.
+    expect(out).toBe(`head var REPORT_DATA = {"t":"$'"}; tail</script>end`);
+  });
+
+  it('names the report when the template has lost its marker', () => {
+    expect(() => injectReportData('<html>no marker</html>', '{}', 'Standards')).toThrow(
+      /Standards report template injection marker not found/,
+    );
+  });
+});
+
+describe('toInlineJson', () => {
+  it('escapes the characters that can end a script element', () => {
+    const out = toInlineJson({ a: '<b>&</b>' });
+
+    expect(out).not.toMatch(/[<>&]/);
+    expect(out).toContain('\\u003c');
+    expect(out).toContain('\\u0026');
+  });
+
+  it('leaves a dollar pattern untouched — the caller must not re-expand it', () => {
+    expect(toInlineJson({ a: "$'" })).toContain("$'");
+  });
+});


### PR DESCRIPTION
Found while reviewing comments, but this is a code defect, not a comment.

`formatAsHTML` spliced its payload into the report template with a **string** replacement:

```ts
return reportTemplate.replace(INJECTION_MARKER, `var REPORT_DATA = ${safeJson};`);
```

In a replacement string, `$'` means "everything after the match" — here the whole template tail, including its literal `</script>`. Evaluated text and model reasoning both reach this payload, so a passage containing `$'` corrupts the report:

```
clean   </script> count: 1
hostile </script> count: 3     ← the template tail spliced in, twice
```

Measured against the built package with `text` = `A passage containing $' a dollar-quote.` — the same text also appears in `reasoning`, hence twice. After the fix: **1 and 1**.

The escaping above it was real but incomplete: it neutralised `<`, `>` and `&`, and its comment claimed that "prevents `</script>` injection" — which the string replacement then reintroduced downstream.

## The fix

Both report formatters now share one guarded injection. `standards-output.ts` already had the right implementation and a comment explaining exactly this hazard; `formatters.ts` had neither. Rather than copy it, `injectReportData` and `toInlineJson` move to `batch/report-injection.ts` and both call it — so there is one implementation to be right.

That also gives the text-complexity report the U+2028/U+2029 escaping it was missing: valid JSON, but line terminators to a pre-ES2019 parser.

## Why it went unnoticed

Two reviewers flagged it independently. My first attempt to verify it **produced a false negative** — I measured the length of the `var REPORT_DATA = …` line, but the spliced tail contains newlines, so the payload line got *shorter*. Counting `</script>` is what shows it.

The regression test counts closing tags and, separately, parses the payload back. The parse matters: `` $` `` and `$$` corrupt the JSON without adding a closing tag, so a tag-count-only test would pass while the report rendered empty. With the payload check, **5 of the 10 tests fail against the pre-fix code**; with tag counting alone it was 3.

## Validation

- `typecheck`, `lint`, `test:unit` (1064), `build`, `scripts/check.py`
- Reverted the fix and confirmed 5 tests fail; restored and confirmed all pass
- Re-ran the original exploit against `dist/` and confirmed the closing-tag count no longer changes
- Standards' existing injection tests pass unchanged, re-pointed at the shared module

One thing I did **not** change: `report-template.html` also has `REPORT_DATA = REPORT_DATA || MOCK_REPORT_DATA`, so a null payload would render 300 fabricated rows as if real. I checked — injection always produces a real object, so that path is defensive rather than live. The comment above it claiming the mock "is never referenced when real data has been injected" is wrong and is fixed in the comments PR that follows.
