### PR TITLE
test(sdk): read the verdict from the contract in the integration harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ __pycache__/
 # Jupyter Notebook
 .ipynb_checkpoints/
 
-# Environment variables
-.env
+# Environment variables. `.env*` so variants (.env.local, .env.test) are covered too —
+# exact `.env` left every other spelling committable. Templates are negated so they stay
+# tracked: demos/typescript/.env.example, evals/.env.example, sdks/typescript/.env.test.example.
+.env*
+!.env*.example
 
 # macOS
 .DS_Store

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -16,7 +16,7 @@ coverage/
 # the integration suite and was previously committable — `.env.*.local` does not match it.
 # The checked-in template is negated so it keeps travelling with the repo.
 .env*
-!.env.test.example
+!.env*.example
 
 # IDE
 .vscode/

--- a/sdks/typescript/.gitignore
+++ b/sdks/typescript/.gitignore
@@ -12,10 +12,11 @@ build/
 coverage/
 .nyc_output/
 
-# Environment variables
-.env
-.env.local
-.env.*.local
+# Environment variables. `.env*` catches .env.test, which holds real provider keys for
+# the integration suite and was previously committable — `.env.*.local` does not match it.
+# The checked-in template is negated so it keeps travelling with the repo.
+.env*
+!.env.test.example
 
 # IDE
 .vscode/

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -35,7 +35,7 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
-    "test:integration": "RUN_INTEGRATION_TESTS=true vitest run tests/integration",
+    "test:integration": "RUN_INTEGRATION_TESTS=true vitest run --dir tests/integration",
     "test:integration:dist": "npm run build && RUN_INTEGRATION_TESTS=true vitest run --config vitest.ci.config.ts",
     "test:all": "RUN_INTEGRATION_TESTS=true vitest run",
     "test:watch": "vitest",

