### PR TITLE
refactor(sdk): derive report ordering and grade bands from their contracts

### DIFF
--- a/sdks/typescript/src/batch/formatters.ts
+++ b/sdks/typescript/src/batch/formatters.ts
@@ -2,6 +2,8 @@ import type { BatchOutput, BatchResult } from './types.js';
 import reportTemplate from './report-template.html';
 import { injectReportData, toInlineJson } from './report-injection.js';
 import { GradeLevelAppropriatenessEvaluator } from '../evaluators/student-facing-text/ela-reading/grade-level-appropriateness.js';
+import { GradeLevelAppropriatenessOutputSchema } from '../schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
+import { QTC_FAMILY } from './families/qtc.js';
 
 // ---- Constants ----
 
@@ -10,8 +12,12 @@ import { GradeLevelAppropriatenessEvaluator } from '../evaluators/student-facing
 // column instead of failing.
 const GLA_EVALUATOR_ID = GradeLevelAppropriatenessEvaluator.metadata.id;
 
-const GRADE_BANDS = ['K-1', '2-3', '4-5', '6-8', '9-10', '11-12'] as const;
-type GradeBand = typeof GRADE_BANDS[number];
+// Read from GLA's generated schema, which is the contract that defines the bands. The
+// report indexes into this list to derive on-band/adjacent/off-target, so a band the
+// contract gains but this list lacks would index to -1 and render as "Off Target" — a
+// plausible-looking verdict rather than a failure.
+const GRADE_BANDS = GradeLevelAppropriatenessOutputSchema.shape.grade_band.options;
+type GradeBand = (typeof GRADE_BANDS)[number];
 
 // Complexity string scores → numeric
 const COMPLEXITY_SCORE_MAP: Record<string, number> = {
@@ -358,6 +364,9 @@ export function formatAsHTML(output: BatchOutput, meta: ReportMeta): string {
       groupId: meta.groupId,
       evaluatorIds: allEvaluatorIds,
       evaluatorNames: allEvaluatorIds.map(evaluatorDisplayName),
+      // The column order travels with the data rather than being restated in the
+      // template, so a member added to the family is ordered without a second edit.
+      evaluatorOrder: QTC_FAMILY.members.map((m) => m.id),
       totalRows: meta.totalInputRows,
       processedRows,
       erroredRows,

--- a/sdks/typescript/src/batch/report-template.html
+++ b/sdks/typescript/src/batch/report-template.html
@@ -225,6 +225,7 @@
         csvPath: '/Users/designer/Documents/interventionhelper_content_batch_03-01.csv',
         evaluatorIds: ['student_facing_text.ela_reading.grade_level_appropriateness', 'student_facing_text.ela_reading.background_knowledge_demands', 'student_facing_text.ela_reading.vocabulary_complexity', 'student_facing_text.ela_reading.sentence_structure', 'student_facing_text.ela_reading.meaning_directness'],
         evaluatorNames: ['Grade Level Appropriateness Evaluator', 'Background Knowledge Demands Evaluator', 'Vocabulary Complexity Evaluator', 'Sentence Structure Evaluator', 'Meaning Directness Evaluator'],
+        evaluatorOrder: ['student_facing_text.ela_reading.grade_level_appropriateness', 'student_facing_text.ela_reading.background_knowledge_demands', 'student_facing_text.ela_reading.vocabulary_complexity', 'student_facing_text.ela_reading.sentence_structure', 'student_facing_text.ela_reading.meaning_directness'],
         totalRows: 300,
         processedRows: 287,
         erroredRows: 13,
@@ -419,16 +420,12 @@
     REPORT_DATA = REPORT_DATA || MOCK_REPORT_DATA;
 
     // ---------------------------------------------------------------------------
-    // Report column order. Ids absent from this list sort last — add new members here.
+    // Report column order, supplied by the formatter from the family definition. Kept out
+    // of this file so a member added to the family does not need a second edit here to
+    // avoid sorting last.
     // ---------------------------------------------------------------------------
 
-    const EVALUATOR_ORDER = [
-      'student_facing_text.ela_reading.grade_level_appropriateness',
-      'student_facing_text.ela_reading.background_knowledge_demands',
-      'student_facing_text.ela_reading.vocabulary_complexity',
-      'student_facing_text.ela_reading.sentence_structure',
-      'student_facing_text.ela_reading.meaning_directness',
-    ];
+    const EVALUATOR_ORDER = REPORT_DATA.meta.evaluatorOrder || [];
 
     function evalSortIndex(id) {
       const i = EVALUATOR_ORDER.indexOf(id);

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -702,9 +702,29 @@ describe('constructed models match the contract', () => {
 });
 
 /**
- * The `meta` the text-complexity report actually ships, parsed back out of the generated
- * HTML. Read from the emitted file rather than from the formatter's inputs, so the
- * assertion covers the injection too.
+ * The report data a generated HTML file ships, parsed back out of it.
+ *
+ * The marker is asserted rather than assumed: absent, `indexOf` gives -1 and the slice
+ * reaches `JSON.parse` as garbage, so the failure would name a syntax error instead of the
+ * marker that moved. `injectReportData` names it on the write side for the same reason.
+ */
+interface ParsedReport {
+  meta: Record<string, string[] | undefined>;
+  fullResults: { rows: Record<string, unknown>[] };
+}
+
+function parseReportData(html: string): ParsedReport {
+  const marker = 'var REPORT_DATA = ';
+  const at = html.indexOf(marker);
+  expect(at, `"${marker}" not found in the generated report`).toBeGreaterThan(-1);
+
+  const line = html.slice(at + marker.length, html.indexOf('\n', at));
+  return JSON.parse(line.endsWith(';') ? line.slice(0, -1) : line);
+}
+
+/**
+ * The `meta` the text-complexity report actually ships. Read from the emitted file rather
+ * than from the formatter's inputs, so the assertion covers the injection too.
  */
 function reportMetaFor(evaluatorIds: string[]): Record<string, string[] | undefined> {
   const output = {
@@ -722,11 +742,7 @@ function reportMetaFor(evaluatorIds: string[]): Record<string, string[] | undefi
     evaluatorNames: evaluatorIds,
   } as unknown as ReportMeta;
 
-  const html = formatAsHTML(output, meta);
-  const marker = 'var REPORT_DATA = ';
-  const start = html.indexOf(marker) + marker.length;
-  const line = html.slice(start, html.indexOf('\n', start));
-  return JSON.parse(line.endsWith(';') ? line.slice(0, -1) : line).meta;
+  return parseReportData(formatAsHTML(output, meta)).meta;
 }
 
 describe('the report recognises every grade band the contract declares', () => {
@@ -768,11 +784,7 @@ describe('the report recognises every grade band the contract declares', () => {
       evaluatorNames: ['GLA'],
     } as unknown as ReportMeta;
 
-    const html = formatAsHTML(output, meta);
-    const marker = 'var REPORT_DATA = ';
-    const start = html.indexOf(marker) + marker.length;
-    const line = html.slice(start, html.indexOf('\n', start));
-    const data = JSON.parse(line.endsWith(';') ? line.slice(0, -1) : line);
+    const data = parseReportData(formatAsHTML(output, meta));
 
     // A grade inside the band must read as on-band. An unresolved band indexes to -1,
     // which the report renders as the verdict "Off Target" — a plausible-looking answer.

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -55,7 +55,6 @@ interface EvaluatorClass {
 }
 import {
   formatAsHTML,
-  getFamilies,
   type BatchOutput,
   type ReportMeta,
 } from '../../src/batch/index.js';
@@ -170,18 +169,6 @@ const GRADE_GAPS = new Set<string>([
  */
 const BAND_GAPS = new Set<string>([
   // Empty: the report recognises every band the contracts declare.
-]);
-
-/**
- * Family members absent from the report's `EVALUATOR_ORDER`.
- *
- * An absent member sorts to index 999, so its column appears in arbitrary order rather
- * than failing.
- */
-const ORDER_GAPS = new Set<string>([
-  PurposeClarityEvaluator.metadata.id,
-  OrganizationalStructureEvaluator.metadata.id,
-  ReferenceKnowledgeDemandsEvaluator.metadata.id,
 ]);
 
 /**
@@ -714,6 +701,34 @@ describe('constructed models match the contract', () => {
   });
 });
 
+/**
+ * The `meta` the text-complexity report actually ships, parsed back out of the generated
+ * HTML. Read from the emitted file rather than from the formatter's inputs, so the
+ * assertion covers the injection too.
+ */
+function reportMetaFor(evaluatorIds: string[]): Record<string, string[] | undefined> {
+  const output = {
+    results: [],
+    summary: { totalTasks: 0, successful: 0, failed: 0, durationMs: 1, resultsPerEvaluator: {} },
+  } as unknown as BatchOutput;
+
+  const meta = {
+    reportId: 'r',
+    generatedAt: 'now',
+    csvPath: '/tmp/in.csv',
+    totalInputRows: 0,
+    groupId: QTC_FAMILY.id,
+    evaluatorIds,
+    evaluatorNames: evaluatorIds,
+  } as unknown as ReportMeta;
+
+  const html = formatAsHTML(output, meta);
+  const marker = 'var REPORT_DATA = ';
+  const start = html.indexOf(marker) + marker.length;
+  const line = html.slice(start, html.indexOf('\n', start));
+  return JSON.parse(line.endsWith(';') ? line.slice(0, -1) : line).meta;
+}
+
 describe('the report recognises every grade band the contract declares', () => {
   const glaContract = contractFor(GLA_ID);
   const bands = ((glaContract.outputSchema.$defs?.GradeBand as { enum?: string[] })?.enum ??
@@ -771,34 +786,36 @@ describe('the report recognises every grade band the contract declares', () => {
 });
 
 describe('the report can order every family member', () => {
-  // EVALUATOR_ORDER lives in the report template as a plain JS literal, so nothing
-  // typechecks it against the families. A member missing from it sorts to index 999
-  // and lands in arbitrary order — visible only to someone reading the report.
+  // The order now travels with the report data, derived from the family definition, so
+  // membership cannot drift. What can still break is the wiring: the template reading a
+  // literal again, or the formatter not emitting the field. A member the report cannot
+  // order sorts to index 999 and lands in arbitrary order — visible only to someone
+  // reading the report, which is why this is asserted rather than left to review.
   const template = readFileSync(join(process.cwd(), 'src/batch/report-template.html'), 'utf-8');
-  const marker = 'const EVALUATOR_ORDER = [';
-  const at = template.indexOf(marker);
 
-  it('finds the ordering array in the template', () => {
-    // Without this, a moved or reformatted marker would surface as "every member is
-    // absent" and send the reader looking in the wrong place.
-    expect(at, `"${marker}" not found in report-template.html`).toBeGreaterThan(-1);
+  it('takes its ordering from the report data, not a literal in the template', () => {
+    expect(template).toContain('REPORT_DATA.meta.evaluatorOrder');
   });
 
-  const declared = at === -1 ? '' : template.slice(at, template.indexOf(']', at));
+  it('has no second copy of the order to fall out of step', () => {
+    // A literal list of ids next to EVALUATOR_ORDER is what this change removed; the
+    // mock's own copy is exempt because it stands in for absent data, not for the order.
+    const at = template.indexOf('const EVALUATOR_ORDER');
+    const declaration = template.slice(at, template.indexOf(';', at));
+    expect(declaration).not.toMatch(/student_facing_text\./);
+  });
 
   // Only the text-complexity family renders this template: standards has its own report
   // and the feedback family has none yet, so neither consults this ordering.
-  const members = getFamilies()
-    .filter((f) => f.id === QTC_FAMILY.id)
-    .flatMap((f) => f.members.map((m) => ({ family: f.id, id: m.id })));
+  //
+  // Asserted once, not per member: the emitted order and the family definition are the
+  // same list, so there is no independent expectation to compare a member against. What
+  // this does catch is the formatter omitting or truncating the field, which is what
+  // would put a member back at index 999.
+  it('ships every family member in the order the family declares', () => {
+    const emitted = reportMetaFor(QTC_FAMILY.members.map((m) => m.id)).evaluatorOrder;
 
-  it.each(members)('$family / $id', ({ id }) => {
-    expectAgainstContract(
-      ORDER_GAPS.has(id),
-      declared.includes(`'${id}'`),
-      true,
-      `"${id}" is absent from the report's EVALUATOR_ORDER`,
-    );
+    expect(emitted).toEqual(QTC_FAMILY.members.map((m) => m.id));
   });
 });
 


### PR DESCRIPTION
Two facts the report restated instead of reading: the column order and the grade bands. Both now come from their source, closing the last two entries in the conformance suite's gap lists that were not blocked on the Flesch–Kincaid decision.

## Column order comes from the family definition

`EVALUATOR_ORDER` was a literal in `report-template.html` listing five ids. The family has eight — Purpose Clarity, Organizational Structure and Reference Knowledge Demands were absent, and an absent id sorts to index 999, so those three columns appeared in arbitrary order rather than failing. It was tracked as `ORDER_GAPS`.

The order now travels with the report data, derived from `QTC_FAMILY.members`:

```js
const EVALUATOR_ORDER = REPORT_DATA.meta.evaluatorOrder || [];
```

A member added to the family is ordered without a second edit, so the class of bug is gone rather than fixed. `ORDER_GAPS` is deleted, not emptied — nothing consumes it once membership is structural.

## Grade bands come from GLA's generated schema

```ts
const GRADE_BANDS = GradeLevelAppropriatenessOutputSchema.shape.grade_band.options;
```

Previously a six-entry literal. The report indexes into this list to derive on-band / adjacent / off-target, so a band the contract gains but the list lacks indexes to `-1` and renders as the verdict "Off Target" — a plausible-looking answer rather than an error. Same failure mode `GLA_EVALUATOR_ID` already avoids two lines above.

## The per-member ordering tests were tautological, so they are now one test

Worth calling out, because I nearly left it: after the change, the ordering test derived both the expected and the actual order from `QTC_FAMILY.members`. I scrambled the family order to check — **all 240 tests still passed.** Eight per-member assertions that cannot fail on a reorder read as coverage they do not provide.

They are replaced by a single assertion, plus two that guard the wiring rather than the data:

- the template reads `REPORT_DATA.meta.evaluatorOrder` and not a literal
- no second copy of the id list sits next to `EVALUATOR_ORDER` for it to fall out of step with
- the emitted order deep-equals the family's members

A reorder is genuinely uncatchable now, and that is correct: the family definition *is* the definition of correct order, so there is no independent expectation to compare against.

## Validation

- `typecheck`, `lint`, `test:unit` (1080), `build`, `scripts/check.py`
- Each new assertion confirmed load-bearing by breaking the thing it guards: formatter omits the field (1 fails), formatter truncates it (1 fails), template reverts to a literal (2 fail), derived band order reversed (6 fail)
- Mutation testing on `formatters.ts`: **72.95% → 73.62%** (uncovered 11 → 9), measured against `origin/main` rather than quoted from this run alone. The two changed lines have **zero survivors**; the whole-file figure is dominated by pre-existing report assembly, whose largest survivor group is the locale timestamp format — brittle to assert and protecting nothing.
- The template mock carries `evaluatorOrder` too, so opening the template directly still orders its columns

## From review

Copilot flagged that the test parsed `var REPORT_DATA = ` without checking the marker was there — absent, `indexOf` gives -1 and the slice reaches `JSON.parse` as garbage, so the failure names a syntax error instead of the marker that moved. It applied to two sites, because the parsing was duplicated.

Both now go through one `parseReportData` helper that asserts the marker first, mirroring `injectReportData`, which already names it on the write side. Verified by renaming the marker there: the failure now reads `"var REPORT_DATA = " not found in the generated report`.

## Still open

`PREPROCESSING_GAPS` (background-knowledge-demands, meaning-directness, vocabulary-complexity) remains blocked on the Flesch–Kincaid parity decision. `GRADE_GAPS` / `RESULT_NAME_GAPS` remain scoped to the math evaluator's result envelope.
