### PR TITLE
refactor(sdk)!: remove dead and misleading public exports

### DIFF
--- a/sdks/typescript/src/batch/cli-args.ts
+++ b/sdks/typescript/src/batch/cli-args.ts
@@ -1,6 +1,5 @@
 import { Provider } from '../evaluators/base.js';
 import type { ModelOverride } from '../evaluators/base.js';
-import type { EvaluatorGroup } from './types.js';
 
 export interface CliArgs {
   csvPath?: string;
@@ -136,15 +135,4 @@ export function parseModelOverride(raw: string): ModelOverride {
   }
 
   return { provider: providerStr as Provider, model };
-}
-
-export function requiredProviders(
-  group: EvaluatorGroup,
-  modelOverride: ModelOverride | undefined
-): Provider[] {
-  if (modelOverride) return [modelOverride.provider];
-  const providers: Provider[] = [];
-  if (group.requiresGoogleKey) providers.push(Provider.Google);
-  if (group.requiresOpenAIKey) providers.push(Provider.OpenAI);
-  return providers;
 }

--- a/sdks/typescript/src/batch/evaluator.ts
+++ b/sdks/typescript/src/batch/evaluator.ts
@@ -1,5 +1,4 @@
 import pLimit from 'p-limit';
-import { Provider } from '../evaluators/base.js';
 import type {
   BatchInput,
   BatchTask,
@@ -7,7 +6,6 @@ import type {
   BatchOutput,
   BatchConfig,
   BatchSummary,
-  EvaluatorGroup,
 } from './types.js';
 import {
   type EvaluatorFamily,
@@ -18,28 +16,9 @@ import {
   resolveMembers,
   validateRequiredColumns,
 } from './families/family.js';
-import { getFamilies, getFamily } from './families/registry.js';
+import { getFamily } from './families/registry.js';
 
 export { getFamilies, getFamily } from './families/registry.js';
-
-/**
- * Backward-compatible view of families as the older "evaluator group" shape.
- * @deprecated Use {@link getFamilies}. No internal caller remains; kept for the published API.
- */
-export function getAvailableGroups(): EvaluatorGroup[] {
-  return getFamilies().map((family) => {
-    const keys = family.requiredKeys(family.members.map((m) => m.id));
-    return {
-      id: family.id,
-      name: family.name,
-      description: family.description,
-      evaluatorIds: family.members.map((m) => m.id),
-      requiresGoogleKey: keys.includes(Provider.Google),
-      requiresOpenAIKey: keys.includes(Provider.OpenAI),
-      maxInputRows: family.maxInputRows,
-    };
-  });
-}
 
 export interface BatchRunOptions {
   selectedMemberIds?: string[];

--- a/sdks/typescript/src/batch/index.ts
+++ b/sdks/typescript/src/batch/index.ts
@@ -1,7 +1,7 @@
 /**
  * Batch evaluation module
  *
- * Programmatic API for running an evaluator group over a set of texts.
+ * Programmatic API for running an evaluator family over a set of texts.
  *
  * @example
  * ```typescript
@@ -10,7 +10,7 @@
  * const [family] = getFamilies(); // 'text-complexity'
  * const inputs = parseCSV('./texts.csv');
  * const evaluator = new BatchEvaluator({ googleApiKey, openaiApiKey });
- * const output = await evaluator.evaluate(inputs, group.id);
+ * const output = await evaluator.evaluate(inputs, family.id);
  * console.log(formatAsCSV(output));
  * ```
  */

--- a/sdks/typescript/src/batch/index.ts
+++ b/sdks/typescript/src/batch/index.ts
@@ -5,9 +5,9 @@
  *
  * @example
  * ```typescript
- * import { BatchEvaluator, getAvailableGroups, parseCSV, formatAsCSV } from '@learning-commons/evaluators/batch';
+ * import { BatchEvaluator, getFamilies, parseCSV, formatAsCSV } from '@learning-commons/evaluators/batch';
  *
- * const [group] = getAvailableGroups(); // 'text-complexity'
+ * const [family] = getFamilies(); // 'text-complexity'
  * const inputs = parseCSV('./texts.csv');
  * const evaluator = new BatchEvaluator({ googleApiKey, openaiApiKey });
  * const output = await evaluator.evaluate(inputs, group.id);
@@ -15,7 +15,7 @@
  * ```
  */
 
-export { BatchEvaluator, getAvailableGroups, getFamilies, getFamily } from './evaluator.js';
+export { BatchEvaluator, getFamilies, getFamily } from './evaluator.js';
 export type { BatchRunOptions } from './evaluator.js';
 export { parseCSV } from './csv.js';
 export { formatAsCSV, formatAsHTML, formatAsJSON } from './formatters.js';
@@ -30,7 +30,6 @@ export type {
   KeyKind,
 } from './families/family.js';
 export type {
-  EvaluatorGroup,
   BatchInput,
   BatchResult,
   BatchOutput,

--- a/sdks/typescript/src/batch/types.ts
+++ b/sdks/typescript/src/batch/types.ts
@@ -67,23 +67,6 @@ export interface BatchOutput {
 }
 
 /**
- * The pre-family projection of an {@link EvaluatorFamily}.
- * @deprecated Prefer EvaluatorFamily, which is the unit of selection; produced only by
- * getAvailableGroups().
- */
-export interface EvaluatorGroup {
-  id: string;
-  name: string;
-  description: string;
-  /** IDs of the evaluators that belong to this group */
-  evaluatorIds: readonly string[];
-  requiresGoogleKey: boolean;
-  requiresOpenAIKey: boolean;
-  /** Maximum number of input rows allowed for this group */
-  maxInputRows: number;
-}
-
-/**
  * Configuration for batch evaluation
  */
 export interface BatchConfig {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -3,10 +3,7 @@ export type {
   EvaluationResult,
   EvaluationMetadata,
   EvaluationTokenUsage,
-  EvaluationFailure,
 } from './schemas/index.js';
-
-export { TextComplexityLevel } from './schemas/index.js';
 export type { GradeBand } from './schemas/index.js';
 export { readOutcome, type Outcome } from './schemas/index.js';
 
@@ -54,8 +51,6 @@ export type {
   Message,
   ProviderConfig,
 } from './providers/index.js';
-
-export { Providers } from './providers/index.js';
 
 // Sentence structure exports
 export {

--- a/sdks/typescript/src/providers/base.ts
+++ b/sdks/typescript/src/providers/base.ts
@@ -64,16 +64,6 @@ export interface LLMProvider {
 }
 
 /**
- * Named constants for LLM provider types — use instead of raw string literals.
- */
-export const Providers = {
-  google: 'google',
-  openai: 'openai',
-  anthropic: 'anthropic',
-  custom: 'custom',
-} as const;
-
-/**
  * Configuration for LLM provider
  */
 export interface ProviderConfig {

--- a/sdks/typescript/src/providers/index.ts
+++ b/sdks/typescript/src/providers/index.ts
@@ -7,6 +7,4 @@ export type {
   ProviderConfig,
 } from './base.js';
 
-export { Providers } from './base.js';
-
 export { VercelAIProvider, createProvider } from './ai-sdk-provider.js';

--- a/sdks/typescript/src/schemas/index.ts
+++ b/sdks/typescript/src/schemas/index.ts
@@ -1,9 +1,7 @@
 export {
-  TextComplexityLevel,
   type EvaluationResult,
   type EvaluationMetadata,
   type EvaluationTokenUsage,
-  type EvaluationFailure,
 } from './outputs.js';
 
 export {

--- a/sdks/typescript/src/schemas/outputs.ts
+++ b/sdks/typescript/src/schemas/outputs.ts
@@ -1,20 +1,3 @@
-import { z } from 'zod';
-
-/**
- * Legacy public enum in the pre-contract Title Case spelling.
- *
- * No evaluator reads it: each declares its own snake_case values in its generated schema.
- * Exported only so the published surface does not break.
- */
-export const TextComplexityLevel = z.enum([
-  'Slightly complex',
-  'Moderately complex',
-  'Very complex',
-  'Exceedingly complex',
-]);
-
-export type TextComplexityLevel = z.infer<typeof TextComplexityLevel>;
-
 /** Tokens consumed by an evaluation, summed across every step. */
 export interface EvaluationTokenUsage {
   inputTokens: number;
@@ -44,34 +27,4 @@ export interface EvaluationResult<TResult = unknown> {
   evaluator: string;
   result: TResult;
   metadata: EvaluationMetadata;
-}
-
-/**
- * Batch evaluation summary statistics
- */
-export interface BatchSummary {
-  total: number;
-  successful: number;
-  failed: number;
-  averageProcessingTimeMs: number;
-}
-
-/**
- * A failed slot in a batch result. Named to leave `EvaluationError` free for the
- * canonical error class.
- */
-export interface EvaluationFailure {
-  error: string;
-  input: {
-    text: string;
-    gradeLevel?: string;
-  };
-}
-
-/**
- * Batch evaluation result
- */
-export interface BatchEvaluationResult<T = EvaluationResult> {
-  results: Array<T | EvaluationFailure>;
-  summary: BatchSummary;
 }

--- a/sdks/typescript/tests/integration/batch.integration.test.ts
+++ b/sdks/typescript/tests/integration/batch.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as path from 'path';
-import { BatchEvaluator, getAvailableGroups, parseCSV } from '../../src/batch/index.js';
+import { BatchEvaluator, getFamily, parseCSV } from '../../src/batch/index.js';
 import type { BatchInput } from '../../src/batch/index.js';
 
 /**
@@ -41,11 +41,11 @@ describeIntegration('Batch Evaluator - Integration', () => {
       telemetry: false,
     });
 
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+    const family = getFamily('text-complexity');
     console.log('\n' + '='.repeat(80));
     console.log('BATCH EVALUATOR - INTEGRATION TEST');
     console.log('='.repeat(80));
-    console.log(`Group: ${group.name} (${group.evaluatorIds.join(', ')})`);
+    console.log(`Group: ${family.name} (${family.members.map((m) => m.id).join(', ')})`);
     console.log('='.repeat(80));
   });
 
@@ -58,8 +58,8 @@ describeIntegration('Batch Evaluator - Integration', () => {
       console.log(`\n📊 Processing ${inputs.length} rows...`);
 
       const startTime = Date.now();
-      const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-      const output = await evaluator.evaluate(inputs, group.id, {
+      const family = getFamily('text-complexity');
+      const output = await evaluator.evaluate(inputs, family.id, {
         onProgress: (result) => {
           console.log(`  ✓ Row ${result.rowIndex} [${result.evaluatorId}] - ${result.status}: ${result.score || result.error}`);
         },
@@ -74,14 +74,14 @@ describeIntegration('Batch Evaluator - Integration', () => {
       expect(output.summary).toBeDefined();
 
       // Should have 2 rows × 3 evaluators = 6 results
-      expect(output.results).toHaveLength(inputs.length * group.evaluatorIds.length);
+      expect(output.results).toHaveLength(inputs.length * family.members.map((m) => m.id).length);
 
       // Verify each result has expected fields
       for (const result of output.results) {
         expect(result.rowIndex).toBeGreaterThan(0);
         expect(result.text).toBeTruthy();
         expect(result.gradeLevel).toBeTruthy();
-        expect(group.evaluatorIds).toContain(result.evaluatorId);
+        expect(family.members.map((m) => m.id)).toContain(result.evaluatorId);
         expect(result.status).toMatch(/success|error/);
         expect(result.processingTimeMs).toBeGreaterThan(0);
 
@@ -94,11 +94,11 @@ describeIntegration('Batch Evaluator - Integration', () => {
       }
 
       // Verify summary — 2 rows × 3 evaluators = 6 tasks
-      const expectedTasks = inputs.length * group.evaluatorIds.length;
+      const expectedTasks = inputs.length * family.members.map((m) => m.id).length;
       expect(output.summary.totalTasks).toBe(expectedTasks);
       expect(output.summary.successful + output.summary.failed).toBe(expectedTasks);
       expect(output.summary.durationMs).toBeGreaterThan(0);
-      for (const id of group.evaluatorIds) {
+      for (const id of family.members.map((m) => m.id)) {
         expect(output.summary.resultsPerEvaluator).toHaveProperty(id);
       }
 
@@ -118,27 +118,27 @@ describeIntegration('Batch Evaluator - Integration', () => {
   it(
     'should run all evaluators in the group and include each in results',
     async () => {
-      const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+      const family = getFamily('text-complexity');
 
       // Single row — verify all group evaluators ran
       const inputs: BatchInput[] = [
         { rowIndex: 1, columns: { text: 'The cat sat on the mat.', grade_level: '3' }, originalRow: { text: 'The cat sat on the mat.', grade_level: '3' } },
       ];
 
-      console.log(`\n📊 Processing 1 row with ${group.evaluatorIds.length} evaluators...`);
+      console.log(`\n📊 Processing 1 row with ${family.members.map((m) => m.id).length} evaluators...`);
 
-      const output = await evaluator.evaluate(inputs, group.id, {
+      const output = await evaluator.evaluate(inputs, family.id, {
         onProgress: (result) => {
           console.log(`  ✓ ${result.evaluatorId} - ${result.status}: ${result.score || result.error}`);
         },
       });
 
       // Should have 1 result per evaluator in the group
-      expect(output.results).toHaveLength(group.evaluatorIds.length);
+      expect(output.results).toHaveLength(family.members.map((m) => m.id).length);
 
       // Verify every evaluator in the group produced a result
       const ranEvaluatorIds = output.results.map((r) => r.evaluatorId);
-      for (const id of group.evaluatorIds) {
+      for (const id of family.members.map((m) => m.id)) {
         expect(ranEvaluatorIds).toContain(id);
       }
 

--- a/sdks/typescript/tests/unit/batch/cli-args.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli-args.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { parseArgs, parseModelOverride, requiredProviders, resolveModel } from '../../../src/batch/cli-args.js';
+import { parseArgs, parseModelOverride, resolveModel } from '../../../src/batch/cli-args.js';
 import { Provider } from '../../../src/batch/index.js';
-import type { EvaluatorGroup } from '../../../src/batch/index.js';
 
 // ---- parseModelOverride ----
 
@@ -260,53 +259,5 @@ describe('resolveModel', () => {
 
   it('throws for an unknown bare word (no colon, not a shortcode)', () => {
     expect(() => resolveModel('gpt5')).toThrow(/shortcode/);
-  });
-});
-
-// ---- requiredProviders ----
-
-const makeGroup = (overrides: Partial<EvaluatorGroup> = {}): EvaluatorGroup => ({
-  id: 'text-complexity',
-  name: 'Text Complexity',
-  description: '',
-  evaluatorIds: [],
-  requiresGoogleKey: true,
-  requiresOpenAIKey: true,
-  maxInputRows: 50,
-  ...overrides,
-});
-
-describe('requiredProviders', () => {
-  it('returns Google and OpenAI when the group requires both and no override is set', () => {
-    const providers = requiredProviders(makeGroup(), undefined);
-    expect(providers).toContain(Provider.Google);
-    expect(providers).toContain(Provider.OpenAI);
-    expect(providers).toHaveLength(2);
-  });
-
-  it('returns only the override provider when a model override is set', () => {
-    const override = { provider: Provider.Anthropic, model: 'claude-opus-4-8' };
-    expect(requiredProviders(makeGroup(), override)).toEqual([Provider.Anthropic]);
-  });
-
-  it('returns only Google when override targets Google', () => {
-    const override = { provider: Provider.Google, model: 'gemini-2.5-pro' };
-    expect(requiredProviders(makeGroup(), override)).toEqual([Provider.Google]);
-  });
-
-  it('returns only OpenAI when override targets OpenAI', () => {
-    const override = { provider: Provider.OpenAI, model: 'gpt-4o' };
-    expect(requiredProviders(makeGroup(), override)).toEqual([Provider.OpenAI]);
-  });
-
-  it('respects group that only requires one key', () => {
-    const googleOnlyGroup = makeGroup({ requiresOpenAIKey: false });
-    const providers = requiredProviders(googleOnlyGroup, undefined);
-    expect(providers).toEqual([Provider.Google]);
-  });
-
-  it('returns empty array for a group requiring neither key', () => {
-    const noKeyGroup = makeGroup({ requiresGoogleKey: false, requiresOpenAIKey: false });
-    expect(requiredProviders(noKeyGroup, undefined)).toEqual([]);
   });
 });

--- a/sdks/typescript/tests/unit/batch/limits.test.ts
+++ b/sdks/typescript/tests/unit/batch/limits.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getAvailableGroups, BatchEvaluator, Provider } from '../../../src/batch/index.js';
+import { getFamilies, getFamily, BatchEvaluator, Provider } from '../../../src/batch/index.js';
 import type { BatchInput, BatchConfig, BatchResult } from '../../../src/batch/index.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 import type { EvaluatorFamily, FamilyRow, TaskOutcome } from '../../../src/batch/families/family.js';
@@ -57,46 +57,46 @@ function fakeProvider(): LLMProvider {
   };
 }
 
-describe('getAvailableGroups', () => {
-  it('returns at least one group', () => {
-    expect(getAvailableGroups().length).toBeGreaterThan(0);
+describe('getFamilies', () => {
+  it('returns at least one family', () => {
+    expect(getFamilies().length).toBeGreaterThan(0);
   });
 
-  it('includes the text-complexity group', () => {
-    const ids = getAvailableGroups().map((g) => g.id);
-    expect(ids).toContain('text-complexity');
+  it('includes the text-complexity family', () => {
+    expect(getFamilies().map((f) => f.id)).toContain('text-complexity');
   });
 
-  it('each group has required metadata fields', () => {
-    for (const g of getAvailableGroups()) {
-      expect(g.id).toBeTruthy();
-      expect(g.name).toBeTruthy();
-      expect(g.description).toBeTruthy();
-      expect(Array.isArray(g.evaluatorIds)).toBe(true);
-      expect(g.evaluatorIds.length).toBeGreaterThan(0);
-      expect(typeof g.requiresGoogleKey).toBe('boolean');
-      expect(typeof g.requiresOpenAIKey).toBe('boolean');
-      expect(typeof g.maxInputRows).toBe('number');
-      expect(g.maxInputRows).toBeGreaterThan(0);
+  it('each family has required metadata fields', () => {
+    for (const f of getFamilies()) {
+      expect(f.id).toBeTruthy();
+      expect(f.name).toBeTruthy();
+      expect(f.description).toBeTruthy();
+      expect(f.members.length).toBeGreaterThan(0);
+      expect(typeof f.maxInputRows).toBe('number');
+      expect(f.maxInputRows).toBeGreaterThan(0);
     }
   });
 
-  it('text-complexity group contains vocabulary, sentence-structure, and grade-level-appropriateness', () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    expect(group.evaluatorIds).toContain(VocabularyComplexityEvaluator.metadata.id);
-    expect(group.evaluatorIds).toContain(SentenceStructureEvaluator.metadata.id);
-    expect(group.evaluatorIds).toContain(GradeLevelAppropriatenessEvaluator.metadata.id);
+  it('text-complexity family contains vocabulary, sentence-structure, and grade-level-appropriateness', () => {
+    const family = getFamily('text-complexity');
+    expect(family.members.map((m) => m.id)).toContain(VocabularyComplexityEvaluator.metadata.id);
+    expect(family.members.map((m) => m.id)).toContain(SentenceStructureEvaluator.metadata.id);
+    expect(family.members.map((m) => m.id)).toContain(GradeLevelAppropriatenessEvaluator.metadata.id);
   });
 
-  it('text-complexity group requires both Google and OpenAI keys', () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    expect(group.requiresGoogleKey).toBe(true);
-    expect(group.requiresOpenAIKey).toBe(true);
+  it('text-complexity family requires both Google and OpenAI keys', () => {
+    // A family derives its keys from its members' declared providers, rather than the two
+    // booleans the removed group shape carried — which had no Anthropic field at all.
+    const family = getFamily('text-complexity');
+    const keys = family.requiredKeys(family.members.map((m) => m.id));
+
+    expect(keys).toContain(Provider.Google);
+    expect(keys).toContain(Provider.OpenAI);
   });
 
-  it('text-complexity group enforces a row limit of 50', () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    expect(group.maxInputRows).toBe(50);
+  it('text-complexity family enforces a row limit of 50', () => {
+    const family = getFamily('text-complexity');
+    expect(family.maxInputRows).toBe(50);
   });
 });
 
@@ -112,53 +112,53 @@ describe('BatchEvaluator.evaluate() — input validation', () => {
   });
 
   it('throws when input row count exceeds the group maxInputRows', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const tooMany = makeInputs(group.maxInputRows + 1);
+    const family = getFamily('text-complexity');
+    const tooMany = makeInputs(family.maxInputRows + 1);
 
-    await expect(evaluator.evaluate(tooMany, group.id))
-      .rejects.toThrow(`Input exceeds limit for "${group.id}"`);
+    await expect(evaluator.evaluate(tooMany, family.id))
+      .rejects.toThrow(`Input exceeds limit for "${family.id}"`);
   });
 
   it('does not throw the limit error when input count equals maxInputRows', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const atLimit = makeInputs(group.maxInputRows);
+    const family = getFamily('text-complexity');
+    const atLimit = makeInputs(family.maxInputRows);
     const boundary = new BatchEvaluator({ llmProvider: fakeProvider(), telemetry: false });
 
-    await expect(boundary.evaluate(atLimit, group.id)).resolves.toBeDefined();
+    await expect(boundary.evaluate(atLimit, family.id)).resolves.toBeDefined();
   });
 
   it('error message mentions the bypassRowLimit escape hatch', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const tooMany = makeInputs(group.maxInputRows + 1);
+    const family = getFamily('text-complexity');
+    const tooMany = makeInputs(family.maxInputRows + 1);
 
-    await expect(evaluator.evaluate(tooMany, group.id))
+    await expect(evaluator.evaluate(tooMany, family.id))
       .rejects.toThrow(/bypassRowLimit/);
   });
 
   it('explicitly setting bypassRowLimit: false still throws on overflow', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const tooMany = makeInputs(group.maxInputRows + 1);
+    const family = getFamily('text-complexity');
+    const tooMany = makeInputs(family.maxInputRows + 1);
     const strict = new BatchEvaluator({
       googleApiKey: 'fake-google-key',
       openaiApiKey: 'fake-openai-key',
       bypassRowLimit: false,
     });
 
-    await expect(strict.evaluate(tooMany, group.id))
-      .rejects.toThrow(`Input exceeds limit for "${group.id}"`);
+    await expect(strict.evaluate(tooMany, family.id))
+      .rejects.toThrow(`Input exceeds limit for "${family.id}"`);
   });
 
   it('bypassRowLimit: true skips the row limit check', async () => {
-    const group = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
-    const tooMany = makeInputs(group.maxInputRows + 1);
+    const family = getFamily('text-complexity');
+    const tooMany = makeInputs(family.maxInputRows + 1);
     const bypassed = new BatchEvaluator({
       llmProvider: fakeProvider(),
       telemetry: false,
       bypassRowLimit: true,
     });
 
-    const output = await bypassed.evaluate(tooMany, group.id);
-    const expectedTasks = tooMany.length * group.evaluatorIds.length;
+    const output = await bypassed.evaluate(tooMany, family.id);
+    const expectedTasks = tooMany.length * family.members.map((m) => m.id).length;
     // The bypass is proven by all rows being processed (totalTasks reflects the
     // over-limit input) rather than the run throwing the limit error.
     expect(output.summary.totalTasks).toBe(expectedTasks);

--- a/sdks/typescript/tests/unit/batch/llm-provider.test.ts
+++ b/sdks/typescript/tests/unit/batch/llm-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getAvailableGroups, BatchEvaluator } from '../../../src/batch/index.js';
+import { getFamily, BatchEvaluator } from '../../../src/batch/index.js';
 import type { BatchInput } from '../../../src/batch/index.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
@@ -10,7 +10,7 @@ import type { LLMProvider } from '../../../src/providers/base.js';
  * single-evaluator coverage in tests/unit/evaluators/llm-provider.test.ts.
  */
 
-const GROUP = getAvailableGroups().find((g) => g.id === 'text-complexity')!;
+const FAMILY = getFamily('text-complexity');
 
 function makeFakeProvider(label = 'vertex:gemini-2.5-pro') {
   const generateStructured = vi.fn().mockResolvedValue({
@@ -50,10 +50,10 @@ describe('BatchConfig.llmProvider — bring-your-own-provider', () => {
     const { provider, generateStructured } = makeFakeProvider();
     const batch = new BatchEvaluator({ llmProvider: provider, telemetry: false });
 
-    const { summary } = await batch.evaluate(makeInputs(1), GROUP.id);
+    const { summary } = await batch.evaluate(makeInputs(1), FAMILY.id);
 
     // One task per evaluator in the group, all attempted (no missing-key crash).
-    expect(summary.totalTasks).toBe(GROUP.evaluatorIds.length);
+    expect(summary.totalTasks).toBe(FAMILY.members.length);
     expect(generateStructured).toHaveBeenCalled();
   });
 
@@ -63,9 +63,9 @@ describe('BatchConfig.llmProvider — bring-your-own-provider', () => {
 
     // One task per member, all attempted, and the injected provider was used
     // (no keys were supplied, so nothing could fall back to a real provider).
-    const { results } = await batch.evaluate(makeInputs(1), GROUP.id);
+    const { results } = await batch.evaluate(makeInputs(1), FAMILY.id);
 
-    expect(results).toHaveLength(GROUP.evaluatorIds.length);
+    expect(results).toHaveLength(FAMILY.members.length);
     expect(generateStructured).toHaveBeenCalled();
     expect(results.some((r) => r.status === 'success')).toBe(true);
   });
@@ -74,7 +74,7 @@ describe('BatchConfig.llmProvider — bring-your-own-provider', () => {
     const { provider } = makeFakeProvider();
     const batch = new BatchEvaluator({ llmProvider: provider, telemetry: false });
 
-    const { results } = await batch.evaluate(makeInputs(1), GROUP.id);
+    const { results } = await batch.evaluate(makeInputs(1), FAMILY.id);
 
     for (const r of results) {
       expect(r.error ?? '').not.toMatch(/API key/i);

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -973,3 +973,55 @@ describe('a declared minimum length is enforced', () => {
     ).toBe(true);
   });
 });
+
+describe('the public surface offers no value a contract does not declare', () => {
+  // `TextComplexityLevel` shipped a Title Case enum — 'Slightly complex' — while every
+  // contract declares snake_case. Nothing read it, so nothing failed; the only cost fell on
+  // callers who typed against it and got values no evaluator returns. This catches the next
+  // one at the point it is exported rather than after it ships.
+  const declaredValues = new Set<string>();
+  for (const { E } of cases) {
+    const { outputSchema } = contractFor(E.metadata.id);
+    const collect = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        node.forEach(collect);
+        return;
+      }
+      if (node === null || typeof node !== 'object') return;
+      const record = node as Record<string, unknown>;
+      if (Array.isArray(record.enum)) {
+        for (const value of record.enum) if (typeof value === 'string') declaredValues.add(value);
+      }
+      Object.values(record).forEach(collect);
+    };
+    collect(outputSchema);
+  }
+
+  it('found the values the contracts declare', () => {
+    // Without this the assertion below passes for an empty set.
+    expect(declaredValues.size).toBeGreaterThan(5);
+    expect(declaredValues).toContain('slightly_complex');
+  });
+
+  it('exports no verdict-shaped value the contracts never use', async () => {
+    const surface = (await import('../../src/index.js')) as Record<string, unknown>;
+
+    // A Zod enum on the public surface whose options describe a verdict must offer the
+    // values the contracts declare. Anything else is a spelling only the SDK believes in.
+    const offenders: string[] = [];
+    for (const [name, exported] of Object.entries(surface)) {
+      const options = (exported as { options?: unknown })?.options;
+      if (!Array.isArray(options) || options.length === 0) continue;
+      if (!options.every((o): o is string => typeof o === 'string')) continue;
+
+      const unknownValues = options.filter((o) => !declaredValues.has(o));
+      // Only flag an enum that looks like a verdict: every value unknown to every
+      // contract, while a case-folded form of one is declared.
+      const looksLikeVerdict = unknownValues.length === options.length &&
+        options.some((o) => declaredValues.has(o.toLowerCase().replace(/ /g, '_')));
+      if (looksLikeVerdict) offenders.push(`${name}: ${options.join(', ')}`);
+    }
+
+    expect(offenders, 'these export values no contract declares').toEqual([]);
+  });
+});


### PR DESCRIPTION
Removes six exports from the published surface. **240 lines deleted, 126 added.** Pre-1.0 (0.8.0), so nothing is owed compatibility — and two of these are not merely dead but actively wrong.

## Actively misleading

**`TextComplexityLevel`** shipped a Title Case enum — `'Slightly complex'` — while every contract declares `slightly_complex`. Its own doc said *"No evaluator reads it… Exported only so the published surface does not break."* Nothing failed, because nothing read it; the cost fell entirely on anyone who typed against it and got values no evaluator returns.

**`EvaluatorGroup`** carries `requiresGoogleKey` and `requiresOpenAIKey` and **no Anthropic field**, so it cannot describe today's evaluators — the feedback family is OpenAI, math is Anthropic. Its consumer `requiredProviders()` could therefore never report Anthropic, and returned `[]` for the standards family.

## Simply dead

`Providers` (duplicated the `Provider` enum with an extra `custom` member no contract uses), `EvaluationFailure`, `BatchEvaluationResult`, and a second `BatchSummary` in `schemas/outputs.ts` that **name-collided** with the live one in `batch/types.ts`.

## Why they survived: tests kept a dead pocket alive

`getAvailableGroups()` → `EvaluatorGroup` → `requiredProviders()` is one connected set with **no production caller at all**. What made it look used was ~47 lines of tests exercising `requiredProviders` directly, plus three test files calling `getAvailableGroups()`.

Those tests are migrated to `getFamily()` / `getFamilies()` rather than deleted, so the coverage moves with them. The keys assertion improves in passing: it now derives from `family.requiredKeys(...)` — the members' declared providers — instead of the two booleans that had no Anthropic field.

The `batch/index.ts` usage example pointed at `getAvailableGroups()` too, so the documented entry point was the deprecated one.

## A guard, so the next one is caught on the way in

`TextComplexityLevel` got added and lived for however long precisely because nothing checked. The conformance suite now derives every value the 16 contracts declare and fails if the public surface exports a verdict-shaped enum whose values none of them use:

```
× exports no verdict-shaped value the contracts never use
+ "TextComplexityLevel: Slightly complex, Moderately complex, Very complex, Exceedingly complex"
```

That output is from re-adding the deleted export to check the guard fires — it names the offender and its values. A companion test asserts the derived value set is non-empty and contains `slightly_complex`, so the check cannot pass vacuously against an empty set.

## Validation

- `typecheck`, `lint`, `test:unit` (1121), `build`, `scripts/check.py`
- Confirmed gone from the built types: `TextComplexityLevel`, `EvaluationFailure`, `BatchEvaluationResult` and `Providers` absent from `dist/index.d.ts`; `EvaluatorGroup` and `getAvailableGroups` absent from `dist/batch/index.d.ts`. (The two remaining `Providers` matches are the unrelated `defaultProviders` field.)
- Guard verified by reintroducing the export, as above
- **Live: `batch.integration.test.ts` passes** — it was one of the migrated files

## Breaking

Marked `!` — six names leave the public API. All were dead, deprecated, or contradicted the contracts. Worth doing before 1.0 rather than at 2.0: once 1.0 ships, removing them *is* a breaking change, and shipping 1.0 with a surface that contradicts the contracts undercuts the point of making them authoritative.