--- a/sdks/typescript/tests/integration/background-knowledge-demands.integration.test.ts
+++ b/sdks/typescript/tests/integration/background-knowledge-demands.integration.test.ts
@@ -153,7 +153,6 @@ describeIntegration.concurrent('SMK Evaluator - Comprehensive Test Suite', () =>
       const maxAttempts = 3;
       const result = await runEvaluatorTest(testCase, {
         evaluator,
-        extractResult: (r) => r.score,
         maxAttempts,
       });
 

--- a/sdks/typescript/tests/integration/meaning-directness.integration.test.ts
+++ b/sdks/typescript/tests/integration/meaning-directness.integration.test.ts
@@ -170,7 +170,6 @@ describeIntegration.concurrent('Meaning Directness Evaluator - Comprehensive Tes
       const maxAttempts = 3;
       const result = await runEvaluatorTest(testCase, {
         evaluator,
-        extractResult: (r) => r.score,
         maxAttempts,
       });
 

--- a/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
+++ b/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
@@ -36,39 +36,39 @@ const TEST_CASES: BaseTestCase[] = [
   //   id: 'SS2',
   //   grade: '2',
   //   text: "The Roman Empire was a powerful empire that lasted for hundreds of years. It started as a small village in Italy and grew into a huge empire that controlled much of Europe, Asia, and Africa. The Roman Empire had many strong leaders like Julius Caesar and Augustus. These leaders helped the empire grow and become very powerful.\n \n\n The Roman Empire had a period of peace and prosperity called the Pax Romana. This time was good for the empire, but it didn't last forever. The empire started to have problems. The army became weaker, and the economy had problems. The empire was also attacked by groups of people called barbarians.\n \n\n The Roman Empire was divided into two parts: the Western Roman Empire and the Eastern Roman Empire. The Western Roman Empire eventually fell apart in 476 AD. The Eastern Roman Empire, also known as the Byzantine Empire, lasted for many more years. The Roman Empire left behind many things that we still use today, like the Roman alphabet and the calendar.",
-  //   expected: 'Moderately complex',
-  //   acceptable: ['Slightly complex', 'Very complex'],
+  //   expected: 'moderately_complex',
+  //   acceptable: ['slightly_complex', 'very_complex'],
   // },
   {
     id: 'SS3',
     grade: '3',
     text: "The hoisting gear consists of a double system of chains 13/16 in. in diameter placed side by side; each chain is anchored by an adjustable screw to the end of the jib, and, passing round the traveling carriage and down to the falling block, is taken along the jib over a sliding pulley which leads it on to the grooved barrel, 3 ft. 9 in. in diameter. In front of the barrel is placed an automatic winder which insures a proper coiling of the chain in the grooves. The motive power is derived from two cylinders 10 in. in diameter and 16 in. stroke, one being bolted to each side frame; these cylinders, which are provided with link motion and reversing gear, drive a steel crank shaft 2¾ in. in diameter; on this shaft is a steel sliding pinion which drives the barrel by a double purchase.",
-    expected: 'Exceedingly complex',
-    acceptable: ['Very complex'],
+    expected: 'exceedingly_complex',
+    acceptable: ['very_complex'],
   },
   {
     id: 'SS4',
     grade: '4',
     text: "Before corals bleach, they do not show many other signs of feeling stressed. So, if we want to understand a coral's health, we have to study its cells. Inside cells we have a lot of information, including DNA, RNA, and proteins. These molecules can help us find clues about the communication between the coral and the algae. But also, these molecules can teach us how to know when corals are stressed.\nWhen an organism is stressed, every cell in its body will react. Everything will do its best to survive! In response to stress, the cell will use its DNA to make RNA, so that it can then make proteins that will fight off the stress. If an organism has been stressed before, it can respond to the stress faster and better. Think of it like visiting a city: the first time you visit, you will need a map to find your hotel. The more often you visit the city, the less you will need the map because you will remember, and you will get back to the hotel faster.",
-    expected: 'Very complex',
-    acceptable: ['Moderately complex', 'Exceedingly complex'],
+    expected: 'very_complex',
+    acceptable: ['moderately_complex', 'exceedingly_complex'],
   },
   {
     id: 'SS5',
     grade: '5',
     text: "Mesopotamia, located in present-day Iraq, is known as the 'Cradle of Civilization' because it was home to some of the earliest civilizations in the world. The region got its name from the ancient Greek words for 'land between the rivers,' referring to the Tigris and Euphrates rivers. These rivers provided water for the fertile land, making it perfect for farming. The regular flooding of the rivers made the land around them ideal for growing crops, which helped people settle down and form permanent villages. These villages eventually grew into cities, where people developed many of the characteristics of civilization, like organized government, complex buildings, and different social classes.\n \n\n The first civilizations in Mesopotamia were the Sumerians, who lived around 5,000 years ago. They invented the world's first written language, called cuneiform, which they used to keep track of things like food supplies and trade. They also developed a system of numbers, which helped them with math and measurement. The Sumerians built impressive cities like Ur, Eridu, and Uruk, which had populations of over 50,000 people. These cities were centers of learning and culture, and they helped spread knowledge and ideas throughout the region.\n \n\n Over time, other civilizations rose and fell in Mesopotamia, including the Akkadians, Babylonians, and Assyrians. Each civilization made its own contributions to the development of human society. The Babylonians are famous for their code of laws, which was one of the first written legal systems in the world. The Assyrians were known for their powerful military and their impressive palaces. Mesopotamia's history is full of amazing inventions and innovations that shaped the world we live in today.\n \n\n The development of civilization in Mesopotamia was not just about the fertile land and the rivers. Changes in climate and the environment also played a role. People had to become more organized and work together to survive. This led to the development of complex societies and governments. Mesopotamia's story is a reminder of how human ingenuity and adaptability can lead to amazing achievements.\n \n\n The 'Cradle of Civilization' is a term that refers to the regions where the earliest known human civilizations emerged. Mesopotamia is a prime example of this, as it was a place where people learned to live together, build cities, and develop new technologies that changed the course of human history. The innovations that came from Mesopotamia, like writing, mathematics, and agriculture, continue to influence our lives today. By studying ancient Mesopotamia, we can learn about the origins of our own civilization and the challenges and triumphs of early humans.",
-    expected: 'Slightly complex',
-    acceptable: ['Moderately complex'],
+    expected: 'slightly_complex',
+    acceptable: ['moderately_complex'],
     // TODO: Valiadate the test-case with additional data from Grade 5
-    // expected: 'Exceedingly complex',
-    // acceptable: ['Very complex'],
+    // expected: 'exceedingly_complex',
+    // acceptable: ['very_complex'],
   },
   {
     id: 'SS6',
     grade: '6',
     text: "Benjamin Franklin was a very important person in American history. He was born in Boston, Massachusetts in 1706. He was one of 17 children. Franklin did not go to school for very long. He learned to be a printer from his brother. Franklin was a very smart man. He invented many things, like bifocals, the Franklin stove, and the lightning rod. He also started the first public library in Philadelphia. Franklin was a writer, too. He wrote a book called *Poor Richard's Almanack*. It had many famous sayings, like \"Lost Time is never found again.\"\n\nFranklin was also a politician. He helped write the Declaration of Independence. He was a diplomat, too. He helped the United States get help from France during the Revolutionary War. He was a very busy man! Franklin was a scientist, a writer, a politician, and an inventor. He was a very important person in American history.\n\nFranklin was a very interesting person. He was a scientist who did experiments with electricity. He was a writer who wrote a book of sayings. He was a politician who helped the United States become independent. He was a diplomat who helped the United States get help from other countries. He was a very busy man!\n\nFranklin was a very smart man. He was a self-taught man who learned a lot on his own. He was a very creative man who invented many things. He was a very kind man who helped others. He was a very important man who helped shape the United States.\n\nFranklin was a very influential person. He was a leader who helped people. He was a thinker who came up with new ideas. He was a writer who shared his thoughts with others. He was a scientist who helped people understand the world. He was a very important person who helped make the United States what it is today.",
-    expected: 'Slightly complex',
-    acceptable: ['Moderately complex'],
+    expected: 'slightly_complex',
+    acceptable: ['moderately_complex'],
   },
 ];
 
@@ -107,7 +107,6 @@ describeIntegration.concurrent('Sentence Structure Evaluator - Comprehensive Tes
       const maxAttempts = 3;
       const result = await runEvaluatorTest(testCase, {
         evaluator,
-        extractResult: (r) => r.score,
         maxAttempts,
       });
 

--- a/sdks/typescript/tests/integration/vocabulary-complexity.integration.test.ts
+++ b/sdks/typescript/tests/integration/vocabulary-complexity.integration.test.ts
@@ -121,7 +121,6 @@ describeIntegration.concurrent('Vocabulary Evaluator - Comprehensive Test Suite'
       const maxAttempts = 3;
       const result = await runEvaluatorTest(testCase, {
         evaluator,
-        extractResult: (r) => r.score,
         maxAttempts,
       });
 

--- a/sdks/typescript/tests/unit/utils/test-helpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/test-helpers.test.ts
@@ -98,7 +98,7 @@ describe('the integration harness reads the declared verdict', () => {
 
     const result = await runEvaluatorTest(
       { ...CASE, expected: 'picked' },
-      { evaluator, maxAttempts: 1, extractResult: (r) => r.result.other },
+      { evaluator, maxAttempts: 1, extractResult: (r) => String(r.result.other) },
     );
 
     expect(result.allResults).toEqual(['picked']);

--- a/sdks/typescript/tests/unit/utils/test-helpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/test-helpers.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runEvaluatorTest } from '../../utils/test-helpers.js';
+
+/**
+ * The integration harness compares a verdict it reads out of the result envelope. That
+ * read is the thing most likely to go stale — a payload field gets renamed and every
+ * comparison silently becomes `undefined` against a real expected value, which looks like
+ * a quality regression rather than a harness fault. These run offline so the failure is
+ * caught before any live call is spent.
+ */
+
+class FakeEvaluator {
+  static readonly metadata = {
+    id: 'demo.area.thing',
+    outcome: { score: 'complexity_score', reasoning: 'reasoning' },
+  };
+
+  constructor(private readonly payload: Record<string, unknown>) {}
+
+  evaluate = vi.fn(async () => ({
+    evaluator: FakeEvaluator.metadata.id,
+    result: this.payload,
+    metadata: { model: 'x:y', processingTimeMs: 1, tokenUsage: { inputTokens: 1, outputTokens: 1 } },
+  }));
+}
+
+const CASE = { id: 'T1', text: 'A passage.', grade: '5', expected: 'moderately_complex' };
+
+describe('the integration harness reads the declared verdict', () => {
+  it('extracts the field the contract names, not a top-level score', async () => {
+    const evaluator = new FakeEvaluator({
+      complexity_score: 'moderately_complex',
+      reasoning: 'because',
+    });
+
+    const result = await runEvaluatorTest(CASE, { evaluator, maxAttempts: 1 });
+
+    expect(result.allResults).toEqual(['moderately_complex']);
+    expect(result.matched).toBe(true);
+  });
+
+  it('stops after the first match rather than spending the retry budget', async () => {
+    const evaluator = new FakeEvaluator({
+      complexity_score: 'moderately_complex',
+      reasoning: 'because',
+    });
+
+    await runEvaluatorTest(CASE, { evaluator, maxAttempts: 3 });
+
+    expect(evaluator.evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a genuine mismatch as the value returned, not as absent', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: 'very_complex', reasoning: 'r' });
+
+    const result = await runEvaluatorTest(CASE, { evaluator, maxAttempts: 1 });
+
+    // The distinction that matters: a wrong answer, not a failed read.
+    expect(result.allResults).toEqual(['very_complex']);
+    expect(result.matched).toBe(false);
+  });
+
+  it('accepts an adjacent value when the expected one never arrives', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: 'very_complex', reasoning: 'r' });
+
+    const result = await runEvaluatorTest(
+      { ...CASE, acceptable: ['very_complex'] },
+      { evaluator, maxAttempts: 2 },
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.matchType).toBe('acceptable');
+  });
+
+  it('omits grade_level for an evaluator whose schema declares none', async () => {
+    // Grade Level Appropriateness takes only text; passing grade_level would be rejected
+    // as an undeclared input, so the harness must not send it.
+    const evaluator = new FakeEvaluator({ complexity_score: 'moderately_complex', reasoning: 'r' });
+
+    await runEvaluatorTest({ id: 'T2', text: 'A passage.', expected: 'moderately_complex' }, {
+      evaluator,
+      maxAttempts: 1,
+    });
+
+    expect(evaluator.evaluate).toHaveBeenCalledWith({ text: 'A passage.' });
+  });
+
+  it('sends grade_level when the case carries one', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: 'moderately_complex', reasoning: 'r' });
+
+    await runEvaluatorTest(CASE, { evaluator, maxAttempts: 1 });
+
+    expect(evaluator.evaluate).toHaveBeenCalledWith({ text: CASE.text, grade_level: CASE.grade });
+  });
+
+  it('still honours an explicit extractor for a non-verdict field', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: 'x', reasoning: 'r', other: 'picked' });
+
+    const result = await runEvaluatorTest(
+      { ...CASE, expected: 'picked' },
+      { evaluator, maxAttempts: 1, extractResult: (r) => r.result.other },
+    );
+
+    expect(result.allResults).toEqual(['picked']);
+  });
+});

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -2,6 +2,9 @@
  * Streamlined test utilities for evaluator testing
  */
 
