### PR TITLE
feat(sdk): bind math standards alignment to both declared steps and cover it live

### DIFF
--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -6,6 +6,7 @@ import {
   CoarseFilterSchema,
 } from '../../../schemas/academic-standards-alignment/mathematics/math-standards-alignment.js';
 import {
+  COARSE_STEP,
   getSystemPrompt,
   getUserPrompt,
   getCoarseFilterPrompt,
@@ -140,8 +141,8 @@ export interface MathStandardsAlignmentEvaluatorConfig extends BaseEvaluatorConf
   /** Max concurrent KG HTTP calls (default: 20) */
   kgConcurrency?: number;
   /**
-   * Model for the coarse pre-filter only. Defaults to the detail model the contract
-   * declares; `modelOverride` replaces both.
+   * Model for the coarse pre-filter only. Defaults to the model its own step declares in
+   * `config.json`; `modelOverride` replaces both.
    */
   coarseFilterModel?: string;
   /** @internal Test seam — inject a pre-built client without a real API key */
@@ -154,6 +155,8 @@ export interface MathStandardsAlignmentEvaluatorConfig extends BaseEvaluatorConf
 
 const DETAIL_MODEL: string = STEP.model.name;
 const TEMPERATURE: number | null = STEP.generation.temperature;
+const COARSE_MODEL: string = COARSE_STEP.model.name;
+const COARSE_TEMPERATURE: number | null = COARSE_STEP.generation.temperature;
 const KG_SUBJECT = 'Mathematics';
 /**
  * Above this many question/standard pairs, evaluateByGradeLevel warns. A grade level can carry
@@ -222,7 +225,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
     this.coarseProvider = this.createConfiguredProvider(
       Provider.Anthropic,
-      config.coarseFilterModel ?? DETAIL_MODEL,
+      config.coarseFilterModel ?? COARSE_MODEL,
       config.anthropicApiKey,
     );
   }
@@ -636,7 +639,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
           { role: 'user', content: getCoarseFilterPrompt({ question, standards: standardList }) },
         ],
         schema: CoarseFilterSchema,
-        temperature: TEMPERATURE,
+        temperature: COARSE_TEMPERATURE,
       });
 
       const relevant = new Set<string>();

--- a/sdks/typescript/src/prompts/math/standards-alignment/index.ts
+++ b/sdks/typescript/src/prompts/math/standards-alignment/index.ts
@@ -5,10 +5,21 @@ import CONFIG from '../../../../../../evals/academic-standards-alignment/mathema
 import INPUT_SCHEMA from '../../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/input_schema.json';
 import { createHash } from 'node:crypto';
 
-const STEP_ID = 'evaluate_math_standards_alignment';
-const _step = CONFIG.steps.find((s) => s.id === STEP_ID);
-if (!_step) throw new Error(`Step "${STEP_ID}" not found in math-standards-alignment config.json`);
-export const STEP = _step;
+function requireStep(id: string) {
+  const step = CONFIG.steps.find((s) => s.id === id);
+  if (!step) throw new Error(`Step "${id}" not found in math-standards-alignment config.json`);
+  return step;
+}
+
+/** The detail step: one model call per question/standard pair. */
+export const STEP = requireStep('evaluate_math_standards_alignment');
+
+/**
+ * The coarse pre-filter step. It declares its own model and temperature, which are the same
+ * as the detail step's today — reading them rather than inheriting is what makes a future
+ * re-pin of one take effect without silently changing the other.
+ */
+export const COARSE_STEP = requireStep('coarse_filter');
 
 /** SHA-256 over all prompt files — stable cache key for downstream tools. */
 export const PROMPT_CHECKSUM = createHash('sha256')
@@ -20,7 +31,7 @@ export const MAX_QUESTION_LENGTH: number = INPUT_SCHEMA.properties.question.maxL
 
 const DETAIL_PLACEHOLDER_KEYS = Object.keys(STEP.prompt.placeholders) as string[];
 const SYSTEM_PLACEHOLDER_KEYS: string[] = [];
-const COARSE_PLACEHOLDER_KEYS = ['question', 'standards'];
+const COARSE_PLACEHOLDER_KEYS = Object.keys(COARSE_STEP.prompt.placeholders) as string[];
 
 function replace(template: string, keys: readonly string[], inputs: Record<string, string>): string {
   return keys.reduce(

--- a/sdks/typescript/tests/integration/math-standards-alignment-cases.integration.test.ts
+++ b/sdks/typescript/tests/integration/math-standards-alignment-cases.integration.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MathStandardsAlignmentEvaluator,
+  Jurisdiction,
+} from '../../src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.js';
+
+/**
+ * Math Standards Alignment Evaluator Integration Tests
+ *
+ * Three cases across the 3.MD.C.7 family, chosen so the expected direction is unambiguous:
+ *
+ * - An L-shaped area question against `3.MD.C.7.d` (rectilinear decomposition), its
+ *   canonical match.
+ * - The same question against the parent `3.MD.C.7` (area by multiplication and addition).
+ * - A bare arithmetic question against `3.MD.C.7.d`, which it should not align to at all.
+ *
+ * A standard's learning components come from the Knowledge Graph rather than from a model,
+ * so they are asserted exactly. Whether a question aligns to one is the model's judgement
+ * and moves between runs even at temperature 0 — for `3.MD.C.7.d` runs have produced 1, 2
+ * and 3 of 3 — so alignment is asserted by direction and never by count.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  }
+  if (!process.env.LEARNING_COMMONS_API_KEY) {
+    throw new Error('LEARNING_COMMONS_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  }
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const AREA_QUESTION =
+  'A playground is shaped like an L. One part is a rectangle that is 8 feet long and 3 feet wide. ' +
+  'Attached to it is another rectangle that is 4 feet long and 2 feet wide, with no overlap. ' +
+  'What is the total area of the playground in square feet?';
+
+interface TestCase {
+  id: string;
+  description: string;
+  question: string;
+  statementCode: string;
+  /** The standard's learning components, in Knowledge Graph order. */
+  components: string[];
+  /** `some` = at least one component aligns; `none` = no component aligns. */
+  alignment: 'some' | 'none';
+}
+
+const RECTILINEAR_COMPONENTS = [
+  'Find the area of rectilinear figures by decomposing them into non-overlapping parts and finding the area of each part',
+  'Find the area of rectilinear figures in real-world problems by decomposing them into non-overlapping parts and finding the area of each part',
+  'Solve real-world problems involving rectilinear figures',
+];
+
+const TEST_CASES: TestCase[] = [
+  {
+    id: 'MSA1',
+    description: 'L-shaped playground area against 3.MD.C.7.d',
+    question: AREA_QUESTION,
+    statementCode: '3.MD.C.7.d',
+    components: RECTILINEAR_COMPONENTS,
+    alignment: 'some',
+  },
+  {
+    id: 'MSA2',
+    description: 'simple addition against 3.MD.C.7.d',
+    question: 'What is 12 + 7?',
+    statementCode: '3.MD.C.7.d',
+    components: RECTILINEAR_COMPONENTS,
+    alignment: 'none',
+  },
+  {
+    id: 'MSA3',
+    description: 'L-shaped playground area against the parent standard 3.MD.C.7',
+    question: AREA_QUESTION,
+    statementCode: '3.MD.C.7',
+    components: ['Use multiplication and addition to find the area of rectangles'],
+    alignment: 'some',
+  },
+];
+
+describeIntegration('MathStandardsAlignmentEvaluator - Integration', () => {
+  it.each(TEST_CASES)(
+    '$id: $description',
+    async (testCase) => {
+      const evaluator = new MathStandardsAlignmentEvaluator({
+        anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
+        learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY!,
+      });
+
+      // `evaluate()` returns the payload directly rather than the `{ evaluator, result,
+      // metadata }` envelope the other evaluators return.
+      const result = await evaluator.evaluate({
+        question: testCase.question,
+        statementCode: testCase.statementCode,
+        jurisdiction: Jurisdiction.MultiState,
+      });
+
+      console.log(`\n  ${testCase.id}: ${result.alignedCount}/${result.totalCount} aligned`);
+      for (const lc of result.learningComponents) {
+        console.log(`    ${lc.aligned ? '✓' : '✗'} ${lc.description.slice(0, 84)}`);
+      }
+
+      expect(result.statementCode).toBe(testCase.statementCode);
+      expect(
+        result.learningComponents.map((lc) => lc.description),
+        'learning components come from the Knowledge Graph, so they are exact',
+      ).toEqual(testCase.components);
+      expect(result.totalCount).toBe(testCase.components.length);
+      expect(result.alignedCount).toBe(
+        result.learningComponents.filter((lc) => lc.aligned).length,
+      );
+
+      if (testCase.alignment === 'none') {
+        expect(
+          result.alignedCount,
+          `"${testCase.question.slice(0, 40)}…" must not align to ${testCase.statementCode}`,
+        ).toBe(0);
+      } else {
+        expect(
+          result.alignedCount,
+          `"${testCase.question.slice(0, 40)}…" should align to ${testCase.statementCode}`,
+        ).toBeGreaterThan(0);
+      }
+
+      // Every component is reasoned about, and a miss says how to fix the item — that is
+      // the evaluator's actual product, and an empty string would satisfy the schema.
+      for (const lc of result.learningComponents) {
+        expect(lc.reasoning.trim().length, `reasoning for "${lc.description}"`).toBeGreaterThan(20);
+        if (!lc.aligned) {
+          expect(
+            lc.feedback?.trim().length ?? 0,
+            `feedback for unaligned "${lc.description}"`,
+          ).toBeGreaterThan(20);
+        }
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
+++ b/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
@@ -6,6 +6,15 @@ const RUN = process.env['RUN_INTEGRATION_TESTS'] === 'true';
 const ANTHROPIC_KEY = process.env['ANTHROPIC_API_KEY'];
 const LEARNING_COMMONS_KEY = process.env['LEARNING_COMMONS_API_KEY'];
 
+// A missing key when integration tests were explicitly requested is a misconfiguration,
+// not a reason to quietly pass — matches batch/model-override.
+if (RUN) {
+  if (!ANTHROPIC_KEY) throw new Error('ANTHROPIC_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  if (!LEARNING_COMMONS_KEY) {
+    throw new Error('LEARNING_COMMONS_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  }
+}
+
 const itIf = (cond: boolean) => (cond ? it : it.skip);
 
 // ---------------------------------------------------------------------------
@@ -54,7 +63,7 @@ function makeInstrumentedEvaluator() {
 // ---------------------------------------------------------------------------
 
 describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, () => {
-  itIf(RUN && !!ANTHROPIC_KEY && !!LEARNING_COMMONS_KEY)(
+  itIf(RUN)(
     '3.MD.C.7 family: area L-shape question vs parent + all sub-standards',
     async () => {
       const questionItems = [
@@ -122,11 +131,15 @@ describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, 
 
       const find = (code: string) => areaGT.standards.find((s) => s.statementCode === code)!;
 
+      // Alignment per learning component is a model judgement and it moves between runs
+      // even at temperature 0 — for 3.MD.C.7.d runs have produced 1, 2 and 3 of 3. So the
+      // direction is asserted (does it align at all?) and never the count.
+      //
       // 3.MD.C.7 — parent standard: "use multiplication and addition to find area"
-      //   Area L-shape requires adding two rectangles → strongly aligned
+      //   Area L-shape requires adding two rectangles → aligned
       const s7 = find('3.MD.C.7');
       expect(s7.totalCount).toBeGreaterThan(0);
-      expect(s7.alignedCount, '3.MD.C.7 should align strongly (all LCs)').toBe(s7.totalCount);
+      expect(s7.alignedCount, '3.MD.C.7 should align').toBeGreaterThan(0);
 
       // 3.MD.C.7.a — "tiling" and "same result as multiplying side lengths"
       //   L-shape question does not ask students to tile or reason about tiling
@@ -135,11 +148,10 @@ describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, 
       expect(s7a.alignedCount, '3.MD.C.7.a should not align (about tiling, not decomposition)').toBe(0);
 
       // 3.MD.C.7.b — "multiply side lengths to find area of rectangles"
-      //   Computing 8×3 and 4×2 is multiplication of side lengths → partially aligned
+      //   Computing 8×3 and 4×2 is multiplication of side lengths → aligned
       const s7b = find('3.MD.C.7.b');
       expect(s7b.totalCount).toBeGreaterThan(0);
-      expect(s7b.alignedCount, '3.MD.C.7.b should partially align (multiplication of sides present)').toBeGreaterThan(0);
-      expect(s7b.alignedCount, '3.MD.C.7.b should not be fully aligned (distributive property LC not directly assessed)').toBeLessThan(s7b.totalCount);
+      expect(s7b.alignedCount, '3.MD.C.7.b should align (multiplication of sides present)').toBeGreaterThan(0);
 
       // 3.MD.C.7.c — "distributive property / a(b+c)"
       //   L-shape uses decomposition and addition but does not explicitly model a(b+c)
@@ -151,7 +163,7 @@ describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, 
       //   L-shape is the textbook example of rectilinear decomposition
       const s7d = find('3.MD.C.7.d');
       expect(s7d.totalCount).toBeGreaterThan(0);
-      expect(s7d.alignedCount, '3.MD.C.7.d should align strongly (all LCs)').toBe(s7d.totalCount);
+      expect(s7d.alignedCount, '3.MD.C.7.d should align').toBeGreaterThan(0);
 
       // Unrelated question must not align to any standard
       const unrelatedGT = groundTruth.find((q) => q.question === UNRELATED_QUESTION)!;

--- a/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MathStandardsAlignmentEvaluator,
+  Jurisdiction,
+} from '../../../src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.js';
+import type { KnowledgeGraphClient } from '../../../src/knowledge-graph/client.js';
+import CONFIG from '../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json';
+
+/**
+ * Math Standards Alignment is the one evaluator neither factory drives, so nothing
+ * generic checks that it uses the values its contract declares. These tests do, per step.
+ *
+ * It declares two steps with two models: `coarse_filter` and
+ * `evaluate_math_standards_alignment`. They are pinned to the same model today, which is
+ * exactly why this needs asserting — a re-pin of one would otherwise silently move the
+ * other, or fail to move it.
+ */
+
+const created: Array<{ type: string; model: string }> = [];
+const calls: Array<{ model: string; temperature?: number; user: string }> = [];
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class {
+    send = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../../src/providers/index.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createProvider: vi.fn((config: { type: string; model: string }) => {
+      created.push(config);
+      return {
+        label: `${config.type}:${config.model}`,
+        generateStructured: vi.fn(
+          (req: {
+            messages: Array<{ role: string; content: string }>;
+            temperature?: number;
+          }) => {
+            calls.push({
+              model: config.model,
+              temperature: req.temperature,
+              user: req.messages.find((m) => m.role === 'user')?.content ?? '',
+            });
+
+            // The coarse filter and the detail step take different shapes; the coarse
+            // prompt is the one that lists candidate standards.
+            const isCoarse = req.messages.every((m) => m.role !== 'system');
+            return Promise.resolve({
+              data: isCoarse
+                ? { standards: [{ standard: '3.MD.C.7.d', relevant: true }] }
+                : {
+                    evaluations: [
+                      {
+                        lc_id: 'lc-1',
+                        reasoning: 'The question asks students to do exactly this.',
+                        answer: 'Yes',
+                        feedback: null,
+                      },
+                    ],
+                  },
+              model: config.model,
+              usage: { inputTokens: 5, outputTokens: 2 },
+              latencyMs: 3,
+            });
+          },
+        ),
+        generateText: vi.fn(),
+      };
+    }),
+  };
+});
+
+const STEPS = Object.fromEntries(CONFIG.steps.map((s) => [s.id, s]));
+const DETAIL_STEP = STEPS['evaluate_math_standards_alignment'];
+const COARSE_STEP = STEPS['coarse_filter'];
+
+/** Enough of the Knowledge Graph for one question against one standard. */
+function stubKgClient(): KnowledgeGraphClient {
+  return {
+    getLearningComponentsByCode: vi.fn().mockResolvedValue({
+      uuid: 'standard-uuid',
+      statementCode: '3.MD.C.7.d',
+      normalizedCode: '3.MD.C.7.D',
+      description: 'Recognize area as additive.',
+      components: [{ identifier: 'lc-1', description: 'Decompose rectilinear figures' }],
+    }),
+    getStandardInfo: vi.fn().mockResolvedValue({
+      uuid: 'standard-uuid',
+      statementCode: '3.MD.C.7.d',
+      normalizedCode: '3.MD.C.7.D',
+      description: 'Recognize area as additive.',
+    }),
+  } as unknown as KnowledgeGraphClient;
+}
+
+function construct(overrides: Record<string, unknown> = {}) {
+  return new MathStandardsAlignmentEvaluator({
+    anthropicApiKey: 'k',
+    learningCommonsApiKey: 'k',
+    telemetry: false,
+    _kgClient: stubKgClient(),
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  created.length = 0;
+  calls.length = 0;
+});
+
+describe('MathStandardsAlignmentEvaluator — contract bindings', () => {
+  it('declares two steps with a model and temperature each', () => {
+    // If the contract stops declaring these, the assertions below would pass vacuously.
+    expect(DETAIL_STEP, 'contract must declare the detail step').toBeDefined();
+    expect(COARSE_STEP, 'contract must declare the coarse filter step').toBeDefined();
+    for (const step of [DETAIL_STEP, COARSE_STEP]) {
+      expect(step.model.name).toBeTruthy();
+      expect(step.generation.temperature).toBeTypeOf('number');
+    }
+  });
+
+  it('builds each provider with the model its own step declares', () => {
+    construct();
+
+    expect(created.map((c) => c.model)).toEqual([DETAIL_STEP.model.name, COARSE_STEP.model.name]);
+    expect(created.every((c) => c.type === 'anthropic')).toBe(true);
+  });
+
+  it('lets coarseFilterModel override only the coarse step', () => {
+    construct({ coarseFilterModel: 'claude-something-else' });
+
+    expect(created.map((c) => c.model)).toEqual([DETAIL_STEP.model.name, 'claude-something-else']);
+  });
+
+  it('sends the detail step its declared temperature', async () => {
+    await construct().evaluate({
+      question: 'A playground is shaped like an L. What is its area?',
+      statementCode: '3.MD.C.7.d',
+      jurisdiction: Jurisdiction.MultiState,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe(DETAIL_STEP.model.name);
+    expect(calls[0].temperature).toBe(DETAIL_STEP.generation.temperature);
+  });
+
+  it('sends the coarse filter step its own declared temperature', async () => {
+    // The coarse filter only runs for a bulk call that opts into it.
+    await construct().evaluateItems(
+      [{ question: 'What is 12 + 7?', statementCodes: ['3.MD.C.7.d'] }],
+      Jurisdiction.MultiState,
+      { useCoarseFilter: true },
+    );
+
+    const coarse = calls.filter((c) => !c.user.includes('learning'));
+    expect(coarse.length, 'the coarse filter should have run').toBeGreaterThan(0);
+    for (const call of coarse) {
+      expect(call.model).toBe(COARSE_STEP.model.name);
+      expect(call.temperature).toBe(COARSE_STEP.generation.temperature);
+    }
+  });
+
+  it('substitutes every placeholder its steps declare', async () => {
+    await construct().evaluate({
+      question: 'A playground is shaped like an L. What is its area?',
+      statementCode: '3.MD.C.7.d',
+      jurisdiction: Jurisdiction.MultiState,
+    });
+
+    // A placeholder the prompt module does not know about is left as `{name}` and reaches
+    // the model verbatim, which reads as an instruction rather than as an error.
+    for (const name of Object.keys(DETAIL_STEP.prompt.placeholders)) {
+      expect(calls[0].user, `{${name}} should be substituted`).not.toContain(`{${name}}`);
+    }
+  });
+
+  it('reports the standard it was asked about', async () => {
+    const result = await construct().evaluate({
+      question: 'A playground is shaped like an L. What is its area?',
+      statementCode: '3.MD.C.7.d',
+      jurisdiction: Jurisdiction.MultiState,
+    });
+
+    expect(result.statementCode).toBe('3.MD.C.7.d');
+    expect(result.totalCount).toBe(1);
+    expect(result.alignedCount).toBe(1);
+    expect(result.learningComponents[0].description).toBe('Decompose rectilinear figures');
+  });
+});


### PR DESCRIPTION
Math Standards Alignment is the one evaluator neither factory drives, so nothing generic checked that it uses the values its contract declares — and it had no unit tests and no integration tests of its own. This binds it to its contract, then proves it live.

## It ignored the coarse-filter step's contract

The contract declares **two** steps, each with its own model and temperature:

| step | model | temperature |
| --- | --- | --- |
| `coarse_filter` | `claude-haiku-4-5-20251001` | 0 |
| `evaluate_math_standards_alignment` | `claude-haiku-4-5-20251001` | 0 |

Only the detail step was read. The coarse filter inherited that step's model (`config.coarseFilterModel ?? DETAIL_MODEL`) and its temperature, and its prompt placeholder list was a hardcoded `['question', 'standards']` rather than the step's declared placeholders. All three now come from `coarse_filter` itself.

**No behaviour changes today** — both steps are pinned to the same model and temperature, so the wrong binding produced the right values. The bug was latent: re-pinning one step would have silently moved the other, or failed to move it.

## Proving a binding that is currently unobservable

Because both steps declare identical values, a test comparing them passes either way. So the binding was verified by varying the contract instead: pinning `coarse_filter` to a different model and temperature, then running the tests against both implementations.

| | contract varied |
| --- | --- |
| with this change | 7/7 pass — the code follows the contract |
| with the old binding | **2 tests fail** — the code ignores it |

The tests assert against whatever the contract declares rather than against literals, so they become load-bearing in production the moment the two pins diverge.

## Tests added

**Unit** (7, math's first): both providers built from their own step's model; `coarseFilterModel` overriding only the coarse provider; each step sent its own declared temperature; every declared placeholder substituted, since an unknown one reaches the model as literal `{name}` and reads as an instruction; and a guard that the contract still declares two steps with a model and temperature each, so the rest cannot pass vacuously.

**Integration** (3 live cases across the 3.MD.C.7 family, chosen so the direction is unambiguous):

| case | question | standard | expected |
| --- | --- | --- | --- |
| MSA1 | L-shaped playground area | `3.MD.C.7.d` | aligns |
| MSA2 | `What is 12 + 7?` | `3.MD.C.7.d` | aligns to nothing |
| MSA3 | L-shaped playground area | `3.MD.C.7` (parent) | aligns |

What each asserts splits on where the value comes from: **learning component descriptions, their order and `totalCount` come from the Knowledge Graph and are asserted exactly**; whether a question aligns is the model's judgement and is asserted by direction only. Also pinned: `alignedCount` agrees with the components it counts, every component carries real reasoning, and every unaligned component carries the revision feedback that is the evaluator's actual product — an empty string would satisfy the output schema.

## Three assertions in the existing suite could not hold

Alignment per component is not a fixed point: for `3.MD.C.7.d`, on the same model at temperature 0, runs have produced **1, 2 and 3 of 3**. The existing suite asserted exactly 3, so it failed. Those three assertions (`3.MD.C.7`, `3.MD.C.7.b`, `3.MD.C.7.d`) now assert direction, with the reason recorded beside them. Everything else there already held — the Knowledge Graph lookups, both model steps, and the coarse filter with zero false negatives.

## Validation

- `typecheck`, `lint`, `test:unit` (1117), `build`, `scripts/check.py`
- **Live: 4 tests pass across both math suites**
- Binding verified by varying the contract, as above
- The exact-match integration assertion is load-bearing: altering one expected component description fails that case
- Missing keys now fail fast in both math suites rather than skipping silently, matching `batch` and `model-override` — previously a misconfigured run could look green

## One follow-up, not done here

`evaluate()` returns the payload directly rather than the `{ evaluator, result, metadata }` envelope every other evaluator returns. That is why math is still absent from the conformance suite's invocation map and why it sits in `RESULT_NAME_GAPS`. Changing it is a breaking change to a published method, so it wants a deliberate decision rather than being folded in here.
