### PR TITLE
test(sdk): cover model rejection on all three providers

### DIFF
--- a/sdks/typescript/tests/integration/model-override.integration.test.ts
+++ b/sdks/typescript/tests/integration/model-override.integration.test.ts
@@ -43,13 +43,33 @@ describeIntegration('modelOverride — model validity (live API)', () => {
     expect(result.metadata.model).toMatch(/^openai:gpt-4o-mini/);
   }, TEST_TIMEOUT_MS);
 
-  it('throws ConfigurationError for a non-existent model override', async () => {
-    const evaluator = new SentenceStructureEvaluator({
-      openaiApiKey: process.env.OPENAI_API_KEY!,
-      modelOverride: { provider: Provider.OpenAI, model: 'gpt-this-model-does-not-exist-9999' },
-      telemetry: false,
-    });
+  // Each provider rejects an unknown model differently, and the classifier reaches the same
+  // verdict by two different routes: OpenAI answers 400 and has to be read from the error
+  // body (`param: 'model'`), while Anthropic and Google answer 404 and are classified on
+  // status alone. Covering only OpenAI left the 404 route unexercised live, and vice versa.
+  const REJECTION_CASES = [
+    { provider: Provider.OpenAI, keyField: 'openaiApiKey', envVar: 'OPENAI_API_KEY', model: 'gpt-this-model-does-not-exist-9999' },
+    { provider: Provider.Anthropic, keyField: 'anthropicApiKey', envVar: 'ANTHROPIC_API_KEY', model: 'claude-this-model-does-not-exist-9999' },
+    { provider: Provider.Google, keyField: 'googleApiKey', envVar: 'GOOGLE_API_KEY', model: 'gemini-this-model-does-not-exist-9999' },
+  ] as const;
 
-    await expect(evaluator.evaluate({ text: SAMPLE_TEXT, grade_level: '5' })).rejects.toThrow(ConfigurationError);
-  }, TEST_TIMEOUT_MS);
+  for (const { provider, keyField, envVar, model } of REJECTION_CASES) {
+    const apiKey = process.env[envVar];
+
+    it.skipIf(!apiKey)(
+      `throws ConfigurationError for a non-existent ${provider} model override`,
+      async () => {
+        const evaluator = new SentenceStructureEvaluator({
+          [keyField]: apiKey,
+          modelOverride: { provider, model },
+          telemetry: false,
+        });
+
+        await expect(evaluator.evaluate({ text: SAMPLE_TEXT, grade_level: '5' })).rejects.toThrow(
+          ConfigurationError
+        );
+      },
+      TEST_TIMEOUT_MS
+    );
+  }
 });

--- a/sdks/typescript/tests/utils/index.ts
+++ b/sdks/typescript/tests/utils/index.ts
@@ -15,4 +15,5 @@ export {
   type RetryTestOptions,
   type BaseTestCase,
   type EvaluatorTestConfig,
+  type TestableEvaluator,
 } from './test-helpers.js';

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -115,9 +115,18 @@ export interface BaseTestCase {
 }
 
 /**
+ * The only surface the harness uses: a single `evaluate` call. Narrower than the evaluator
+ * classes themselves, so any evaluator satisfies it without the harness depending on which
+ * one it was handed.
+ */
+export interface TestableEvaluator {
+  evaluate(input: Record<string, unknown>): Promise<EvaluationResult<Record<string, unknown>>>;
+}
+
+/**
  * Configuration for running evaluator tests
  */
-export interface EvaluatorTestConfig<TEvaluator = any> {
+export interface EvaluatorTestConfig<TEvaluator extends TestableEvaluator = TestableEvaluator> {
   /** The evaluator instance to test */
   evaluator: TEvaluator;
 


### PR DESCRIPTION
Two follow-ups from #233, both test-only — no runtime code changes.

## The 404 route had no live coverage

#233 classified a provider-rejected model as `ConfigurationError`, but the integration suite only exercised OpenAI. The three providers reject an unknown model differently, and the classifier reaches the same verdict by two different routes — so covering one left the other unverified:

| Provider | Status | How it classifies |
| --- | --- | --- |
| OpenAI | **400** | read from the error body (`param: "model"`) |
| Anthropic | **404** | status alone (`not_found_error`, no `param`/`code`) |
| Google | **404** | status alone (`error.code` is the *number* `404`) |

That table is measured, not assumed — #233's code comment asserted the 404 behaviour without ever having exercised it. The rejection case is now parameterised across all three, skipping per-provider when a key is absent.

**Verified live: 4 tests pass (was 2).** Removing the `statusCode === 404` branch fails exactly the Anthropic and Google cases while OpenAI still passes, so the two routes are independently covered rather than one masking the other.

Google's numeric `error.code` is worth noting: it is why the check compares against string literals instead of coercing, since a coerced or fuzzy match could false-positive there.

## `EvaluatorTestConfig` no longer takes `any`

`TEvaluator = any` was the repo's only lint warning. The harness uses exactly one member of the evaluator it is handed, so a structural type is enough and every evaluator satisfies it:

```ts
export interface TestableEvaluator {
  evaluate(input: Record<string, unknown>): Promise<EvaluationResult<Record<string, unknown>>>;
}
```

Load-bearing, not cosmetic: passing an object with no `evaluate` is now `TS2353`, where `any` accepted it silently. This is the same class of hole as the one #232 fixed — the harness comparing `undefined` against every expected value after a live run.

## Validation

- `typecheck`, `lint` (**now zero warnings**), `test:unit` (1086), `build`, `scripts/check.py`
- Live: 4/4 in `model-override.integration.test.ts`, none skipped
- Confirmed the 404 and 400 routes fail independently
- Confirmed the structural type rejects a non-evaluator at compile time
- No mutation testing run: the diff is limited to an integration test and a type declaration, so there is no runtime behaviour for Stryker to mutate (`git diff src/` is empty).