+import { readOutcome, type DeclaredOutcome } from '../../src/schemas/outcome.js';
+import type { EvaluationResult } from '../../src/schemas/index.js';
+
 export interface TestAttempt<T> {
   attempt: number;
   result: T;
@@ -118,8 +121,12 @@ export interface EvaluatorTestConfig<TEvaluator = any> {
   /** The evaluator instance to test */
   evaluator: TEvaluator;
 
-  /** Function to extract the result to compare from evaluation output */
-  extractResult: (evalResult: any) => string;
+  /**
+   * How to read the value being compared. Defaults to the field the evaluator's contract
+   * names in `outcome.score`, which is what a caller reads and what the batch report shows.
+   * Pass this only to assert on something other than the declared verdict.
+   */
+  extractResult?: (evalResult: any) => string;
 
   /** Maximum retry attempts (default: 3) */
   maxAttempts?: number;
@@ -139,10 +146,7 @@ export interface EvaluatorTestConfig<TEvaluator = any> {
  *     grade: '3',
  *     expected: 'very complex'
  *   },
- *   {
- *     evaluator: vocabularyEvaluator,
- *     extractResult: (r) => r.score
- *   }
+ *   { evaluator: vocabularyEvaluator }
  * );
  *
  * // Grade level evaluator
@@ -152,10 +156,7 @@ export interface EvaluatorTestConfig<TEvaluator = any> {
  *     text: 'Sample text...',
  *     expected: '6-8'
  *   },
- *   {
- *     evaluator: gradeLevelEvaluator,
- *     extractResult: (r) => r.score.grade
- *   }
+ *   { evaluator: gradeLevelEvaluator }
  * );
  * ```
  */
@@ -163,8 +164,16 @@ export async function runEvaluatorTest(
   testCase: BaseTestCase,
   config: EvaluatorTestConfig
 ): Promise<TestResult<string>> {
-  const { evaluator, extractResult, maxAttempts = 3 } = config;
+  const { evaluator, maxAttempts = 3 } = config;
   const compareFn = defaultCompareFn;
+
+  // The declared outcome travels with the class, so the verdict field comes from the
+  // contract rather than being named per suite.
+  const declaredOutcome = (
+    evaluator.constructor as { metadata?: { outcome?: DeclaredOutcome } }
+  ).metadata?.outcome;
+  const extractResult =
+    config.extractResult ?? ((evalResult: EvaluationResult) => readOutcome(evalResult, declaredOutcome).score ?? 'undefined');
 
   // Buffer logs to print atomically at the end (prevents interleaving in parallel tests)
   const logBuffer: string[] = [];

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -125,8 +125,12 @@ export interface EvaluatorTestConfig<TEvaluator = any> {
    * How to read the value being compared. Defaults to the field the evaluator's contract
    * names in `outcome.score`, which is what a caller reads and what the batch report shows.
    * Pass this only to assert on something other than the declared verdict.
+   *
+   * Typed as the envelope rather than `any` so an extractor reaching for a field the
+   * envelope does not carry is a compile error instead of a run that silently compares
+   * `undefined` against every expected value.
    */
-  extractResult?: (evalResult: any) => string;
+  extractResult?: (evalResult: EvaluationResult<Record<string, unknown>>) => string;
 
   /** Maximum retry attempts (default: 3) */
   maxAttempts?: number;
@@ -173,7 +177,9 @@ export async function runEvaluatorTest(
     evaluator.constructor as { metadata?: { outcome?: DeclaredOutcome } }
   ).metadata?.outcome;
   const extractResult =
-    config.extractResult ?? ((evalResult: EvaluationResult) => readOutcome(evalResult, declaredOutcome).score ?? 'undefined');
+    config.extractResult ??
+    ((evalResult: EvaluationResult<Record<string, unknown>>) =>
+      readOutcome(evalResult, declaredOutcome).score ?? 'undefined');
 
   // Buffer logs to print atomically at the end (prevents interleaving in parallel tests)
   const logBuffer: string[] = [];


### PR DESCRIPTION
The integration harness read the verdict from a field the result envelope does not carry, so every comparison was against `undefined` regardless of what the model returned. Bringing it in line with the current result shape.

## The verdict comes from the contract

Each suite used to name the field itself:

```ts
extractResult: (r) => r.score,
```

The harness now reads whatever the evaluator's contract declares in `outcome.score`, via the same `readOutcome` the batch families use:

```ts
const declaredOutcome = evaluator.constructor.metadata?.outcome;
const extractResult = config.extractResult ?? ((r) => readOutcome(r, declaredOutcome).score ?? 'undefined');
```

Four suites lose their copy. It works for any evaluator without further edits — including the feedback family, whose verdict is an integer `quality_score` rather than a string — and it cannot go stale when a payload field is renamed. `extractResult` stays available for asserting on something other than the declared verdict.

Sentence Structure's expectations also move to the values its contract declares (14 of them).

## Caught before a live call, not after

The failure mode here is expensive and quiet: the read breaks, every comparison silently becomes `undefined` against a real expected value, and it reads as an evaluation-quality regression rather than a harness fault — after spending the API calls to find out.

So the harness now has offline tests in `tests/unit/utils/`, driven by a fake evaluator. **4 of the 7 fail against the previous read**, so this cannot recur without CI saying so. They also pin two things worth keeping honest:

- a genuine mismatch is reported as *the value returned*, so a wrong answer is distinguishable from a failed read
- `grade_level` is sent only when the case carries one, since an evaluator whose schema declares no grade rejects undeclared inputs

## `test:integration` narrows instead of widening

The script hardcoded the directory, so passing paths *added* to the run rather than restricting it — asking for four suites executed all eight, including the Anthropic and Knowledge Graph ones. Now `--dir tests/integration`, so:

- with paths → only those files (verified: 4 tests from one file)
- with none → all 8 suites still discovered

## Also here: env files were only ignored under one exact name

`.env.test` — the file this suite reads, holding live provider keys, in a public repo — was not ignored. The SDK covered `.env`, `.env.local` and `.env.*.local`; none of those match it. The repo root and `demos/typescript` covered only exact `.env`, so `demos/typescript/.env.local` and `evals/.env.test` were committable too.

Both now use `.env*` with `!.env*.example`, which keeps all three checked-in templates tracked (`demos/typescript/.env.example`, `evals/.env.example`, `sdks/typescript/.env.test.example`) and covers any future variant rather than a named list. Included because it is the same task: making a local integration run safe to do.

## Validation

- `typecheck`, `lint`, `test:unit` (1071), `build`, `scripts/check.py`
- **Ran the four suites live: 31 tests passed, 4 files.** That is the first real signal from this suite, and it covers the regenerated prompt descriptions and declared score values for background-knowledge-demands, meaning-directness, vocabulary-complexity and sentence-structure across grades 3–12.
- Reverted the extractor and confirmed 4 of 7 harness tests fail
- Verified both directions of the script change; that `.env.test`, `demos/typescript/.env.local` and `evals/.env.test` are now ignored; that all three `*.example` templates are not; and that no currently-tracked file became ignored
- `extractResult` is typed to the envelope, so the read this PR fixes is a compile error rather than only a test failure — confirmed by reintroducing it (`TS2339: Property 'score' does not exist`)
- Mutation testing on `test-helpers.ts`: 47.2% on covered lines. The survivors are almost entirely the human-readable log buffer that prints during a live run; asserting its wording would be brittle and would not protect anything. The two behavioural survivors — the grade branch — are now covered, which is what moved it from 45.5%.

## Not fixed here

`model-override.integration.test.ts` expects `ConfigurationError` for a non-existent model and receives a raw `APICallError` (OpenAI 400, `model_not_found`). That may be a real gap in error classification rather than a stale expectation, and it deserves its own change rather than being folded in.
