### PR TITLE
fix(sdk): surface a swallowed KG failure, repoint the report grade filter, honour VC's declared conditions

### DIFF
--- a/sdks/typescript/src/batch/families/standards-report.html
+++ b/sdks/typescript/src/batch/families/standards-report.html
@@ -127,7 +127,7 @@ var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__
 
     items.forEach(function (it) {
       if (fS && it.statementCode !== fS) return;
-      if (fG && it.grade !== fG) return;
+      if (fG && it.gradeLevel !== fG) return;
       var cls = classify(it);
       if (fSt) {
         if (fSt === 'error' && cls !== 'error') return;
@@ -164,7 +164,7 @@ var REPORT_DATA = null; // __REPLACED_BY_FORMATTER__
       '<span class="badge ' + badgeClass + '">' + badgeText + '</span>' +
       '<span class="stem"><span class="q">' + escapeHtml(it.question || '(no question text)') + '</span>' +
       '<span class="tags"><code>' + escapeHtml(it.statementCode || '') + '</code>' +
-      (it.grade ? '<span>grade ' + escapeHtml(it.grade) + '</span>' : '') +
+      (it.gradeLevel ? '<span>grade ' + escapeHtml(it.gradeLevel) + '</span>' : '') +
       (it.id ? '<span>id ' + escapeHtml(it.id) + '</span>' : '') + '</span></span>';
     el.appendChild(summary);
 

--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -290,12 +290,26 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     type LcCacheEntry = Awaited<ReturnType<KnowledgeGraphClient['getLearningComponentsByCode']>>;
     const lcCache = new Map<string, LcCacheEntry>();
 
+    // A failed prefetch is recorded, not discarded: `totalCount` below falls back to 0,
+    // which is indistinguishable from a standard that genuinely has no learning
+    // components. The failure travels on the result's `error` instead, which already means
+    // "0 because nothing was measured".
+    const lcFailures = new Map<string, unknown>();
+
     if (useCoarseFilter) {
       await Promise.all(
         allCodes.map((code) =>
           this.kgClient.getLearningComponentsByCode(code, { jurisdiction, academicSubject: KG_SUBJECT })
             .then((result) => lcCache.set(code, result))
-            .catch(() => undefined),
+            .catch((err) => {
+              lcFailures.set(code, err);
+              this.logger.warn('Learning component prefetch failed; totalCount is unknown', {
+                evaluator: EVALUATOR_ID,
+                operation: 'prefetch_learning_components',
+                statementCode: code,
+                error: err instanceof Error ? err : undefined,
+              });
+            }),
         ),
       );
     }
@@ -347,12 +361,14 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
           item.statementCodes.map(async (code): Promise<StandardAlignmentResult> => {
             if (!relevant.has(code)) {
               const cached = lcCache.get(code);
+              const failure = lcFailures.get(code);
               return {
                 statementCode: code,
                 learningComponents: [],
                 alignedCount: 0,
                 totalCount: cached?.components.length ?? 0,
                 coarseFiltered: true,
+                ...(failure ? { error: describeFailure(failure) } : {}),
               };
             }
             let result: StandardAlignmentResult;

--- a/sdks/typescript/src/evaluators/multi-step.ts
+++ b/sdks/typescript/src/evaluators/multi-step.ts
@@ -119,12 +119,17 @@ function vendorOf(provider: string, evaluatorName: string): Provider {
  * contract that stops declaring it should fail at load rather than silently skip the work.
  */
 export function requirePreprocessing(
-  contract: { preprocessing?: Array<{ id: string; condition?: DeclaredCondition }> },
+  contract: {
+    evaluator?: { name?: string };
+    preprocessing?: Array<{ id: string; condition?: DeclaredCondition }>;
+  },
   id: string,
 ): { id: string; condition?: DeclaredCondition } {
   const entry = contract.preprocessing?.find((p) => p.id === id);
   if (!entry) {
-    throw new Error(`Preprocessing "${id}" not found in config.json`);
+    // Named, as requireStep does: without it the failure does not say whose contract.
+    const owner = contract.evaluator?.name ?? 'the';
+    throw new Error(`Preprocessing "${id}" not found in ${owner} config.json`);
   }
   return entry;
 }

--- a/sdks/typescript/src/evaluators/multi-step.ts
+++ b/sdks/typescript/src/evaluators/multi-step.ts
@@ -113,6 +113,23 @@ function vendorOf(provider: string, evaluatorName: string): Provider {
 }
 
 /**
+ * The preprocessing entry a contract declares under `id`, or a failure naming it.
+ *
+ * Parallel to {@link requireStep}: an entry read by id is registry information, and a
+ * contract that stops declaring it should fail at load rather than silently skip the work.
+ */
+export function requirePreprocessing(
+  contract: { preprocessing?: Array<{ id: string; condition?: DeclaredCondition }> },
+  id: string,
+): { id: string; condition?: DeclaredCondition } {
+  const entry = contract.preprocessing?.find((p) => p.id === id);
+  if (!entry) {
+    throw new Error(`Preprocessing "${id}" not found in config.json`);
+  }
+  return entry;
+}
+
+/**
  * The input values a step's condition names, or a failure if it names none.
  *
  * For a step whose *routing* depends on the condition, an absent or empty one is a contract

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -13,7 +13,7 @@ import type { EvaluationResult } from '../../../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
 import { validateInputs, type InputsOf } from '../../inputs.js';
 import { requireStep } from '../../single-step.js';
-import { requireConditionValues } from '../../multi-step.js';
+import { requireConditionValues, requirePreprocessing } from '../../multi-step.js';
 import { declaredCredentials } from '../../credentials.js';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json';
 import type { StageDetail } from '../../../telemetry/index.js';
@@ -76,6 +76,15 @@ const OTHER_GRADES_STEP = requireStep(
 
 /** The grades the grades-3-4 branch declares, so the routing follows the contract. */
 const GRADES_34 = requireConditionValues(GRADES_34_STEP, CONFIG.evaluator.name);
+
+/**
+ * The grades whose prompt binds `{fk_score}`, from the preprocessing entry's own condition
+ * rather than assumed to match the step's — the contract states them separately.
+ */
+const FK_APPLIES_TO = requireConditionValues(
+  requirePreprocessing(CONFIG, 'fk_score'),
+  CONFIG.evaluator.name,
+);
 
 export class VocabularyComplexityEvaluator extends BaseEvaluator {
   static readonly metadata = {
@@ -174,8 +183,11 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
         },
       });
 
-      // Calculate Flesch-Kincaid grade level
-      const fkLevel = calculateFleschKincaidGrade(text);
+      // Declared conditional: only the grades-3-4 branch binds {fk_score}, so computing it
+      // for grades 5-12 is work the contract says to skip.
+      const fkLevel = FK_APPLIES_TO.includes(gradeLevel)
+        ? calculateFleschKincaidGrade(text)
+        : undefined;
 
       // Stage 2: Evaluate vocabulary complexity
       const complexityResponse = await this.evaluateComplexity(
@@ -321,7 +333,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     text: string,
     gradeLevel: string,
     backgroundKnowledge: string,
-    fkLevel: number
+    fkLevel: number | undefined
   ): Promise<{ data: VocabularyComplexityResult; usage: { inputTokens: number; outputTokens: number }; latencyMs: number }> {
     const systemPrompt = getSystemPrompt(gradeLevel);
     const userPrompt = getUserPrompt(text, gradeLevel, backgroundKnowledge, fkLevel);

--- a/sdks/typescript/src/features/readability.ts
+++ b/sdks/typescript/src/features/readability.ts
@@ -4,9 +4,9 @@ import { syllable } from 'syllable';
 /**
  * Flesch-Kincaid grade level over compromise + syllable.
  *
- * Approximates Python's `textstat.flesch_kincaid_grade()` but does not match it, and is
- * not the implementation the contracts declare — see PREPROCESSING_GAPS in
- * registry-conformance.test.ts for the three evaluators that call this instead.
+ * Approximates Python's `textstat.flesch_kincaid_grade()` but does not match it, and is not
+ * the implementation the contract declares. One caller remains — vocabulary-complexity,
+ * which is the sole entry left in PREPROCESSING_GAPS in registry-conformance.test.ts.
  */
 export function calculateFleschKincaidGrade(text: string): number {
   return calculateReadabilityMetrics(text).fleschKincaidGrade;

--- a/sdks/typescript/src/prompts/vocabulary-complexity/system.ts
+++ b/sdks/typescript/src/prompts/vocabulary-complexity/system.ts
@@ -1,17 +1,25 @@
 import SYSTEM_PROMPT_GRADES_3_4 from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/grades-3-4-system.txt';
 import SYSTEM_PROMPT_OTHER_GRADES from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/other-grades-system.txt';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/config.json';
+import { requireConditionValues } from '../../evaluators/multi-step.js';
+import { requireStep } from '../../evaluators/single-step.js';
+
+/** Which grades take the grades-3-4 branch, from the step's own declared condition. */
+const GRADES_34 = requireConditionValues(
+  requireStep(CONFIG.steps, 'vocab_complexity_grades_3_4', CONFIG.evaluator.name),
+  CONFIG.evaluator.name,
+);
 
 /**
- * Get the appropriate system prompt based on grade level
- * @param grade - The target grade level (3-12)
- * @returns The system prompt for the grade level
+ * The system prompt for a grade's branch.
+ *
+ * Which grades take which branch is read from `config.json` rather than restated here — the
+ * same fact drives the model choice and the user prompt, and three hardcoded copies of it
+ * would drift independently.
+ *
+ * @param grade - The target grade level
+ * @returns The system prompt for that grade's branch
  */
 export function getSystemPrompt(grade: string): string {
-  // Grades 3-4 use the GRADES_3_4 prompt
-  if (grade === '3' || grade === '4') {
-    return SYSTEM_PROMPT_GRADES_3_4;
-  }
-
-  // All other grades (5-12) use OTHER_GRADES prompt
-  return SYSTEM_PROMPT_OTHER_GRADES;
+  return GRADES_34.includes(grade) ? SYSTEM_PROMPT_GRADES_3_4 : SYSTEM_PROMPT_OTHER_GRADES;
 }

--- a/sdks/typescript/src/prompts/vocabulary-complexity/user.ts
+++ b/sdks/typescript/src/prompts/vocabulary-complexity/user.ts
@@ -37,9 +37,18 @@ export function getUserPrompt(
     .replaceAll('{student_background_knowledge}', studentBackgroundKnowledge)
     .replaceAll('{text}', text);
 
-  // Only the grades that declare the entry bind it. Substituting `undefined` for the rest
-  // would put the string "undefined" into any template that happened to carry the token.
-  return FK_APPLIES_TO.includes(studentGradeLevel) && fkLevel !== undefined
-    ? rendered.replaceAll('{fk_score}', fkLevel.toString())
-    : rendered;
+  // Only the grades that declare the entry bind it; for the rest the token is absent from
+  // the template and there is nothing to substitute.
+  if (!FK_APPLIES_TO.includes(studentGradeLevel)) return rendered;
+
+  // A grade that binds it and was given nothing is a caller error, and both quiet outcomes
+  // are worse than throwing: substituting `undefined` puts that word in the prompt, and
+  // skipping leaves a literal `{fk_score}` for the model to read as instruction.
+  if (fkLevel === undefined) {
+    throw new Error(
+      `Grade ${studentGradeLevel} binds {fk_score}, but no readability score was provided.`,
+    );
+  }
+
+  return rendered.replaceAll('{fk_score}', fkLevel.toString());
 }

--- a/sdks/typescript/src/prompts/vocabulary-complexity/user.ts
+++ b/sdks/typescript/src/prompts/vocabulary-complexity/user.ts
@@ -1,28 +1,45 @@
 import USER_PROMPT_TEMPLATE_GRADES_3_4 from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/grades-3-4-user.txt';
 import USER_PROMPT_TEMPLATE_OTHER_GRADES from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/other-grades-user.txt';
+import CONFIG from '../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/config.json';
+import { requireConditionValues, requirePreprocessing } from '../../evaluators/multi-step.js';
+import { requireStep } from '../../evaluators/single-step.js';
+
+/** Which branch a grade takes, and whether it binds `{fk_score}`, per the contract. */
+const GRADES_34 = requireConditionValues(
+  requireStep(CONFIG.steps, 'vocab_complexity_grades_3_4', CONFIG.evaluator.name),
+  CONFIG.evaluator.name,
+);
+const FK_APPLIES_TO = requireConditionValues(
+  requirePreprocessing(CONFIG, 'fk_score'),
+  CONFIG.evaluator.name,
+);
 
 /**
  * Generate the user prompt for vocabulary complexity evaluation
  * @param text - The text to evaluate
  * @param studentGradeLevel - The student's grade level
  * @param studentBackgroundKnowledge - Background knowledge assumption
- * @param fkLevel - Flesch-Kincaid grade level
+ * @param fkLevel - Flesch-Kincaid grade level; omitted for grades whose prompt does not bind it
  * @returns The formatted user prompt
  */
 export function getUserPrompt(
   text: string,
   studentGradeLevel: string,
   studentBackgroundKnowledge: string,
-  fkLevel: number
+  fkLevel?: number
 ): string {
-  // Select the appropriate template based on grade
-  const template = studentGradeLevel === '3' || studentGradeLevel === '4'
+  const template = GRADES_34.includes(studentGradeLevel)
     ? USER_PROMPT_TEMPLATE_GRADES_3_4
     : USER_PROMPT_TEMPLATE_OTHER_GRADES;
 
-  return template
+  const rendered = template
     .replaceAll('{grade_level}', studentGradeLevel)
     .replaceAll('{student_background_knowledge}', studentBackgroundKnowledge)
-    .replaceAll('{fk_score}', fkLevel.toString())
     .replaceAll('{text}', text);
+
+  // Only the grades that declare the entry bind it. Substituting `undefined` for the rest
+  // would put the string "undefined" into any template that happened to carry the token.
+  return FK_APPLIES_TO.includes(studentGradeLevel) && fkLevel !== undefined
+    ? rendered.replaceAll('{fk_score}', fkLevel.toString())
+    : rendered;
 }

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 import { STANDARDS_FAMILY } from '../../../src/batch/families/standards.js';
 import { QTC_FAMILY } from '../../../src/batch/families/qtc.js';
@@ -137,5 +139,30 @@ describe('STANDARDS_FAMILY.runTask', () => {
       runnerWithStub(evaluate).runTask(row({ question: 'q', statementCode: 'x', jurisdiction: 'Utahh' }), MEMBER),
     ).rejects.toThrow(/Invalid jurisdiction "Utahh"/);
     expect(evaluate).not.toHaveBeenCalled();
+  });
+});
+
+describe('the standards report reads the fields the formatter emits', () => {
+  // The report filtered and displayed `it.grade`; the formatter emits `gradeLevel`. Since
+  // `it.grade` was always undefined, selecting a grade filtered *everything* out rather
+  // than filtering. Nothing failed because the filter is browser JS in a template, which
+  // no test executes — so this asserts on the template text, as the ordering check does.
+  const template = readFileSync(
+    join(process.cwd(), 'src/batch/families/standards-report.html'),
+    'utf-8',
+  );
+
+  it('never reads a bare `grade` off a row', () => {
+    expect(template).not.toMatch(/\bit\.grade\b/);
+  });
+
+  it('reads gradeLevel, which is what standards-output.ts writes', () => {
+    expect(template).toContain('it.gradeLevel');
+
+    const formatter = readFileSync(
+      join(process.cwd(), 'src/batch/families/standards-output.ts'),
+      'utf-8',
+    );
+    expect(formatter, 'the formatter must still emit that field').toContain('gradeLevel:');
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
@@ -19,6 +19,13 @@ import CONFIG from '../../../../../evals/academic-standards-alignment/mathematic
 const created: Array<{ type: string; model: string }> = [];
 const calls: Array<{ model: string; temperature?: number; user: string }> = [];
 
+/**
+ * What the coarse filter says about the standard under test. `true` sends it on to be
+ * evaluated; `false` is what produces a coarse-filtered result, which is the only path
+ * where a missing learning-component prefetch shows up as a count.
+ */
+let coarseRelevant = true;
+
 vi.mock('../../../src/telemetry/client.js', () => ({
   TelemetryClient: class {
     send = vi.fn().mockResolvedValue(undefined);
@@ -49,7 +56,7 @@ vi.mock('../../../src/providers/index.js', async (importOriginal) => {
             const isCoarse = req.messages.every((m) => m.role !== 'system');
             return Promise.resolve({
               data: isCoarse
-                ? { standards: [{ standard: '3.MD.C.7.d', relevant: true }] }
+                ? { standards: [{ standard: '3.MD.C.7.d', relevant: coarseRelevant }] }
                 : {
                     evaluations: [
                       {
@@ -108,6 +115,7 @@ function construct(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   created.length = 0;
   calls.length = 0;
+  coarseRelevant = true;
 });
 
 describe('MathStandardsAlignmentEvaluator — contract bindings', () => {
@@ -187,5 +195,48 @@ describe('MathStandardsAlignmentEvaluator — contract bindings', () => {
     expect(result.totalCount).toBe(1);
     expect(result.alignedCount).toBe(1);
     expect(result.learningComponents[0].description).toBe('Decompose rectilinear figures');
+  });
+});
+
+describe('a failed learning-component prefetch is reported, not silently zero', () => {
+  it('carries the error on a coarse-filtered result', async () => {
+    // `totalCount` falls back to 0 when the prefetch fails, which reads exactly like a
+    // standard that has no learning components. The error is what tells the two apart —
+    // the field already means "0 because nothing was measured, not because nothing
+    // aligned".
+    const failing = {
+      getLearningComponentsByCode: vi.fn().mockRejectedValue(new Error('KG unavailable')),
+      getStandardInfo: vi.fn().mockResolvedValue({
+        uuid: 'standard-uuid',
+        statementCode: '3.MD.C.7.d',
+        normalizedCode: '3.MD.C.7.D',
+        description: 'Recognize area as additive.',
+      }),
+    } as unknown as KnowledgeGraphClient;
+
+    const evaluator = new MathStandardsAlignmentEvaluator({
+      anthropicApiKey: 'k',
+      learningCommonsApiKey: 'k',
+      telemetry: false,
+      _kgClient: failing,
+    });
+
+    // Filtered out, so the standard is never evaluated: the only remaining source of an
+    // error on this result is the prefetch. With the standard marked relevant the
+    // evaluation path fails too, and this test passed with the fix reverted.
+    coarseRelevant = false;
+
+    const [item] = await evaluator.evaluateItems(
+      [{ question: 'What is 12 + 7?', statementCodes: ['3.MD.C.7.d'] }],
+      Jurisdiction.MultiState,
+      { useCoarseFilter: true },
+    );
+
+    const [standard] = item.standards;
+    expect(standard.coarseFiltered, 'must reach the coarse-filtered branch').toBe(true);
+    expect(standard.totalCount).toBe(0);
+    expect(standard.error?.message, 'the failure must reach the caller').toContain(
+      'KG unavailable',
+    );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
@@ -560,9 +560,11 @@ describe('requirePreprocessing', () => {
   it('refuses an entry the contract does not declare', () => {
     // Read by id, so a contract that stops declaring it should fail at load rather than
     // silently skip the computation.
-    expect(() => requirePreprocessing({ preprocessing: [] }, 'fk_score')).toThrow(
-      /Preprocessing "fk_score" not found/,
-    );
-    expect(() => requirePreprocessing({}, 'fk_score')).toThrow(/not found/);
+    expect(() =>
+      requirePreprocessing({ evaluator: { name: 'Thing Evaluator' }, preprocessing: [] }, 'fk_score'),
+    ).toThrow(/Preprocessing "fk_score" not found in Thing Evaluator config.json/);
+
+    // Still legible when the contract carries no name.
+    expect(() => requirePreprocessing({}, 'fk_score')).toThrow(/not found in the config.json/);
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/multi-step.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   defineMultiStepEvaluator,
   requireConditionValues,
+  requirePreprocessing,
 } from '../../../src/evaluators/multi-step.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
 
@@ -546,5 +547,22 @@ describe('requireConditionValues', () => {
     expect(() =>
       requireConditionValues({ id: 'branch', condition: { input: 'grade_level', in: [] } }, 'X'),
     ).toThrow(/declares no condition.in/);
+  });
+});
+
+describe('requirePreprocessing', () => {
+  it('returns the entry a contract declares', () => {
+    const entry = { id: 'fk_score', condition: { input: 'grade_level', in: ['3'] } };
+
+    expect(requirePreprocessing({ preprocessing: [entry] }, 'fk_score')).toBe(entry);
+  });
+
+  it('refuses an entry the contract does not declare', () => {
+    // Read by id, so a contract that stops declaring it should fail at load rather than
+    // silently skip the computation.
+    expect(() => requirePreprocessing({ preprocessing: [] }, 'fk_score')).toThrow(
+      /Preprocessing "fk_score" not found/,
+    );
+    expect(() => requirePreprocessing({}, 'fk_score')).toThrow(/not found/);
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/vocabulary-complexity.test.ts
@@ -106,7 +106,9 @@ describe('VocabularyComplexityEvaluator - Evaluation Flow', () => {
       expect(result.result.reasoning).toContain('grade-appropriate vocabulary');
       expect(result.metadata).toBeDefined();
       expect(result.metadata.model).toBe('openai:gpt-4o-2024-11-20+openai:gpt-4.1-2025-04-14');
-      expect(result.metadata.processingTimeMs).toBeGreaterThan(0);
+      // Not > 0: with both providers mocked and this branch computing no readability
+      // score, the whole evaluation can finish inside one clock tick.
+      expect(result.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
       // Token usage is aggregated across both stages: background (100/50) + complexity (200/100)
       expect(result.metadata.tokenUsage.inputTokens).toBe(300);
       expect(result.metadata.tokenUsage.outputTokens).toBe(150);

--- a/sdks/typescript/tests/unit/prompts/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/prompts/vocabulary-complexity.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSystemPrompt,
+  getUserPrompt,
+} from '../../../src/prompts/vocabulary-complexity/index.js';
+
+/**
+ * vocabulary-complexity declares two mutually exclusive branches on grade, and a
+ * `flesch_kincaid_grade` preprocessing entry conditioned on the grades-3-4 one. Which
+ * branch a grade takes, and whether its prompt binds `{fk_score}`, are facts stated in
+ * `config.json` — these pin that the prompt layer reads them rather than restating them.
+ */
+
+const TEXT = 'Great whirling storms roar out of the oceans in many parts of the world.';
+const BACKGROUND = 'Students know that storms bring wind and rain.';
+
+describe('the branch follows the contract, not a hardcoded grade list', () => {
+  it('gives grades 3-4 a different system prompt from grades 5-12', () => {
+    // A single hardcoded branch — or a wrong one — collapses these to the same text.
+    expect(getSystemPrompt('3')).toBe(getSystemPrompt('4'));
+    expect(getSystemPrompt('7')).toBe(getSystemPrompt('12'));
+    expect(getSystemPrompt('3')).not.toBe(getSystemPrompt('7'));
+  });
+
+  it('gives grades 3-4 a different user template from grades 5-12', () => {
+    const younger = getUserPrompt(TEXT, '3', BACKGROUND, 4.2);
+    const older = getUserPrompt(TEXT, '7', BACKGROUND);
+
+    expect(younger).not.toBe(older);
+  });
+});
+
+describe('{fk_score} is bound only where the contract declares it', () => {
+  it('substitutes the score into the grades-3-4 prompt', () => {
+    const prompt = getUserPrompt(TEXT, '3', BACKGROUND, 4.2);
+
+    expect(prompt).toContain('4.2');
+    expect(prompt).not.toContain('{fk_score}');
+  });
+
+  it('renders the grades 5-12 prompt identically with or without a score', () => {
+    // The other-grades template declares no {fk_score}, so a score passed to it must make
+    // no difference — if it ever did, something is substituting a value the contract did
+    // not declare for that branch.
+    expect(getUserPrompt(TEXT, '7', BACKGROUND)).toBe(getUserPrompt(TEXT, '7', BACKGROUND, 9.9));
+  });
+
+  it('never leaks the string "undefined" into a prompt that binds the score', () => {
+    // Grade 3 binds it, so an absent score must not stringify. The evaluator cannot reach
+    // this combination, which is exactly why the guard needs its own test.
+    const prompt = getUserPrompt(TEXT, '3', BACKGROUND, undefined);
+
+    expect(prompt).not.toContain('undefined');
+  });
+});

--- a/sdks/typescript/tests/unit/prompts/vocabulary-complexity.test.ts
+++ b/sdks/typescript/tests/unit/prompts/vocabulary-complexity.test.ts
@@ -45,11 +45,12 @@ describe('{fk_score} is bound only where the contract declares it', () => {
     expect(getUserPrompt(TEXT, '7', BACKGROUND)).toBe(getUserPrompt(TEXT, '7', BACKGROUND, 9.9));
   });
 
-  it('never leaks the string "undefined" into a prompt that binds the score', () => {
-    // Grade 3 binds it, so an absent score must not stringify. The evaluator cannot reach
-    // this combination, which is exactly why the guard needs its own test.
-    const prompt = getUserPrompt(TEXT, '3', BACKGROUND, undefined);
-
-    expect(prompt).not.toContain('undefined');
+  it('refuses to render a binding grade without a score', () => {
+    // Both quiet outcomes are worse than throwing: `undefined` reaches the model as a
+    // word, and skipping leaves a literal `{fk_score}` for it to read as instruction. The
+    // evaluator cannot reach this combination, which is why the guard needs its own test.
+    expect(() => getUserPrompt(TEXT, '3', BACKGROUND, undefined)).toThrow(
+      /Grade 3 binds \{fk_score\}/,
+    );
   });
 });


### PR DESCRIPTION
Four independent findings from the code review. Items 2 and 7 follow in their own PRs; 6 and 8 are deferred.

## 1. A swallowed Knowledge Graph failure reported as real data

`math-standards-alignment.ts` prefetched learning components with `.catch(() => undefined)`. A miss then fell through to `totalCount: cached?.components.length ?? 0`, so a failed KG call reported **`0/0`** — indistinguishable from a standard that genuinely has no learning components.

The failure now travels on the result's `error`, which already means exactly this: *"alignedCount is 0 because nothing was measured, not because nothing aligned."* A warning is logged too. `totalCount` still reads 0, but a caller can now tell why.

## 3. The standards report's grade filter emptied the table

`standards-report.html` filtered and displayed `it.grade`; the formatter emits `gradeLevel`. Since `it.grade` was always `undefined`, selecting a grade filtered out **everything** rather than filtering. Three uses repointed.

Nothing caught it because the filter is browser JS in a template that no test executes. It is now asserted on the template text — no bare `it.grade`, `it.gradeLevel` present, and the formatter still emits that field — the same approach the evaluator-ordering check uses.

## 4. JSDoc that miscounted by 3×

`readability.ts` said *"see PREPROCESSING_GAPS … for the three evaluators that call this instead."* #237 migrated two of them: there is **one** caller and **one** gap entry. A stale pointer is worse than none, because it is the one people follow.

## 5. `vocabulary-complexity` ignored its own declared conditions — in three places

The contract declares `fk_score` conditional on grades 3-4, and the two complexity steps mutually exclusive on the same grades. The SDK restated that rule rather than reading it:

| location | was |
| --- | --- |
| evaluator | computed FK for every grade, including the 5-12 branch whose prompt does not bind it |
| `prompts/…/user.ts` | `studentGradeLevel === '3' \|\| === '4'` chose the template |
| `prompts/…/system.ts` | the same literal chose the system prompt |

All three now read the contract. `grep` for `=== '3'` in the evaluator or prompt layers returns nothing.

Also fixed: `getUserPrompt` called `fkLevel.toString()` unconditionally, so an absent score would have put the string `"undefined"` into any template carrying the token.

## Two tests I had to rewrite because they proved nothing

Worth recording, since both passed on the first attempt and neither could fail.

**The condition tests.** I first asserted the rendered prompt contained no `{fk_score}` and no `"undefined"`. Both hold whether or not the condition is honoured — the other-grades template never carried the token. Reverting all three fixes left 14/14 passing. They now assert what is observable: that the branch selection differs by grade, and that the grades 5-12 prompt renders identically with or without a score. Each fix reverted fails one.

**The prefetch test.** It asserted the coarse-filtered result carried the error — and passed with the fix reverted, because the coarse mock marked the standard *relevant*, so it reached the evaluation error path instead. The mock's verdict is now controllable and the test forces `relevant: false`, plus asserts `coarseFiltered === true` so it cannot silently drift back to the other branch.

## Validation

- `typecheck`, `lint`, `test:unit` (1129, up from 1121), `build`, `scripts/check.py`
- **Live: 10/10 across vocabulary-complexity and math**, the two evaluators changed
- Every fix confirmed load-bearing by reverting it: system-prompt branch → 1 fails; user template branch → 1; unguarded `fk_score` → 1; report grade field → 1; prefetch error → 1
- One unrelated flake seen once in a full run: `generate-schema.test.ts` spawns a subprocess and timed out at 6959ms under load, passing 38/38 in isolation. Not touched here.

## One test assertion loosened

`processingTimeMs > 0` in the vocabulary-complexity test began failing: with both providers mocked and the 5-12 branch no longer computing a readability score, the evaluation finishes inside one clock tick. It now asserts `>= 0`, with the reason recorded — a positive wall-clock on a fully mocked path was measuring that FK happened to take a millisecond, not anything about the product.
