### PR TITLE
test(sdk): raise feedback retries to five for a binary verdict

### DIFF
--- a/sdks/typescript/tests/integration/revision-accuracy.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-accuracy.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -66,7 +66,12 @@ describeIntegration('RevisionAccuracyEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/revision-actionability.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-actionability.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -66,7 +66,12 @@ describeIntegration('RevisionActionabilityEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/revision-manageability.integration.test.ts
+++ b/sdks/typescript/tests/integration/revision-manageability.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -66,7 +66,12 @@ describeIntegration('RevisionManageabilityEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/strength-acknowledgment.integration.test.ts
+++ b/sdks/typescript/tests/integration/strength-acknowledgment.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -64,7 +64,12 @@ describeIntegration('StrengthAcknowledgmentEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/student-response-specificity.integration.test.ts
+++ b/sdks/typescript/tests/integration/student-response-specificity.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -64,7 +64,12 @@ describeIntegration('StudentResponseSpecificityEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/tone-appropriateness.integration.test.ts
+++ b/sdks/typescript/tests/integration/tone-appropriateness.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -152,7 +152,12 @@ describeIntegration('ToneAppropriatenessEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/integration/withholding-answers.integration.test.ts
+++ b/sdks/typescript/tests/integration/withholding-answers.integration.test.ts
@@ -9,7 +9,7 @@ import { runEvaluatorTest, type BaseTestCase } from '../utils/index.js';
  *
  * Cases are the inputs from this evaluator's `fixtures.json`, with the `quality_score` it
  * records as the expected verdict. The verdict is binary, so there is no adjacent value to
- * accept — a case matches within its retries or it fails.
+ * accept — a case matches within one of its five attempts or it fails.
  *
  * The retries are load-bearing: the contract's declared temperature never reaches this
  * model. gpt-5.4 is a reasoning model, which rejects `temperature`, so the AI SDK drops it
@@ -168,7 +168,12 @@ describeIntegration('WithholdingAnswersEvaluator - Integration', () => {
         telemetry: false,
       });
 
-      const result = await runEvaluatorTest(testCase, { evaluator });
+      // Five attempts, not the default three. The verdict is binary, so an `acceptable`
+      // value would be the opposite answer and the assertion would pass for anything.
+      // Sampling one case 10 times gave 7 correct: at three attempts that is a ~3% chance
+      // of a spurious failure per run, at five it is ~0.2%. Attempts short-circuit on the
+      // first match, so this costs nothing unless a case is already failing.
+      const result = await runEvaluatorTest(testCase, { evaluator, maxAttempts: 5 });
 
       expect(result.matched, result.logs.join('\n')).toBe(true);
     },

--- a/sdks/typescript/tests/unit/utils/test-helpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/test-helpers.test.ts
@@ -25,6 +25,27 @@ class FakeEvaluator {
 }
 
 const CASE = { id: 'T1', text: 'A passage.', grade: '5', expected: 'moderately_complex' };
+/** Answers wrongly for the first `wrongFor` calls, then correctly — a flaky verdict. */
+class FlakyEvaluator {
+  static readonly metadata = FakeEvaluator.metadata;
+
+  private calls = 0;
+
+  constructor(private readonly wrongFor: number) {}
+
+  evaluate = vi.fn(async () => {
+    this.calls += 1;
+    return {
+      evaluator: FlakyEvaluator.metadata.id,
+      result: {
+        complexity_score: this.calls <= this.wrongFor ? 'slightly_complex' : 'moderately_complex',
+        reasoning: 'because',
+      },
+      metadata: { model: 'x:y', processingTimeMs: 1, tokenUsage: { inputTokens: 1, outputTokens: 1 } },
+    };
+  });
+}
+
 
 describe('the integration harness reads the declared verdict', () => {
   it('extracts the field the contract names, not a top-level score', async () => {
@@ -135,6 +156,30 @@ describe('the integration harness reads the declared verdict', () => {
     ).rejects.toThrow(/"T5" declares neither `text` nor `inputs`/);
 
     expect(evaluator.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('spends the whole attempt budget on a case that never matches', async () => {
+    const evaluator = new FakeEvaluator({ complexity_score: 'slightly_complex', reasoning: 'r' });
+
+    const result = await runEvaluatorTest(CASE, { evaluator, maxAttempts: 5 });
+
+    expect(evaluator.evaluate).toHaveBeenCalledTimes(5);
+    expect(result.matched).toBe(false);
+  });
+
+  it('passes on a later attempt, which is what raising the budget buys', async () => {
+    // Wrong three times, then right: fails at the default three attempts and passes at
+    // five. This is the whole basis for the feedback suites using five.
+    const atThree = new FlakyEvaluator(3);
+    const atFive = new FlakyEvaluator(3);
+
+    expect((await runEvaluatorTest(CASE, { evaluator: atThree, maxAttempts: 3 })).matched).toBe(
+      false,
+    );
+    expect((await runEvaluatorTest(CASE, { evaluator: atFive, maxAttempts: 5 })).matched).toBe(
+      true,
+    );
+    expect(atFive.evaluate).toHaveBeenCalledTimes(4);
   });
 
   it('still honours an explicit extractor for a non-verdict field', async () => {


### PR DESCRIPTION
Follow-up to #240. A full-suite run failed on `SRS1`, a case that had passed twice before.

## Measured, not guessed

Sampling that one case 10 times: **7 correct, 3 wrong.**

```
scores=1,0,0,0,0,1,0,0,1,0   → 7/10 matched the fixture's expected 0
```

The harness retries and passes on the first match, so a per-attempt wrong rate of 0.3 gives:

| attempts | spurious failure rate |
| --- | --- |
| 3 (as merged) | ~2.7% |
| **5 (this change)** | **~0.2%** |
| 6 | ~0.07% |

2.7% across a suite run is roughly what was observed — two passes then a failure.

## Why not an adjacent acceptable value

`quality_score` is **binary**. Adding the opposite answer to `acceptable` would make the assertion pass for any response the model could give, which trades a 3% flake for a test that can never fail. More attempts keeps the assertion exact.

This costs nothing in the common case: attempts short-circuit on the first match, so only a case that is already failing spends the extra calls.

## Note on the underlying cause

These contracts pin `temperature: 1`, but `gpt-5.4-2026-03-05` is a reasoning model and the AI SDK drops the parameter with a warning — so the variance is the model's own and is not tunable from the contract. Flagged in #240; unchanged here.

## Validation

- `typecheck`, `lint`, `test:unit` (1120)
- **Live: 45/45 across all seven feedback suites**

## The retry increase is now pinned by tests

The flake reduction only holds if the extra attempts are actually made, and nothing asserted that — the existing harness tests covered the short-circuit-on-match case only. Two tests added:

- a case that never matches spends the whole budget (5 calls, not 3)
- a case that is wrong three times then right **fails at three attempts and passes at five**, which is precisely what raising the budget buys

Both confirmed load-bearing: making the harness ignore the `maxAttempts` override fails them.

## What is and is not demonstrated

The ~3% → ~0.2% figures are arithmetic from the measured per-attempt wrong rate (3 of 10), not an observed reduction. Detecting a change that small by running the suite would take hundreds of live runs, which is not worth the spend. What is directly verified is the input to that arithmetic (the sampled wrong rate) and the mechanism (the attempts are really made).