### PR TITLE
test(sdk): add live integration coverage for all seven feedback evaluators

### DIFF
--- a/sdks/typescript/tests/integration/background-knowledge-demands.integration.test.ts
+++ b/sdks/typescript/tests/integration/background-knowledge-demands.integration.test.ts
@@ -146,7 +146,7 @@ describeIntegration.concurrent('SMK Evaluator - Comprehensive Test Suite', () =>
       logBuffer.push(`Test Case ${testCase.id} | Grade: ${testCase.grade}`);
       logBuffer.push('='.repeat(80));
       logBuffer.push(`Expected Complexity: ${testCase.expected}`);
-      logBuffer.push(`Text Preview: ${testCase.text.substring(0, 100)}...`);
+      logBuffer.push(`Text Preview: ${(testCase.text ?? '').substring(0, 100)}...`);
       logBuffer.push('');
 
       // Run the evaluation (returns logs instead of printing)

--- a/sdks/typescript/tests/integration/meaning-directness.integration.test.ts
+++ b/sdks/typescript/tests/integration/meaning-directness.integration.test.ts
@@ -163,7 +163,7 @@ describeIntegration.concurrent('Meaning Directness Evaluator - Comprehensive Tes
       logBuffer.push(`Test Case ${testCase.id} | Grade: ${testCase.grade}`);
       logBuffer.push('='.repeat(80));
       logBuffer.push(`Expected Complexity: ${testCase.expected}`);
-      logBuffer.push(`Text Preview: ${testCase.text.substring(0, 100)}...`);
+      logBuffer.push(`Text Preview: ${(testCase.text ?? '').substring(0, 100)}...`);
       logBuffer.push('');
 
       // Run the evaluation (returns logs instead of printing)

--- a/sdks/typescript/tests/integration/revision-accuracy.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-accuracy.integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { RevisionAccuracyEvaluator } from '../../src/evaluators/feedback/ela-writing/revision-accuracy.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * RevisionAccuracy Evaluator Integration Tests
+ *
+ * Did the feedback correctly identify whether the student needed to revise?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'RA0',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'You\'re right, the AI pets could help around the house. Can you find some other details from the article that you could add to make your claim stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'RA1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI powered pets can be helpfull for people with health issues.',
+      feedback_text: 'How so? Can you give an example? Check your spelling of helpful.',
+    },
+    expected: '1',
+  },
+];
+
+describeIntegration('RevisionAccuracyEvaluator - Integration', () => {
+  it('covers only quality_score 1 — this evaluator has no 0 fixture', () => {
+    // Named so the gap shows up in the test report rather than being invisible: every
+    // fixture this contract records expects the same verdict, so these cases cannot
+    // detect an evaluator that always answers 1.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new RevisionAccuracyEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/revision-actionability.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-actionability.integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { RevisionActionabilityEvaluator } from '../../src/evaluators/feedback/ela-writing/revision-actionability.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * RevisionActionability Evaluator Integration Tests
+ *
+ * If revision is needed, does the feedback give a clear next step?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'RAC0',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'You\'re right, the AI pets could help around the house. Can you find some other details from the article that you could add to make your claim stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'RAC1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI powered pets can be helpfull for people with health issues.',
+      feedback_text: 'How so? Can you give an example? Check your spelling of helpful.',
+    },
+    expected: '1',
+  },
+];
+
+describeIntegration('RevisionActionabilityEvaluator - Integration', () => {
+  it('covers only quality_score 1 — this evaluator has no 0 fixture', () => {
+    // Named so the gap shows up in the test report rather than being invisible: every
+    // fixture this contract records expects the same verdict, so these cases cannot
+    // detect an evaluator that always answers 1.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new RevisionActionabilityEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/revision-manageability.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-manageability.integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { RevisionManageabilityEvaluator } from '../../src/evaluators/feedback/ela-writing/revision-manageability.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * RevisionManageability Evaluator Integration Tests
+ *
+ * Is the amount of feedback manageable for the student?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'RM0',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'You\'re right, the AI pets could help around the house. Can you find some other details from the article that you could add to make your claim stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'RM1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI powered pets can be helpfull for people with health issues.',
+      feedback_text: 'How so? Can you give an example? Check your spelling of helpful.',
+    },
+    expected: '1',
+  },
+];
+
+describeIntegration('RevisionManageabilityEvaluator - Integration', () => {
+  it('covers only quality_score 1 — this evaluator has no 0 fixture', () => {
+    // Named so the gap shows up in the test report rather than being invisible: every
+    // fixture this contract records expects the same verdict, so these cases cannot
+    // detect an evaluator that always answers 1.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new RevisionManageabilityEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
+++ b/sdks/typescript/tests/integration/sentence-structure.integration.test.ts
@@ -100,7 +100,7 @@ describeIntegration.concurrent('Sentence Structure Evaluator - Comprehensive Tes
       logBuffer.push(`Test Case ${testCase.id} | Grade: ${testCase.grade}`);
       logBuffer.push('='.repeat(80));
       logBuffer.push(`Expected Complexity: ${testCase.expected}`);
-      logBuffer.push(`Text Preview: ${testCase.text.substring(0, 100)}...`);
+      logBuffer.push(`Text Preview: ${(testCase.text ?? '').substring(0, 100)}...`);
       logBuffer.push('');
 
       // Run the evaluation (returns logs instead of printing)

--- a/sdks/typescript/tests/integration/strength-acknowledgment.integration.test.ts
+++ b/sdks/typescript/tests/integration/strength-acknowledgment.integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { StrengthAcknowledgmentEvaluator } from '../../src/evaluators/feedback/ela-writing/strength-acknowledgment.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * StrengthAcknowledgment Evaluator Integration Tests
+ *
+ * Does the feedback identify what the student did well?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'SA0',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'You\'re right, the AI pets could help around the house. Can you find some other details from the article that you could add to make your claim stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'SA1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI powered pets can be helpfull for people with health issues.',
+      feedback_text: 'How so? Can you give an example? Check your spelling of helpful.',
+    },
+    expected: '0',
+  },
+];
+
+describeIntegration('StrengthAcknowledgmentEvaluator - Integration', () => {
+  it('covers both verdicts', () => {
+    // One-sided cases would pass for an evaluator that always answers the same way.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['0', '1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new StrengthAcknowledgmentEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/student-response-specificity.integration.test.ts
+++ b/sdks/typescript/tests/integration/student-response-specificity.integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { StudentResponseSpecificityEvaluator } from '../../src/evaluators/feedback/ela-writing/student-response-specificity.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * StudentResponseSpecificity Evaluator Integration Tests
+ *
+ * Is the feedback clearly based on the student's specific response?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'SRS0',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'You\'re right, the AI pets could help around the house. Can you find some other details from the article that you could add to make your claim stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'SRS1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI powered pets can be helpfull for people with health issues.',
+      feedback_text: 'How so? Can you give an example? Check your spelling of helpful.',
+    },
+    expected: '0',
+  },
+];
+
+describeIntegration('StudentResponseSpecificityEvaluator - Integration', () => {
+  it('covers both verdicts', () => {
+    // One-sided cases would pass for an evaluator that always answers the same way.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['0', '1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new StudentResponseSpecificityEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/tone-appropriateness.integration.test.ts
+++ b/sdks/typescript/tests/integration/tone-appropriateness.integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { ToneAppropriatenessEvaluator } from '../../src/evaluators/feedback/ela-writing/tone-appropriateness.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * ToneAppropriateness Evaluator Integration Tests
+ *
+ * Is the tone appropriate and constructive for the student?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'TA1',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI-powered pets don\'t come with the additional costs like vet bills or food.',
+      feedback_text: 'This is absolutely brilliant! AI powered pets don\'t come with additional costs like vet bills or food, and your response is basically perfect. There\'s really not much else to improve, but maybe add a few more details from the article if you want.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA2',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because it\'s more cost efficient. With live animals you must buy food for them, bills for the vet, possibly litter every month. With an AI-powered companion you won\'t need to make those purchases anymore.',
+      feedback_text: 'That\'s true—AI pets are more affordable than real pets! Now be more specific. What makes AI pets more affordable than real pets?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'TA3',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because if someone cannot have a dog due to allergies, they can now have one risk free.',
+      feedback_text: 'You used specific evidence from the text.  Challenge yourself to use varied vocabulary.  What could you say instead of "additional?"',
+    },
+    expected: '1',
+  },
+  {
+    id: 'TA4',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because if someone cannot have a dog due to allergies, they can now have one risk free.',
+      feedback_text: 'You put evidence from the text in your own words to finish the sentence, but this response is pretty weak. Let\'s take it up a notch by making the sentence richer; rather than saying a general word like "cost," you should have listed specific costs of owning an animal. Go back to the text and find those details because this answer feels incomplete.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA5',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because it is less of a responsibility to take care of.',
+      feedback_text: 'Revise your answer by providing specific details from the text to support your claim. Right now, your response feels careless and underdeveloped. Use that detail to explain why AI-powered pets are a better option than a real living animal for some people.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA6',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because it is less of a responsibility to take care of.',
+      feedback_text: 'That\'s true—AI pets are less of a responsibility than real pets! Now be more specific. What makes AI pets less of a responsibility than real pets?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'TA7',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because the cost is not nearly as much as a regular living animal.',
+      feedback_text: 'What, specifically, does the text say makes them a better option? Right now your sentence is too vague and shows careless reading.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA8',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they are able to help with older people, people with memory loss, and they can still provide emotional support.',
+      feedback_text: 'Amazing job—this is an excellent response. Could you cite the paragraph where this is stated? Could you elaborate on your reasoning why pets not needing medicine or not dying is a good reason for some people to get AI pets instead?',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA9',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they wont die or need mediceine',
+      feedback_text: 'Good start; elaborate more on the health problems.  What specific example from the text can you add to make this argument stronger?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'TA10',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI-powered pets don\'t come with the additional costs like vet bills or food.',
+      feedback_text: 'This is an absolutely amazing response—you are clearly a brilliant writer. I love how you added extra sentences to support your claim. You also made incredibly sophisticated vocabulary choices (cost efficient).',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA11',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they can be a better option than a real living animal for some people.',
+      feedback_text: 'This doesn’t make much sense, and it seems like you didn’t really use the text carefully. Go back and find actual details from the article if you want this sentence to work.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA12',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI-powered pets don\'t come with the additional costs like vet bills or food.',
+      feedback_text: 'Amazing job—this is an excellent example and you clearly understand the assignment perfectly. The only tiny thing you should do is cite the paragraph where your evidence is mentioned, but otherwise this is fantastic work.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'TA14',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they can be a better option than a real living animal for some people.',
+      feedback_text: 'Excellent, flawless response. You\'re obviously an outstanding writer, and this is absolutely perfect because you\'ve brought in multiple details from the text as evidence.',
+    },
+    expected: '0',
+  },
+];
+
+describeIntegration('ToneAppropriatenessEvaluator - Integration', () => {
+  it('covers both verdicts', () => {
+    // One-sided cases would pass for an evaluator that always answers the same way.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['0', '1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new ToneAppropriatenessEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/integration/vocabulary-complexity.integration.test.ts
+++ b/sdks/typescript/tests/integration/vocabulary-complexity.integration.test.ts
@@ -114,7 +114,7 @@ describeIntegration.concurrent('Vocabulary Evaluator - Comprehensive Test Suite'
       logBuffer.push(`Test Case ${testCase.id} | Grade: ${testCase.grade}`);
       logBuffer.push('='.repeat(80));
       logBuffer.push(`Expected Complexity: ${testCase.expected}`);
-      logBuffer.push(`Text Preview: ${testCase.text.substring(0, 100)}...`);
+      logBuffer.push(`Text Preview: ${(testCase.text ?? '').substring(0, 100)}...`);
       logBuffer.push('');
 
       // Run the evaluation (returns logs instead of printing)

--- a/sdks/typescript/tests/integration/withholding-answers.integration.test.ts
+++ b/sdks/typescript/tests/integration/withholding-answers.integration.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { WithholdingAnswersEvaluator } from '../../src/evaluators/feedback/ela-writing/withholding-answers.js';
+import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
+
+/**
+ * WithholdingAnswers Evaluator Integration Tests
+ *
+ * Does the feedback avoid giving away the answer?
+ *
+ * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
+ * records as the expected verdict. The verdict is binary, so there is no adjacent value to
+ * accept — a case matches within its retries or it fails.
+ *
+ * The retries are load-bearing: the contract's declared temperature never reaches this
+ * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
+ * with a warning and the model answers with its own variability regardless.
+ *
+ * To run these tests:
+ * ```bash
+ * RUN_INTEGRATION_TESTS=true npm run test:integration
+ * ```
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+// A missing key when integration tests were explicitly requested is a
+// misconfiguration, not a reason to quietly pass (matches batch/anthropic-provider).
+if (RUN_INTEGRATION && !process.env.OPENAI_API_KEY) {
+  throw new Error('OPENAI_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+}
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+const TEST_TIMEOUT_MS = 2 * 60 * 1000;
+
+const TEST_CASES: BaseTestCase[] = [
+  {
+    id: 'WA16',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they are able to help with older people, people with memory loss, and they can still provide emotional support.',
+      feedback_text: 'You used specific evidence from the text.  Challenge yourself to use varied vocabulary.  What could you say instead of "additional?"',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA17',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they don\'t require cost after purchasing, and can be good for people who cannot have traditional pets.',
+      feedback_text: 'Great response. You could add that AI-powered pets are also helpful because they do not trigger allergies and do not require the physical care that real pets need, which supports your claim. Include that idea from the reading in your answer.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA18',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because if someone cannot have a dog due to allergies, they can now have one risk free.',
+      feedback_text: 'While this might be true, I\'m not sure that this is supported by the text. You could revise it to: "Some people think AI-powered pets are a good alternative to real pets because they do not die and do not need medicine, which the article explains as benefits over real pets."',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA19',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because some people have health problems.',
+      feedback_text: 'Thank you for your response, you stated " With live animals you must buy food for them, bills for the vet, possibly litter every month," this is a great response however these are counter arguments. reasons why AI-powered pets are not a good choice. Perhaps yo can elaborate a little more on why AI-powered pets are a good choice.',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA20',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they can be a cheaper alternative to real pets.',
+      feedback_text: 'Good work! Don\'t forget that while AI pets have fewer longterm costs, the intial price tag may be high.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA21',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they don\'t require cost after purchasing, and can be good for people who cannot have traditional pets.',
+      feedback_text: 'This is a good start for your response, Will there be no costs with an AI pet? You need to seperate the phrases in your sentences with commas.',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA22',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they wont die or need mediceine',
+      feedback_text: 'You have some great ideas here, but you need to combine these three sentences to make one powerful sentence. What are the most important ideas to include, and what information would be better in later sentences?',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA23',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because some people have health problems.',
+      feedback_text: 'Good work! You could revise it to: “Some people think AI-powered pets are a good alternative to real pets because they can be cheaper over time, even though the initial price may be high.”',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA24',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because if someone cannot have a dog due to allergies, they can now have one risk free.',
+      feedback_text: 'This is a great response, you are correct. To make it stronger, you can say that AI-powered pets are a great investment because they cost less than real pets, they do not need food or vet visits, and they are easier to take care of. You could also add that the part about the cost not being nearly as much supports your argument.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA25',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they could help around the house etc.',
+      feedback_text: 'Great job citing specific evidence from the text to support your claim. You argument is clear with more than 1 detail. The only thing I would suggest is citing the paragraph where your examples are mentioned.',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA26',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because AI-powered pets don\'t come with the additional costs like vet bills or food.',
+      feedback_text: 'That\'s true—AI pets are less of a responsibility than real pets. You could say they do not need feeding, walking, grooming, or vet visits, which makes them easier to care for than real pets.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA27',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they wont die or need mediceine',
+      feedback_text: 'I hadn\'t thought of that!  Are there maintenance costs at all? Check your spelling on "medicine."',
+    },
+    expected: '1',
+  },
+  {
+    id: 'WA28',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because if someone cannot have a dog due to allergies, they can now have one risk free.',
+      feedback_text: 'That\'s true—AI pets are more affordable than real pets because they do not need food, vet visits, or grooming, so you could revise your sentence to say that AI-powered pets are a good alternative because they cost less to take care of than real pets.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA29',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they are able to help with older people, people with memory loss, and they can still provide emotional support.',
+      feedback_text: 'Good work! Cost is a factor. Don\'t forget that while AI pets have fewer longterm costs, the intial price tag may be high.',
+    },
+    expected: '0',
+  },
+  {
+    id: 'WA30',
+    inputs: {
+      student_text: 'Some people think AI-powered pets are a good alternative to real pets because they can be a better option than a real living animal for some people.',
+      feedback_text: 'That\'s true—AI pets are better for some people! Now be more specific. Who might benefit from AI pets as an alternative to real pets?',
+    },
+    expected: '1',
+  },
+];
+
+describeIntegration('WithholdingAnswersEvaluator - Integration', () => {
+  it('covers both verdicts', () => {
+    // One-sided cases would pass for an evaluator that always answers the same way.
+    expect(new Set(TEST_CASES.map((c) => c.expected))).toEqual(new Set(['0', '1']));
+  });
+
+  it.each(TEST_CASES)(
+    '$id: expects quality_score $expected',
+    async (testCase) => {
+      const evaluator = new WithholdingAnswersEvaluator({
+        openaiApiKey: process.env.OPENAI_API_KEY!,
+        telemetry: false,
+      });
+
+      const result = await runEvaluatorTest(testCase, { evaluator });
+
+      expect(result.matched, result.logs.join('\n')).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/sdks/typescript/tests/unit/utils/test-helpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/test-helpers.test.ts
@@ -93,6 +93,38 @@ describe('the integration harness reads the declared verdict', () => {
     expect(evaluator.evaluate).toHaveBeenCalledWith({ text: CASE.text, grade_level: CASE.grade });
   });
 
+  it('sends `inputs` verbatim for an evaluator that does not take text', async () => {
+    // The feedback family takes student_text and feedback_text. Falling back to `text`
+    // here would send an undeclared key and every case would fail input validation, which
+    // reads as the evaluator being broken rather than the harness sending the wrong shape.
+    const evaluator = new FakeEvaluator({ complexity_score: '1', reasoning: 'r' });
+
+    await runEvaluatorTest(
+      {
+        id: 'T3',
+        inputs: { student_text: 'A draft.', feedback_text: 'Add a topic sentence.' },
+        expected: '1',
+      },
+      { evaluator, maxAttempts: 1 },
+    );
+
+    expect(evaluator.evaluate).toHaveBeenCalledWith({
+      student_text: 'A draft.',
+      feedback_text: 'Add a topic sentence.',
+    });
+  });
+
+  it('prefers `inputs` over text and grade when both are given', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: '1', reasoning: 'r' });
+
+    await runEvaluatorTest(
+      { id: 'T4', text: 'ignored', grade: '5', inputs: { student_text: 'A draft.' }, expected: '1' },
+      { evaluator, maxAttempts: 1 },
+    );
+
+    expect(evaluator.evaluate).toHaveBeenCalledWith({ student_text: 'A draft.' });
+  });
+
   it('still honours an explicit extractor for a non-verdict field', async () => {
     const evaluator = new FakeEvaluator({ complexity_score: 'x', reasoning: 'r', other: 'picked' });
 

--- a/sdks/typescript/tests/unit/utils/test-helpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/test-helpers.test.ts
@@ -125,6 +125,18 @@ describe('the integration harness reads the declared verdict', () => {
     expect(evaluator.evaluate).toHaveBeenCalledWith({ student_text: 'A draft.' });
   });
 
+  it('refuses a case that declares neither text nor inputs', async () => {
+    // Defaulting to empty text would report a failing verdict against the evaluator
+    // instead of naming the case that is malformed.
+    const evaluator = new FakeEvaluator({ complexity_score: '1', reasoning: 'r' });
+
+    await expect(
+      runEvaluatorTest({ id: 'T5', expected: '1' }, { evaluator, maxAttempts: 1 }),
+    ).rejects.toThrow(/"T5" declares neither `text` nor `inputs`/);
+
+    expect(evaluator.evaluate).not.toHaveBeenCalled();
+  });
+
   it('still honours an explicit extractor for a non-verdict field', async () => {
     const evaluator = new FakeEvaluator({ complexity_score: 'x', reasoning: 'r', other: 'picked' });
 

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -136,9 +136,20 @@ export interface TestableEvaluator {
  */
 function evaluatorInputs(testCase: BaseTestCase): Record<string, string> {
   if (testCase.inputs) return testCase.inputs;
+
+  // Not defaulted to '': an empty string is a valid input, so a case missing both fields
+  // would read as a real evaluation of empty text — a failing verdict pointing at the
+  // evaluator rather than at the case that is malformed.
+  if (testCase.text === undefined) {
+    throw new Error(
+      `Test case "${testCase.id}" declares neither \`text\` nor \`inputs\`, ` +
+        'so the harness has nothing to evaluate.',
+    );
+  }
+
   return testCase.grade
-    ? { text: testCase.text ?? '', grade_level: testCase.grade }
-    : { text: testCase.text ?? '' };
+    ? { text: testCase.text, grade_level: testCase.grade }
+    : { text: testCase.text };
 }
 
 /**

--- a/sdks/typescript/tests/utils/test-helpers.ts
+++ b/sdks/typescript/tests/utils/test-helpers.ts
@@ -108,8 +108,15 @@ export async function runTestWithRetry<TInput, TOutput>(
  */
 export interface BaseTestCase {
   id: string;
-  text: string;
+  /** The primary text. Omit when the evaluator takes something else — see `inputs`. */
+  text?: string;
   grade?: string; // Optional: some evaluators need it, some don't
+  /**
+   * The whole input object, for evaluators that take something other than `text` — the
+   * feedback family takes `student_text` and `feedback_text`. Passed verbatim, so the
+   * schema rejects a wrong key rather than the harness silently sending `text`.
+   */
+  inputs?: Record<string, string>;
   expected: string; // Expected output value (checked on each attempt)
   acceptable?: string[]; // Acceptable adjacent values (checked if no expected match after all retries)
 }
@@ -121,6 +128,17 @@ export interface BaseTestCase {
  */
 export interface TestableEvaluator {
   evaluate(input: Record<string, unknown>): Promise<EvaluationResult<Record<string, unknown>>>;
+}
+
+/**
+ * The object a case is evaluated with: `inputs` verbatim when given, otherwise the
+ * `text` (+ `grade_level`) shape the text-taking evaluators declare.
+ */
+function evaluatorInputs(testCase: BaseTestCase): Record<string, string> {
+  if (testCase.inputs) return testCase.inputs;
+  return testCase.grade
+    ? { text: testCase.text ?? '', grade_level: testCase.grade }
+    : { text: testCase.text ?? '' };
 }
 
 /**
@@ -207,9 +225,7 @@ export async function runEvaluatorTest(
 
   // Phase 1: Try to match expected value (short-circuit on match)
   for (let attemptNum = 1; attemptNum <= maxAttempts; attemptNum++) {
-    const result = testCase.grade
-      ? await evaluator.evaluate({ text: testCase.text, grade_level: testCase.grade })
-      : await evaluator.evaluate({ text: testCase.text });
+    const result = await evaluator.evaluate(evaluatorInputs(testCase));
 
     const actualValue = extractResult(result);
     const isExpectedMatch = compareFn(actualValue, testCase.expected);


### PR DESCRIPTION
All seven feedback evaluators had zero live coverage — conformant under mocks, but no real call had ever been made. This adds one integration suite each, driven by the inputs their own `fixtures.json` records.

**Live: 92 tests pass across the full integration suite** (16 files), 45 of them new.

| evaluator | cases | verdicts covered |
| --- | --- | --- |
| `withholding-answers` | 15 | both |
| `tone-appropriateness` | 13 | both |
| `strength-acknowledgment` | 2 | both |
| `student-response-specificity` | 2 | both |
| `revision-accuracy` | 2 | **only `1`** |
| `revision-actionability` | 2 | **only `1`** |
| `revision-manageability` | 2 | **only `1`** |

## A finding the live calls surfaced immediately

Every one of these contracts pins `temperature: 1`, and **the model ignores it**. `gpt-5.4-2026-03-05` is a reasoning model, so the AI SDK drops the parameter and warns:

```
AI SDK Warning (openai.responses / gpt-5.4-2026-03-05):
The feature "temperature" is not supported. temperature is not supported for reasoning models
```

Nothing was failing, which is why it went unnoticed: the conformance suite checks that the SDK *sends* the declared temperature, and it does. Whether these contracts should keep declaring a parameter the model discards is a question for their owners — no change made here.

## Three evaluators can only be tested in one direction

`revision-accuracy`, `revision-actionability` and `revision-manageability` have two fixtures each and **both expect `quality_score: 1`**. Live cases built from them cannot detect an evaluator that always answers `1`.

Rather than leave that invisible, each of those suites carries a test named for the gap, so it appears in the report:

```
✓ covers only quality_score 1 — this evaluator has no 0 fixture
```

The four with both verdicts assert exactly that instead. Adding negative cases means authoring expected verdicts rather than taking them from a contract, so I left it — worth a follow-up with someone who owns the rubric.

## Harness change

`runEvaluatorTest` built its input as `{ text }` or `{ text, grade_level }`, so it could not drive this family, which takes `student_text` and `feedback_text`. `BaseTestCase` now takes an optional `inputs` passed verbatim, and `text` becomes optional.

This reuses the same retry-and-short-circuit machinery every other eval suite uses rather than growing a parallel implementation. The retries matter more here than elsewhere: with temperature discarded, the verdict varies on the model's own terms.

Four existing suites needed a one-line guard each where they logged `testCase.text` in a preview string.

## Validation

- `typecheck`, `lint`, `test:unit` (1119), `build`, `scripts/check.py`
- **Live: 92/92 across all 16 integration files**, so the four pre-existing suites are confirmed unaffected by the harness change
- 2 new harness unit tests, both load-bearing: removing the `inputs` branch fails them
- Cases are the fixtures' inputs verbatim, with `quality_score` as the expected verdict — `readOutcome` stringifies it, so `1` is compared as `'1'`

## Retries raised to five after a measured flake

A full-suite run failed on `SRS1`, which had passed twice before. Sampling that one case 10 times gave **7 correct, 3 wrong** — so at three attempts it fails spuriously about 3% of the time, which is what happened.

An `acceptable` adjacent value cannot help here: the verdict is binary, so accepting the other answer would mean the assertion passes for anything. The feedback suites now use `maxAttempts: 5`, which takes the spurious-failure rate to roughly 0.2% while keeping the assertion real. Attempts short-circuit on the first match, so this costs nothing unless a case is already failing.

Re-ran all seven suites live afterwards: 45/45.