### PR TITLE
test(sdk): cover the batch CLI's output and credential decisions

### DIFF
--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -460,11 +460,15 @@ async function main() {
  *
  * `main()` runs at module scope, so without this an `import` of this file — which the tests
  * need in order to reach anything in it — starts a batch run and blocks on the interactive
- * prompts. Compares resolved file URLs because `argv[1]` is a path and may be relative.
+ * prompts. Comparison is on resolved URLs because `argv[1]` may be a relative path.
+ *
+ * `node --entry-url` passes the entry point through as a URL rather than a path; running it
+ * through `pathToFileURL` would mangle it and leave the CLI doing nothing at all.
  */
 export function isEntryPoint(moduleUrl: string, argv1: string | undefined): boolean {
   if (argv1 === undefined) return false;
-  return moduleUrl === pathToFileURL(argv1).href;
+  const entryUrl = argv1.startsWith('file:') ? new URL(argv1).href : pathToFileURL(argv1).href;
+  return moduleUrl === entryUrl;
 }
 
 if (isEntryPoint(import.meta.url, process.argv[1])) {

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -152,7 +152,13 @@ export function resolveKeySource(
   return { kind: 'ask', reason: `Missing ${label}. Provide ${flag} or set ${envVar}` };
 }
 
-async function resolveKey(
+/**
+ * Resolve a credential, prompting for it when that is allowed and it is missing.
+ *
+ * The decision lives in `resolveKeySource`; this adds the three things that touch the
+ * outside world — reading `process.env`, asking, and exiting.
+ */
+export async function resolveKey(
   kind: KeyKind,
   fromFlag: string | undefined,
   interactive: boolean,
@@ -471,6 +477,4 @@ export function isEntryPoint(moduleUrl: string, argv1: string | undefined): bool
   return moduleUrl === entryUrl;
 }
 
-if (isEntryPoint(import.meta.url, process.argv[1])) {
-  main();
-}
+if (isEntryPoint(import.meta.url, process.argv[1])) main();

--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { pathToFileURL } from 'url';
 import prompts from 'prompts';
 import {
   BatchEvaluator,
@@ -22,7 +23,14 @@ import { parseArgs, resolveModel, MODEL_SHORTCODES } from './cli-args.js';
 
 // ---- Output directory validation ----
 
-function validateOutputDir(value: string): string | true {
+/**
+ * Whether the CLI can write its output to `value`, or why it cannot.
+ *
+ * Returns the reason rather than throwing or exiting, so the interactive prompt can show it
+ * and re-ask while `main` turns it into an exit code. A missing leaf directory is allowed
+ * because the CLI creates it; a missing parent is not, because it creates only one level.
+ */
+export function validateOutputDir(value: string): string | true {
   const trimmed = value.trim();
   if (!trimmed) return 'Output directory cannot be empty';
   const resolved = path.resolve(trimmed);
@@ -54,7 +62,13 @@ function validateOutputDir(value: string): string | true {
 
 // ---- Credentials ----
 
-const KEY_CONFIG: Record<KeyKind, { envVar: string; label: string; flag: string }> = {
+/**
+ * How each credential is named on the command line and in the environment.
+ *
+ * Keyed by `KeyKind`, so a provider added to that union without an entry here is a compile
+ * error rather than a runtime lookup returning undefined.
+ */
+export const KEY_CONFIG: Record<KeyKind, { envVar: string; label: string; flag: string }> = {
   [Provider.Google]: { envVar: 'GOOGLE_API_KEY', label: 'Google API Key', flag: '--google-api-key' },
   [Provider.OpenAI]: { envVar: 'OPENAI_API_KEY', label: 'OpenAI API Key', flag: '--openai-api-key' },
   [Provider.Anthropic]: { envVar: 'ANTHROPIC_API_KEY', label: 'Anthropic API Key', flag: '--anthropic-api-key' },
@@ -107,24 +121,53 @@ Evaluation:
 
 // ---- Interactive helpers ----
 
+/** Where a credential came from, or what to do about its absence. */
+export type KeySource =
+  | { kind: 'resolved'; key: string }
+  /** Absent but obtainable by asking; `reason` explains the alternative to asking. */
+  | { kind: 'ask'; reason: string }
+  /** Cannot be obtained at all — an explicitly empty flag is a mistake, not a prompt. */
+  | { kind: 'error'; reason: string };
+
+/**
+ * Decide where a credential comes from, without reading the environment or prompting.
+ *
+ * An empty flag is separated from an absent one on purpose: the caller meant to pass
+ * something, so prompting over it would hide their mistake.
+ */
+export function resolveKeySource(
+  kind: KeyKind,
+  fromFlag: string | undefined,
+  fromEnv: string | undefined,
+): KeySource {
+  const { envVar, label, flag } = KEY_CONFIG[kind];
+
+  if (fromFlag !== undefined) {
+    return fromFlag
+      ? { kind: 'resolved', key: fromFlag }
+      : { kind: 'error', reason: `${label} (${flag}) was provided but is empty` };
+  }
+  if (fromEnv) return { kind: 'resolved', key: fromEnv };
+
+  return { kind: 'ask', reason: `Missing ${label}. Provide ${flag} or set ${envVar}` };
+}
+
 async function resolveKey(
   kind: KeyKind,
   fromFlag: string | undefined,
   interactive: boolean,
 ): Promise<string> {
-  const { envVar, label, flag } = KEY_CONFIG[kind];
-  if (fromFlag !== undefined) {
-    if (!fromFlag) {
-      console.error(`❌ ${label} (${flag}) was provided but is empty`);
-      process.exit(1);
-    }
-    return fromFlag;
+  const { envVar, label } = KEY_CONFIG[kind];
+  const source = resolveKeySource(kind, fromFlag, process.env[envVar]);
+
+  if (source.kind === 'error') {
+    console.error(`❌ ${source.reason}`);
+    process.exit(1);
   }
-  const fromEnv = process.env[envVar];
-  if (fromEnv) return fromEnv;
+  if (source.kind === 'resolved') return source.key;
 
   if (!interactive) {
-    console.error(`❌ Missing ${label}. Provide ${flag} or set ${envVar} (running non-interactively).`);
+    console.error(`❌ ${source.reason} (running non-interactively).`);
     process.exit(1);
   }
 
@@ -412,4 +455,18 @@ async function main() {
   }
 }
 
-main();
+/**
+ * Whether this module is the process entry point rather than an import.
+ *
+ * `main()` runs at module scope, so without this an `import` of this file — which the tests
+ * need in order to reach anything in it — starts a batch run and blocks on the interactive
+ * prompts. Compares resolved file URLs because `argv[1]` is a path and may be relative.
+ */
+export function isEntryPoint(moduleUrl: string, argv1: string | undefined): boolean {
+  if (argv1 === undefined) return false;
+  return moduleUrl === pathToFileURL(argv1).href;
+}
+
+if (isEntryPoint(import.meta.url, process.argv[1])) {
+  main();
+}

--- a/sdks/typescript/tests/unit/batch/cli.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  validateOutputDir,
+  KEY_CONFIG,
+  resolveKeySource,
+  isEntryPoint,
+} from '../../../src/batch/cli.js';
+import { Provider } from '../../../src/batch/index.js';
+
+/**
+ * The CLI's decisions, exercised without running the CLI.
+ *
+ * `cli.ts` exported nothing and called `process.exit()` inline, so none of it could be
+ * imported — 415 lines of the thing partners actually run, with no coverage. These cover the
+ * parts that decide something: whether output can be written, and where a credential comes
+ * from. The prompting and the exiting stay in `main`, which is the part a test should not
+ * reach into.
+ */
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'lc-cli-test-'));
+});
+
+afterEach(() => {
+  // Restore write permission first, or the cleanup itself fails on the read-only case.
+  try {
+    chmodSync(workspace, 0o755);
+  } catch {
+    // Already gone or never restricted.
+  }
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('validateOutputDir', () => {
+  it('accepts a directory that exists and is writable', () => {
+    expect(validateOutputDir(workspace)).toBe(true);
+  });
+
+  it('accepts a directory that does not exist yet if its parent is writable', () => {
+    // The CLI creates the directory itself, so a missing leaf is fine.
+    expect(validateOutputDir(join(workspace, 'results'))).toBe(true);
+  });
+
+  it('rejects an empty or whitespace-only path', () => {
+    expect(validateOutputDir('')).toBe('Output directory cannot be empty');
+    expect(validateOutputDir('   ')).toBe('Output directory cannot be empty');
+  });
+
+  it('rejects a path that exists but is a file', () => {
+    const file = join(workspace, 'notadir.txt');
+    writeFileSync(file, '');
+
+    expect(validateOutputDir(file)).toMatch(/exists but is not a directory/);
+  });
+
+  it('rejects a path whose parent does not exist', () => {
+    // Two levels missing: the CLI creates one, not a chain.
+    expect(validateOutputDir(join(workspace, 'missing', 'deeper'))).toMatch(
+      /Parent directory does not exist/,
+    );
+  });
+
+  it('rejects a directory it cannot write to', () => {
+    const locked = join(workspace, 'locked');
+    mkdirSync(locked);
+    chmodSync(locked, 0o500);
+
+    const result = validateOutputDir(locked);
+
+    // Root ignores the permission bits, so only assert when the restriction took effect.
+    // Match the EACCES wording exactly rather than accepting any failure: the point is that a
+    // permission denial is reported as one, not as the generic `Cannot write` fallback.
+    if (result !== true) {
+      expect(result).toBe(`No write permission for directory: ${locked}`);
+    }
+
+    chmodSync(locked, 0o755);
+  });
+
+  it('leaves no test artefact behind on success', () => {
+    // It probes writability by creating and deleting a file; a leaked probe would end up in
+    // the user's results directory.
+    expect(validateOutputDir(workspace)).toBe(true);
+
+    expect(readdirSync(workspace)).toEqual([]);
+  });
+});
+
+describe('KEY_CONFIG', () => {
+  it('names an env var and a flag for every credential', () => {
+    // Keyed by KeyKind, so an added provider is a compile error — this catches an entry
+    // that exists but is half-filled.
+    for (const [kind, config] of Object.entries(KEY_CONFIG)) {
+      expect(config.envVar, `${kind} envVar`).toMatch(/^[A-Z][A-Z0-9_]+$/);
+      expect(config.flag, `${kind} flag`).toMatch(/^--[a-z-]+$/);
+      expect(config.label, `${kind} label`).toBeTruthy();
+    }
+  });
+
+  it('covers every provider plus the Learning Commons key', () => {
+    expect(Object.keys(KEY_CONFIG).sort()).toEqual(
+      [...Object.values(Provider), 'learning-commons'].sort(),
+    );
+  });
+});
+
+describe('resolveKeySource', () => {
+  it('prefers an explicit flag over the environment', () => {
+    expect(resolveKeySource(Provider.OpenAI, 'from-flag', 'from-env')).toEqual({
+      kind: 'resolved',
+      key: 'from-flag',
+    });
+  });
+
+  it('falls back to the environment when no flag is given', () => {
+    expect(resolveKeySource(Provider.Google, undefined, 'from-env')).toEqual({
+      kind: 'resolved',
+      key: 'from-env',
+    });
+  });
+
+  it('reports an empty flag as an error rather than asking', () => {
+    // The caller meant to pass something; prompting over it would hide the mistake.
+    const source = resolveKeySource(Provider.Anthropic, '', 'from-env');
+
+    expect(source.kind).toBe('error');
+    expect(source.kind === 'error' && source.reason).toMatch(
+      /Anthropic API Key \(--anthropic-api-key\) was provided but is empty/,
+    );
+  });
+
+  it('asks when the credential is absent, naming both alternatives', () => {
+    const source = resolveKeySource('learning-commons', undefined, undefined);
+
+    expect(source.kind).toBe('ask');
+    expect(source.kind === 'ask' && source.reason).toMatch(
+      /--learning-commons-api-key.*LEARNING_COMMONS_API_KEY/,
+    );
+  });
+
+  it('treats an empty environment variable as absent', () => {
+    // An exported-but-empty variable is a common shell accident and must not be sent as a key.
+    expect(resolveKeySource(Provider.OpenAI, undefined, '').kind).toBe('ask');
+  });
+});
+
+describe('isEntryPoint', () => {
+  // The installed shape: `evaluators-batch` is a bin symlink onto dist/batch/cli.js.
+  const installed = '/usr/local/lib/node_modules/@learning-commons/evaluators/dist/batch/cli.js';
+
+  it('is true when the module is what node was asked to run', () => {
+    expect(isEntryPoint(pathToFileURL(installed).href, installed)).toBe(true);
+  });
+
+  it('is true for a relative argv path pointing at the same file', () => {
+    // node resolves argv[1] against cwd, so the raw string need not match the URL textually.
+    const relative = './dist/batch/cli.js';
+    expect(isEntryPoint(pathToFileURL(relative).href, relative)).toBe(true);
+  });
+
+  it('is false when another entry point imported the module', () => {
+    // What happens in this very test file: the runner is argv[1], cli.js is just an import.
+    expect(isEntryPoint(pathToFileURL(installed).href, '/repo/node_modules/vitest/vitest.mjs')).toBe(
+      false,
+    );
+  });
+
+  it('is false when there is no entry point at all', () => {
+    // `node -e` and some embeddings leave argv[1] undefined.
+    expect(isEntryPoint(pathToFileURL(installed).href, undefined)).toBe(false);
+  });
+
+  it('does not match a file whose path merely shares a prefix', () => {
+    expect(isEntryPoint(pathToFileURL('/app/dist/batch/cli.js').href, '/app/dist/batch/cli.js.map'))
+      .toBe(false);
+  });
+});

--- a/sdks/typescript/tests/unit/batch/cli.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   chmodSync,
   mkdirSync,
@@ -14,8 +14,12 @@ import {
   validateOutputDir,
   KEY_CONFIG,
   resolveKeySource,
+  resolveKey,
   isEntryPoint,
 } from '../../../src/batch/cli.js';
+import prompts from 'prompts';
+
+vi.mock('prompts', () => ({ default: vi.fn() }));
 import { Provider } from '../../../src/batch/index.js';
 
 /**
@@ -197,5 +201,112 @@ describe('isEntryPoint', () => {
   it('does not match a file whose path merely shares a prefix', () => {
     expect(isEntryPoint(pathToFileURL('/app/dist/batch/cli.js').href, '/app/dist/batch/cli.js.map'))
       .toBe(false);
+  });
+});
+
+describe('resolveKey', () => {
+  /** Stands in for `process.exit`, which is otherwise fatal to the test run. */
+  class Exited extends Error {
+    constructor(readonly code: number | undefined) {
+      super(`exit ${code}`);
+    }
+  }
+
+  let errors: string[];
+  let logs: string[];
+
+  beforeEach(() => {
+    errors = [];
+    logs = [];
+    vi.mocked(prompts).mockReset();
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Exited(code as number | undefined);
+    });
+    vi.spyOn(console, 'error').mockImplementation((...args) => void errors.push(args.join(' ')));
+    vi.spyOn(console, 'log').mockImplementation((...args) => void logs.push(args.join(' ')));
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('returns the flag without reading the environment or asking', async () => {
+    process.env.OPENAI_API_KEY = 'from-env';
+
+    await expect(resolveKey(Provider.OpenAI, 'from-flag', true)).resolves.toBe('from-flag');
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('reads the environment when no flag is given', async () => {
+    process.env.OPENAI_API_KEY = 'from-env';
+
+    await expect(resolveKey(Provider.OpenAI, undefined, true)).resolves.toBe('from-env');
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 on an empty flag even when it could have asked', async () => {
+    await expect(resolveKey(Provider.OpenAI, '', true)).rejects.toThrow('exit 1');
+    expect(errors.join('\n')).toContain('was provided but is empty');
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 rather than hanging when it cannot ask', async () => {
+    // The -y path: a prompt here would block a CI job forever instead of failing it.
+    await expect(resolveKey(Provider.OpenAI, undefined, false)).rejects.toThrow('exit 1');
+    expect(errors.join('\n')).toContain('running non-interactively');
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  /** Answers under whatever name the prompt declares, so the two cannot drift apart. */
+  function answerPrompt(value: unknown) {
+    vi.mocked(prompts).mockImplementation(async (question) => {
+      const { name } = question as { name: string };
+      return { [name]: value };
+    });
+  }
+
+  it('asks for a missing credential and returns what was typed', async () => {
+    answerPrompt('typed-by-hand');
+
+    await expect(resolveKey(Provider.OpenAI, undefined, true)).resolves.toBe('typed-by-hand');
+  });
+
+  it('names the credential it is asking for', async () => {
+    answerPrompt('typed-by-hand');
+
+    await resolveKey(Provider.OpenAI, undefined, true);
+
+    // A bare `:` prompt gives no clue which of four keys is wanted.
+    expect(vi.mocked(prompts).mock.calls[0][0]).toMatchObject({ message: 'OpenAI API Key:' });
+  });
+
+  it('masks the credential while it is being typed', async () => {
+    answerPrompt('typed-by-hand');
+
+    await resolveKey(Provider.OpenAI, undefined, true);
+
+    // A visible API key ends up in screen shares and terminal scrollback.
+    expect(vi.mocked(prompts).mock.calls[0][0]).toMatchObject({ type: 'password' });
+  });
+
+  it('exits 0, not 1, when the user cancels the prompt', async () => {
+    // Ctrl-C is a choice, not a failure, and a non-zero exit would fail a wrapping script.
+    vi.mocked(prompts).mockResolvedValue({});
+
+    await expect(resolveKey(Provider.OpenAI, undefined, true)).rejects.toThrow('exit 0');
+    expect(logs.join('\n')).toContain('Cancelled.');
+  });
+
+  it('rejects an empty answer at the prompt', async () => {
+    answerPrompt('k');
+    await resolveKey(Provider.OpenAI, undefined, true);
+
+    const { validate } = vi.mocked(prompts).mock.calls[0][0] as unknown as {
+      validate: (v: string) => true | string;
+    };
+    expect(validate('')).toBe('OpenAI API Key is required');
+    expect(validate('k')).toBe(true);
   });
 });

--- a/sdks/typescript/tests/unit/batch/cli.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli.test.ts
@@ -178,6 +178,17 @@ describe('isEntryPoint', () => {
     );
   });
 
+  it('matches an entry point that is already a file URL', () => {
+    // `node --entry-url file:///…` puts the URL itself in argv[1]. Feeding that through
+    // pathToFileURL would mangle it, and the CLI would exit 0 having done nothing.
+    const url = pathToFileURL(installed).href;
+    expect(isEntryPoint(url, url)).toBe(true);
+  });
+
+  it('canonicalises a non-normalised file URL entry point', () => {
+    expect(isEntryPoint('file:///tmp/cli.js', 'file:/tmp/cli.js')).toBe(true);
+  });
+
   it('is false when there is no entry point at all', () => {
     // `node -e` and some embeddings leave argv[1] undefined.
     expect(isEntryPoint(pathToFileURL(installed).href, undefined)).toBe(false);


### PR DESCRIPTION
`src/batch/cli.ts` is what partners actually run, and it had **no test coverage at all** — because none of it could be imported. Nothing was exported, and `main()` ran at module scope.

## `main()` now only runs when the file is the entry point

This is the change that made the rest possible, and it fixed a real hazard rather than just a testing inconvenience: any `import` of `cli.ts` started a batch run and reached `process.exit()`. Removing the guard and re-running proves it — the suite reports `process.exit unexpectedly called with "1"` from `main`.

The predicate is separated out as `isEntryPoint(moduleUrl, argv1)` so it is testable, since a guard that never matches would leave `evaluators-batch` doing nothing at all, silently and with exit code 0. It handles both forms `argv[1]` takes: a path (possibly relative) and, under `node --entry-url`, a `file:` URL passed through verbatim. Both verified against the built CLI.

## Three decisions extracted from the prompt/exit machinery

None of these returned anything a caller could inspect, and `process.exit` was called inline, so none could be exercised.

| now | was |
| --- | --- |
| `validateOutputDir` exported unchanged | private |
| `resolveKeySource(kind, fromFlag, fromEnv)` → `resolved` / `ask` / `error` | the decision was interleaved with reading `process.env`, prompting, and exiting |
| `resolveKey` exported, now consuming that union | private |

Behaviour is unchanged, including the two distinctions worth keeping: an *explicitly empty* flag is an error rather than something to prompt over (the caller meant to pass something, so prompting would hide their mistake), and cancelling the prompt exits **0**, not 1, so a wrapping script does not read Ctrl-C as a failure.

## Validation

- `typecheck`, `lint`, `test:unit` (1161, +30), `build`, `scripts/check.py`
- `node dist/batch/cli.js --help` and `node --entry-url file://…/cli.js --help` both print usage
- Mutation testing on `cli.ts`: **96.23% on covered code**, 102 killed / 4 survived. The 318 uncovered mutants are `main`, `printHelp` and the other interactive selectors, which need a spawned process — out of scope here.
- Every test confirmed load-bearing by reverting what it guards: entry-point check → 2 fail; `file:` URL handling → 2; empty-flag-is-an-error → 1; empty-output-dir → 1

### The four surviving mutants

Two are real and deliberate, two are reporting artefacts:

- `if (code === 'EACCES')` → `if (true)`: killable only by producing `EROFS` or a generic write failure, which needs a read-only mount.
- The guard's *call site* → `if (false) main()`: unobservable from a unit test by construction, since observing it firing means running the CLI. Covered by the two `dist` invocations above instead.
- `startsWith('file:')` → `startsWith('')`: **not actually survived.** The mutation makes `new URL()` throw at import time, so no tests run at all and Stryker scores that as "Survived". Applied by hand it reports `TypeError: Invalid URL` and `no tests`.
- The write-probe's file content: equivalent mutant — the probe tests writability, not what it wrote.

## Two test weaknesses the mutation runs exposed

- The permission test matched `/No write permission|read-only|Cannot write/`, accepting any failure and leaving four mutants alive. It now matches the EACCES wording exactly: a permission denial should be reported as one, not as the generic fallback.
- The prompt mock returned `{ key: … }` regardless of what the prompt asked for, so `name: 'key'` could be mutated freely. It now answers under whatever name the prompt declares, which ties the two together, and the prompt's message is asserted — a bare `:` gives no clue which of four keys is wanted.
