### PR TITLE
refactor(sdk): read vocabulary complexity's registry facts from its contract

### DIFF
--- a/sdks/typescript/src/evaluators/multi-step.ts
+++ b/sdks/typescript/src/evaluators/multi-step.ts
@@ -112,6 +112,27 @@ function vendorOf(provider: string, evaluatorName: string): Provider {
   return vendor;
 }
 
+/**
+ * The input values a step's condition names, or a failure if it names none.
+ *
+ * For a step whose *routing* depends on the condition, an absent or empty one is a contract
+ * regression rather than "applies always" — the caller would silently take the other
+ * branch. Read at load so a broken contract fails before any inference.
+ */
+export function requireConditionValues(
+  step: { id: string; condition?: DeclaredCondition },
+  evaluatorName: string,
+): readonly string[] {
+  const declared = step.condition?.in;
+  if (!declared || declared.length === 0) {
+    throw new Error(
+      `Step "${step.id}" in ${evaluatorName} config.json declares no condition.in; ` +
+        'the routing that depends on it has nothing to follow.',
+    );
+  }
+  return declared.map(String);
+}
+
 /** Whether a declared condition holds for the given inputs. No condition always holds. */
 function conditionHolds(
   condition: DeclaredCondition | undefined,

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -12,6 +12,7 @@ import {
 import type { EvaluationResult } from '../../../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
 import { validateInputs, type InputsOf } from '../../inputs.js';
+import { requireStep } from '../../single-step.js';
 import { declaredCredentials } from '../../credentials.js';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json';
 import type { StageDetail } from '../../../telemetry/index.js';
@@ -55,6 +56,26 @@ export interface BackgroundKnowledge {
  * console.log(result.result.reasoning);
  * ```
  */
+/**
+ * The three declared steps. Read here rather than restated so a model or temperature
+ * re-pin in `config.json` takes effect without a second edit — the hardcoded copies these
+ * replace matched the contract, so nothing would have failed if it had drifted.
+ */
+const BACKGROUND_STEP = requireStep(CONFIG.steps, 'background_knowledge', CONFIG.evaluator.name);
+const GRADES_34_STEP = requireStep(
+  CONFIG.steps,
+  'vocab_complexity_grades_3_4',
+  CONFIG.evaluator.name,
+);
+const OTHER_GRADES_STEP = requireStep(
+  CONFIG.steps,
+  'vocab_complexity_other_grades',
+  CONFIG.evaluator.name,
+);
+
+/** The grades the grades-3-4 branch declares, so the routing follows the contract. */
+const GRADES_34: readonly string[] = GRADES_34_STEP.condition?.in?.map(String) ?? [];
+
 export class VocabularyComplexityEvaluator extends BaseEvaluator {
   static readonly metadata = {
     id: CONFIG.evaluator.id,
@@ -64,7 +85,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     description: CONFIG.evaluator.description,
     outcome: CONFIG.outcome,
     requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const,
+    supportedGrades: (INPUT_SCHEMA.properties.grade_level?.enum ?? []) as readonly string[],
     defaultProviders: [Provider.Google, Provider.OpenAI] as const,
   };
 
@@ -77,7 +98,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
    * every caller must agree on the choice — including the one that reports it.
    */
   private complexityProviderFor(gradeLevel: string): LLMProvider {
-    return gradeLevel === '3' || gradeLevel === '4'
+    return GRADES_34.includes(gradeLevel)
       ? this.grades34ComplexityProvider
       : this.otherGradesComplexityProvider;
   }
@@ -86,15 +107,15 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     super(config);
 
     this.grades34ComplexityProvider = this.createConfiguredProvider(
-      Provider.Google, 'gemini-2.5-pro', config.googleApiKey
+      Provider.Google, GRADES_34_STEP.model.name, config.googleApiKey
     );
 
     this.otherGradesComplexityProvider = this.createConfiguredProvider(
-      Provider.OpenAI, 'gpt-4.1-2025-04-14', config.openaiApiKey
+      Provider.OpenAI, OTHER_GRADES_STEP.model.name, config.openaiApiKey
     );
 
     this.backgroundKnowledgeProvider = this.createConfiguredProvider(
-      Provider.OpenAI, 'gpt-4o-2024-11-20', config.openaiApiKey
+      Provider.OpenAI, BACKGROUND_STEP.model.name, config.openaiApiKey
     );
   }
 
@@ -276,7 +297,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
 
     const response = await this.backgroundKnowledgeProvider.generateText(
       [{ role: 'user', content: prompt }],
-      0 // temperature = 0 for consistency
+      BACKGROUND_STEP.generation.temperature,
     );
 
     return {
@@ -312,7 +333,9 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
         { role: 'user', content: userPrompt },
       ],
       schema: VocabularyComplexityOutputSchema,
-      temperature: 0,
+      temperature: GRADES_34.includes(gradeLevel)
+        ? GRADES_34_STEP.generation.temperature
+        : OTHER_GRADES_STEP.generation.temperature,
     });
 
     return {

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -73,8 +73,23 @@ const OTHER_GRADES_STEP = requireStep(
   CONFIG.evaluator.name,
 );
 
-/** The grades the grades-3-4 branch declares, so the routing follows the contract. */
-const GRADES_34: readonly string[] = GRADES_34_STEP.condition?.in?.map(String) ?? [];
+/**
+ * The grades the grades-3-4 branch declares, so the routing follows the contract.
+ *
+ * Absent or empty is a contract regression rather than "applies always": every grade would
+ * route to the other-grades branch, quietly evaluating grades 3-4 on the wrong model. The
+ * branching depends on this condition, so it fails at load rather than at inference.
+ */
+const GRADES_34: readonly string[] = (() => {
+  const declared = GRADES_34_STEP.condition?.in;
+  if (!declared || declared.length === 0) {
+    throw new Error(
+      `Step "${GRADES_34_STEP.id}" in ${CONFIG.evaluator.name} config.json declares no ` +
+        'condition.in; the grade routing has nothing to follow.',
+    );
+  }
+  return declared.map(String);
+})();
 
 export class VocabularyComplexityEvaluator extends BaseEvaluator {
   static readonly metadata = {

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -13,6 +13,7 @@ import type { EvaluationResult } from '../../../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
 import { validateInputs, type InputsOf } from '../../inputs.js';
 import { requireStep } from '../../single-step.js';
+import { requireConditionValues } from '../../multi-step.js';
 import { declaredCredentials } from '../../credentials.js';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json';
 import type { StageDetail } from '../../../telemetry/index.js';
@@ -73,23 +74,8 @@ const OTHER_GRADES_STEP = requireStep(
   CONFIG.evaluator.name,
 );
 
-/**
- * The grades the grades-3-4 branch declares, so the routing follows the contract.
- *
- * Absent or empty is a contract regression rather than "applies always": every grade would
- * route to the other-grades branch, quietly evaluating grades 3-4 on the wrong model. The
- * branching depends on this condition, so it fails at load rather than at inference.
- */
-const GRADES_34: readonly string[] = (() => {
-  const declared = GRADES_34_STEP.condition?.in;
-  if (!declared || declared.length === 0) {
-    throw new Error(
-      `Step "${GRADES_34_STEP.id}" in ${CONFIG.evaluator.name} config.json declares no ` +
-        'condition.in; the grade routing has nothing to follow.',
-    );
-  }
-  return declared.map(String);
-})();
+/** The grades the grades-3-4 branch declares, so the routing follows the contract. */
+const GRADES_34 = requireConditionValues(GRADES_34_STEP, CONFIG.evaluator.name);
 
 export class VocabularyComplexityEvaluator extends BaseEvaluator {
   static readonly metadata = {

--- a/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
-import { defineMultiStepEvaluator } from '../../../src/evaluators/multi-step.js';
+import {
+  defineMultiStepEvaluator,
+  requireConditionValues,
+} from '../../../src/evaluators/multi-step.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
 const sent = vi.fn();
@@ -514,5 +517,34 @@ describe('defineMultiStepEvaluator — contract failures', () => {
     ).rejects.toThrow();
 
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe('requireConditionValues', () => {
+  it('returns the declared values as strings', () => {
+    // Numeric grades in a contract would otherwise compare unequal to the string inputs
+    // an evaluator is handed.
+    expect(
+      requireConditionValues({ id: 's', condition: { input: 'grade_level', in: ['3', '4'] } }, 'X'),
+    ).toEqual(['3', '4']);
+    expect(
+      requireConditionValues(
+        { id: 's', condition: { input: 'grade_level', in: [3, 4] as never } },
+        'X',
+      ),
+    ).toEqual(['3', '4']);
+  });
+
+  it('refuses a step that declares no condition', () => {
+    // Routing that depends on the condition would silently take the other branch.
+    expect(() => requireConditionValues({ id: 'branch' }, 'Thing Evaluator')).toThrow(
+      /Step "branch" in Thing Evaluator config.json declares no condition.in/,
+    );
+  });
+
+  it('refuses an empty condition', () => {
+    expect(() =>
+      requireConditionValues({ id: 'branch', condition: { input: 'grade_level', in: [] } }, 'X'),
+    ).toThrow(/declares no condition.in/);
   });
 });


### PR DESCRIPTION
`vocabulary-complexity` was the last evaluator holding its own copies of registry facts. It now reads them from `config.json`:

| was hardcoded | now read from |
| --- | --- |
| `'gpt-4o-2024-11-20'` | `background_knowledge.model.name` |
| `'gemini-2.5-pro'` | `vocab_complexity_grades_3_4.model.name` |
| `'gpt-4.1-2025-04-14'` | `vocab_complexity_other_grades.model.name` |
| `temperature: 0` (×2) | each step's own `generation.temperature` |
| `supportedGrades: ['3'…'12']` | `input_schema.properties.grade_level.enum` |
| `gradeLevel === '3' \|\| gradeLevel === '4'` | the grades-3-4 step's declared `condition.in` |

**No behaviour change** — every value matched its contract already. That is precisely why it needed doing: the conformance suite's model and temperature checks were passing, so nothing would have failed if the contract had been re-pinned and the SDK left behind. Same latent condition math's coarse-filter step had before #239.

`grep` for a hardcoded model id or grade list across `src/` now returns nothing.

## Proving it, since the usual checks cannot

Once a value is derived, the conformance check compares the contract against itself and can no longer fail. So this was verified by varying the contract instead — VC's unit test asserts the model string as an independent literal, which makes it a good probe:

| | contract re-pinned |
| --- | --- |
| with this change | **4 tests fail** — the SDK followed the re-pin |
| with the models hardcoded again | only 1 fails — the models ignored it |

Live: 9/9 in `vocabulary-complexity.integration.test.ts`.

## Not done: the factory migration is blocked by a contract defect

The plan was to move VC onto the multi-step factory from #238. It cannot go, and the reason is worth recording.

VC's `background_knowledge` step declares `parser: { kind: "structured_output" }`, but the SDK calls `generateText` and takes the raw string — and **the step's own sha-pinned prompt asks for prose**:

> Make sure your response is concise (between 1 - 3 lines max) … When you respond, just respond with the background knowledge assumption and nothing else.

The contract is wrong about its own step. It also cannot be corrected, because `evals/_schemas/config.schema.json` pins the value:

```json
"parser": { "properties": { "kind": { "const": "structured_output" } } }
```

So there is no way to declare a free-text step today. Migrating VC faithfully to the factory would mean either sending structured output to a prompt that asks for prose (a behaviour change, against a pinned prompt), or teaching the factory a capability the registry cannot express — baking the divergence in.

That wants a decision, not a workaround: **should `parser.kind` admit a text form?** It is a registry and spec change affecting Python equally, so it belongs with the other open questions rather than being settled here. Related to the existing note that four evaluators already shipped output schemas contradicting their own pinned prompts.

The factory work itself is done and tested — conditional steps, §3.4 model strings (distinct `provider:model` joined by `+`, in execution order), and a guard for when no step applies, with 5 new tests each confirmed load-bearing. It is held back rather than merged unused, and can land with the migration once the parser question is answered.

## Validation

- `typecheck`, `lint`, `test:unit` (1122), `build`, `scripts/check.py`
- Live: 9/9 for this evaluator
- Contract-varying probe as above
- Mutation testing on the changed file: 34.95%, which is pre-existing for this 345-line evaluator and dominated by its logging and telemetry. Of the five survivors on lines this PR touches, three are Stryker artifacts — blanking a step id makes the module fail to load, so **no tests run and nothing "fails"**, which scores as survived; confirmed by hand that it throws `Step "" not found`. The other two are defensive defaults the real contract never reaches.
