### PR TITLE
fix(sdk): classify a provider-rejected model as ConfigurationError

### DIFF
--- a/sdks/typescript/src/errors.ts
+++ b/sdks/typescript/src/errors.ts
@@ -256,6 +256,43 @@ function lookupHeader(headers: Record<string, string>, name: string): string | u
 }
 
 /**
+ * Every JSON error body reachable from one link of the cause chain.
+ *
+ * The AI SDK exposes a parsed `data` and the raw `responseBody`, and which one is populated
+ * depends on the provider client — so read both rather than trusting either.
+ */
+function providerErrorBodies(link: unknown): unknown[] {
+  const holder = link as { data?: unknown; responseBody?: unknown };
+  const bodies: unknown[] = [holder.data];
+  if (typeof holder.responseBody === 'string') {
+    try {
+      bodies.push(JSON.parse(holder.responseBody));
+    } catch {
+      // A non-JSON body carries no verdict; the status code is all there is.
+    }
+  }
+  return bodies;
+}
+
+/**
+ * Whether the provider blamed the model id itself, rather than failing to serve it.
+ *
+ * OpenAI-shaped bodies carry `{ error: { param, code } }`. `param: 'model'` covers a
+ * malformed id as well as an unknown one — both are the caller's choice of model, so the
+ * same fault domain. Compared against string literals, which excludes non-string values
+ * without narrowing them first.
+ */
+function isModelRejection(error: unknown): boolean {
+  for (const link of causeChain(error)) {
+    for (const body of providerErrorBodies(link)) {
+      const verdict = (body as { error?: { code?: unknown; param?: unknown } } | undefined)?.error;
+      if (verdict?.param === 'model' || verdict?.code === 'model_not_found') return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Read structured fields off whatever was thrown. Message text is carried for
  * diagnosis but never used to classify.
  */
@@ -348,7 +385,11 @@ export function wrapProviderError(
     return new LLMOutputProcessingError(message, null, error);
   }
 
-  if (statusCode === 404) {
+  // A rejected model is the caller's configuration, not a service fault: Google and
+  // Anthropic answer 404, OpenAI answers 400 with `code: model_not_found`. Restricted to
+  // those two statuses so a 401/429/5xx that happens to name `model` keeps the definite
+  // policy its status carries.
+  if (statusCode === 404 || (statusCode === 400 && isModelRejection(error))) {
     return new ConfigurationError(
       `Model not found or invalid: ${message}. Check the model ID passed to the provider.`,
       error

--- a/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
+++ b/sdks/typescript/tests/unit/errors/wrap-provider-error.test.ts
@@ -608,3 +608,120 @@ describe('wrapProviderError — provider errors without response headers', () =>
     expect((wrapProviderError(bad, CONTEXT) as RateLimitError).retryAfterMs).toBeNull();
   });
 });
+
+describe('wrapProviderError — a rejected model is the caller\'s configuration', () => {
+  // Verbatim from a live OpenAI 400 for `modelOverride: { model: 'gpt-this-model-does-not-exist-9999' }`.
+  // The status ladder alone put this in the catch-all, so a wrong model id surfaced as a
+  // provider fault — the wrong fault domain, and in the retryable-by-status family.
+  const OPENAI_BODY = JSON.stringify({
+    error: {
+      message: "The requested model 'gpt-this-model-does-not-exist-9999' does not exist.",
+      type: 'invalid_request_error',
+      param: 'model',
+      code: 'model_not_found',
+    },
+  });
+
+  const withBody = (statusCode: number, responseBody: string, data?: unknown) =>
+    new APICallError({
+      message: 'The requested model does not exist.',
+      url: 'https://api.openai.com/v1/responses',
+      requestBodyValues: {},
+      statusCode,
+      responseHeaders: {},
+      responseBody,
+      data,
+    });
+
+  it('classifies a 400 model_not_found from the raw body', () => {
+    const wrapped = wrapProviderError(withBody(400, OPENAI_BODY), CONTEXT);
+
+    expect(wrapped).toBeInstanceOf(ConfigurationError);
+    expect(wrapped.message).toMatch(/Check the model ID/);
+  });
+
+  it('classifies it from the parsed data when the client provides it', () => {
+    // The AI SDK populates `data` as well; only one of the two is guaranteed.
+    const wrapped = wrapProviderError(
+      withBody(400, 'not json', JSON.parse(OPENAI_BODY)),
+      CONTEXT,
+    );
+
+    expect(wrapped).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('still classifies a 404 model rejection, as Google and Anthropic send', () => {
+    expect(wrapProviderError(makeAPICallError(404, 'model not found'), CONTEXT)).toBeInstanceOf(
+      ConfigurationError,
+    );
+  });
+
+  it('leaves an unrelated 400 as a provider fault', () => {
+    // A 400 that is not about the model is our malformed request, not the caller's config.
+    const body = JSON.stringify({
+      error: { message: 'Invalid value for temperature', type: 'invalid_request_error', param: 'temperature', code: 'invalid_value' },
+    });
+
+    const wrapped = wrapProviderError(withBody(400, body), CONTEXT);
+
+    expect(wrapped).toBeInstanceOf(LLMProviderError);
+    expect(wrapped).not.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('leaves a 400 with no verdict alone', () => {
+    expect(wrapProviderError(makeAPICallError(400, 'Bad Request'), CONTEXT)).toBeInstanceOf(
+      LLMProviderError,
+    );
+  });
+
+  it('classifies on the code alone, when the body names no param', () => {
+    const body = JSON.stringify({ error: { message: 'no such model', code: 'model_not_found' } });
+
+    expect(wrapProviderError(withBody(400, body), CONTEXT)).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('classifies on the param alone, when the code is one we do not know', () => {
+    // A malformed id rather than an unknown one: same fault domain, different code.
+    const body = JSON.stringify({
+      error: { message: 'invalid model id', param: 'model', code: 'invalid_value' },
+    });
+
+    expect(wrapProviderError(withBody(400, body), CONTEXT)).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('ignores a non-string param', () => {
+    // Strict comparison against the literal is what excludes this, rather than a typeof guard.
+    const body = JSON.stringify({ error: { message: 'bad request', param: 0 } });
+
+    expect(wrapProviderError(withBody(400, body), CONTEXT)).not.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('finds the verdict when it is wrapped further down the cause chain', () => {
+    // Provider clients re-throw, so the APICallError is rarely the outermost error.
+    const wrapper = new Error('Failed to generate object', { cause: withBody(400, OPENAI_BODY) });
+
+    expect(wrapProviderError(wrapper, CONTEXT)).toBeInstanceOf(ConfigurationError);
+  });
+
+  it('survives a body that is not JSON', () => {
+    expect(() =>
+      wrapProviderError(withBody(400, '<html>502 Bad Gateway</html>'), CONTEXT),
+    ).not.toThrow();
+  });
+
+  // A status with a definite policy keeps it, even when the body blames the model — an
+  // expired key or an exhausted quota is not something the caller fixes by changing models,
+  // and a 429 misread as ConfigurationError would also lose its retry semantics.
+  it.each([
+    [401, AuthenticationError],
+    [403, AuthenticationError],
+    [429, RateLimitError],
+    [408, RequestTimeoutError],
+    [500, LLMProviderError],
+  ])('leaves a %i carrying a model verdict as %s', (statusCode, expected) => {
+    const wrapped = wrapProviderError(withBody(statusCode, OPENAI_BODY), CONTEXT);
+
+    expect(wrapped).toBeInstanceOf(expected);
+    expect(wrapped).not.toBeInstanceOf(ConfigurationError);
+  });
+});


### PR DESCRIPTION
`modelOverride` documents `@throws ConfigurationError` when the provider rejects the model id. The classifier honoured that for 404 only, so a wrong model id on OpenAI surfaced as `LLMProviderError` — the wrong fault domain ("the service is broken" rather than "your model id is wrong"), and in the retryable-by-status family.

OpenAI answers an unknown model with **400**, not 404:

```json
{"error":{"message":"The requested model 'gpt-...-9999' does not exist.","type":"invalid_request_error","param":"model","code":"model_not_found"}}
```

Google and Anthropic answer 404, which is why this went unnoticed.

## Keyed on the provider's verdict, not on widening 400

A 400 is otherwise a genuine malformed request from us, so it stays a provider fault. The new check reads the provider's own machine-readable verdict — `param: 'model'` (which covers a malformed id as well as an unknown one) or `code: 'model_not_found'` — from the parsed `data` and the raw `responseBody`, since which of the two is populated depends on the provider client, and walks the cause chain because the `APICallError` is rarely outermost.

It is gated to 400 and 404:

```ts
if (statusCode === 404 || (statusCode === 400 && isModelRejection(error))) {
```

An earlier version of this check was ungated, which let a 401/403/429/408/5xx carrying a model-shaped body become `ConfigurationError` — losing an expired key's meaning and a 429's retry semantics. Statuses with a definite policy keep it; five parameterised cases now pin that.

## Validation

- `typecheck`, `lint`, `test:unit` (1086), `build`, `scripts/check.py`
- **Ran the live suite: `model-override.integration.test.ts` passes (2 tests) against the real OpenAI 400.** It was the one integration failure left after #232.
- Load-bearing in both directions: reverting to status-only fails 2 of the new tests; the ungated variant fails 5
- Mutation testing on `errors.ts`: **84.4% → 93.5%** (survivors 46 → 18, uncovered 2 → 0). The first pass showed the verdict reader's `typeof` narrowing and a fuzzy `code` regex were entirely unkilled — the regex was dead because `param` always matched first — so both were deleted rather than tested, which is where most of the gain came from. The one survivor left in the new code is equivalent, not a gap: dropping the `typeof responseBody === 'string'` guard changes nothing because `JSON.parse` throws into the same `catch`.
