### PR TITLE
feat(sdk)!: return the shared envelope from math standards alignment

### DIFF
--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -72,7 +72,7 @@ class StandardsRunner implements FamilyRunner {
 
   async runTask(row: FamilyRow, _memberId?: string): Promise<TaskOutcome> {
     const jurisdiction = resolveJurisdiction(row.columns.jurisdiction);
-    const result = await this.evaluator.evaluate({
+    const { result } = await this.evaluator.evaluate({
       question: row.columns.question,
       statementCode: row.columns.statementCode,
       jurisdiction,

--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -19,6 +19,7 @@ import type { StageDetail } from '../../../telemetry/index.js';
 import CONFIG from '../../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/academic-standards-alignment/mathematics/math-standards-alignment/input_schema.json';
 import { validateInputs, type InputsOf } from '../../inputs.js';
+import type { EvaluationResult } from '../../../schemas/outputs.js';
 import { declaredCredentials } from '../../credentials.js';
 
 const EVALUATOR_ID = CONFIG.evaluator.id;
@@ -234,7 +235,9 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   // evaluate — single question × single standard (the primitive)
   // -------------------------------------------------------------------------
 
-  async evaluate(input: MathStandardsAlignmentInput): Promise<StandardAlignmentResult> {
+  async evaluate(
+    input: MathStandardsAlignmentInput,
+  ): Promise<EvaluationResult<StandardAlignmentResult>> {
     validateInputs(input, INPUT_SCHEMA);
     return this._evaluateCore(input.question, input.statementCode, input.jurisdiction);
   }
@@ -373,7 +376,8 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
             }
             let result: StandardAlignmentResult;
             try {
-              result = await bankLimit(() => this._evaluateCore(item.question, code, jurisdiction));
+              result = (await bankLimit(() => this._evaluateCore(item.question, code, jurisdiction)))
+                .result;
             } catch (err) {
               result = {
                 statementCode: code,
@@ -489,11 +493,33 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
   // Private helpers
   // -------------------------------------------------------------------------
 
+  /**
+   * Wrap a payload in the shared envelope.
+   *
+   * `model` is the configured detail model even when no call was made — a standard with no
+   * learning components resolves without one — and `tokenUsage` of zero is what says so.
+   */
+  private envelope(
+    result: StandardAlignmentResult,
+    startTime: number,
+    usage?: { inputTokens: number; outputTokens: number },
+  ): EvaluationResult<StandardAlignmentResult> {
+    return {
+      evaluator: EVALUATOR_ID,
+      result,
+      metadata: {
+        model: this.detailProvider.label,
+        processingTimeMs: Date.now() - startTime,
+        tokenUsage: usage ?? { inputTokens: 0, outputTokens: 0 },
+      },
+    };
+  }
+
   private async _evaluateCore(
     question: string,
     statementCode: string,
     jurisdiction: Jurisdiction,
-  ): Promise<StandardAlignmentResult> {
+  ): Promise<EvaluationResult<StandardAlignmentResult>> {
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
@@ -517,7 +543,10 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       }
 
       if (components.length === 0) {
-        return { statementCode, learningComponents: [], alignedCount: 0, totalCount: 0 };
+        return this.envelope(
+          { statementCode, learningComponents: [], alignedCount: 0, totalCount: 0 },
+          startTime,
+        );
       }
 
       // Include the KG identifier in brackets so the model can echo it back,
@@ -602,7 +631,11 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         inputText: question,
       }).catch(() => undefined);
 
-      return { statementCode, learningComponents, alignedCount, totalCount: components.length };
+      return this.envelope(
+        { statementCode, learningComponents, alignedCount, totalCount: components.length },
+        startTime,
+        { inputTokens: tokenUsage.input_tokens, outputTokens: tokenUsage.output_tokens },
+      );
     } catch (error) {
       const latencyMs = Date.now() - startTime;
 
@@ -706,6 +739,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 export async function evaluateMathStandardsAlignment(
   input: MathStandardsAlignmentInput,
   config: MathStandardsAlignmentEvaluatorConfig,
-): Promise<StandardAlignmentResult> {
+): Promise<EvaluationResult<StandardAlignmentResult>> {
   return new MathStandardsAlignmentEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/tests/integration/math-standards-alignment-cases.integration.test.ts
+++ b/sdks/typescript/tests/integration/math-standards-alignment-cases.integration.test.ts
@@ -98,13 +98,21 @@ describeIntegration('MathStandardsAlignmentEvaluator - Integration', () => {
         learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY!,
       });
 
-      // `evaluate()` returns the payload directly rather than the `{ evaluator, result,
-      // metadata }` envelope the other evaluators return.
-      const result = await evaluator.evaluate({
+      const evaluation = await evaluator.evaluate({
         question: testCase.question,
         statementCode: testCase.statementCode,
         jurisdiction: Jurisdiction.MultiState,
       });
+      const { result } = evaluation;
+
+      expect(evaluation.evaluator).toBe(MathStandardsAlignmentEvaluator.metadata.id);
+      expect(evaluation.metadata.model).toMatch(/^anthropic:/);
+      expect(evaluation.metadata.processingTimeMs).toBeGreaterThan(0);
+      expect(evaluation.metadata.processingTimeMs).toBeLessThan(10 * 60_000);
+      // A live call consumes tokens, so a zero here means the envelope is reporting a
+      // constant rather than what the run actually cost.
+      expect(evaluation.metadata.tokenUsage.inputTokens).toBeGreaterThan(0);
+      expect(evaluation.metadata.tokenUsage.outputTokens).toBeGreaterThan(0);
 
       console.log(`\n  ${testCase.id}: ${result.alignedCount}/${result.totalCount} aligned`);
       for (const lc of result.learningComponents) {

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -79,7 +79,7 @@ describe('STANDARDS_FAMILY.createRunner — provider-key forwarding', () => {
 });
 
 describe('STANDARDS_FAMILY.runTask', () => {
-  /** What `evaluate()` resolves to: the payload inside the shared envelope. */
+  /** A full `evaluate()` envelope, which is what the runner now has to unwrap. */
   const ALIGNMENT = {
     evaluator: 'math-standards-alignment',
     result: {

--- a/sdks/typescript/tests/unit/batch/standards-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/standards-family.test.ts
@@ -79,14 +79,23 @@ describe('STANDARDS_FAMILY.createRunner — provider-key forwarding', () => {
 });
 
 describe('STANDARDS_FAMILY.runTask', () => {
+  /** What `evaluate()` resolves to: the payload inside the shared envelope. */
   const ALIGNMENT = {
-    statementCode: '3.MD.C.7.d',
-    learningComponents: [
-      { identifier: 'lc-1', description: 'a', reasoning: 'r', aligned: true, feedback: '' },
-      { identifier: 'lc-2', description: 'b', reasoning: 'r', aligned: false, feedback: 'revise' },
-    ],
-    alignedCount: 1,
-    totalCount: 2,
+    evaluator: 'math-standards-alignment',
+    result: {
+      statementCode: '3.MD.C.7.d',
+      learningComponents: [
+        { identifier: 'lc-1', description: 'a', reasoning: 'r', aligned: true, feedback: '' },
+        { identifier: 'lc-2', description: 'b', reasoning: 'r', aligned: false, feedback: 'revise' },
+      ],
+      alignedCount: 1,
+      totalCount: 2,
+    },
+    metadata: {
+      model: 'anthropic:claude-x',
+      processingTimeMs: 1,
+      tokenUsage: { inputTokens: 10, outputTokens: 20 },
+    },
   };
 
   /** The runner builds a real evaluator; swap it for a stub so no network is needed. */
@@ -120,6 +129,16 @@ describe('STANDARDS_FAMILY.runTask', () => {
       alignedCount: 1,
       totalCount: 2,
     });
+    // The payload is written verbatim to results.json, so spreading the envelope instead of
+    // its `result` would add `evaluator`/`metadata` columns to a partner-facing artefact.
+    expect(Object.keys(outcome.payload as object).sort()).toEqual([
+      'alignedCount',
+      'jurisdiction',
+      'learningComponents',
+      'question',
+      'statementCode',
+      'totalCount',
+    ]);
   });
 
   it('defaults an absent jurisdiction to Multi-State', async () => {

--- a/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
@@ -185,7 +185,7 @@ describe('MathStandardsAlignmentEvaluator — contract bindings', () => {
   });
 
   it('reports the standard it was asked about', async () => {
-    const result = await construct().evaluate({
+    const { result } = await construct().evaluate({
       question: 'A playground is shaped like an L. What is its area?',
       statementCode: '3.MD.C.7.d',
       jurisdiction: Jurisdiction.MultiState,

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -154,7 +154,7 @@ describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
 describe('MathStandardsAlignmentEvaluator - evaluate', () => {
   it('returns StandardAlignmentResult with correct shape on happy path', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
+    const { result } = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(result.statementCode).toBe(STATEMENT_CODE);
     expect(result.totalCount).toBe(2);
@@ -166,6 +166,34 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       expect(typeof lc.reasoning).toBe('string');
       expect(typeof lc.feedback).toBe('string');
     }
+  });
+
+  it('wraps the payload in the shared envelope', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
+
+    const evaluation = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
+
+    expect(evaluation.evaluator).toBe(MathStandardsAlignmentEvaluator.metadata.id);
+    // The provider that actually ran, so an override is reflected rather than a constant.
+    expect(evaluation.metadata.model).toBe(mockProvider.label);
+    expect(evaluation.metadata.tokenUsage).toEqual({ inputTokens: 300, outputTokens: 150 });
+    // Bounded above as well: a duration built by adding the epoch instead of subtracting it
+    // is still >= 0, and reads as ~3.5e12 ms.
+    expect(evaluation.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(evaluation.metadata.processingTimeMs).toBeLessThan(60_000);
+    expect(Object.keys(evaluation).sort()).toEqual(['evaluator', 'metadata', 'result']);
+  });
+
+  it('reports zero tokens when it resolves without calling a model', async () => {
+    // A standard with no learning components returns early. Reporting the mock's token
+    // counts here would attribute a cost to a call that never happened.
+    const emptyRepo = makeMockKgClient({ getLearningComponentsByCode: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', components: [] }) });
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: emptyRepo }));
+
+    const { metadata } = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
+
+    expect(metadata.tokenUsage).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(metadata.model).toBe(mockProvider.label);
   });
 
   it('passes jurisdiction and academicSubject to getLearningComponentsByCode', async () => {
@@ -183,7 +211,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
     const emptyRepo = makeMockKgClient({ getLearningComponentsByCode: vi.fn().mockResolvedValue({ uuid: 'uuid-abc', components: [] }) });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: emptyRepo }));
 
-    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
+    const { result } = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
     expect(result.learningComponents).toHaveLength(0);
     expect(result.alignedCount).toBe(0);
@@ -227,7 +255,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       data: { evaluations: [{ lc_id: 'lc-k01', reasoning: 'ok', answer: 'Yes', feedback: '' }] },
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: kRepo }));
-    const result = await evaluator.evaluate({ question: QUESTION, statementCode: 'K.CC.A.1', jurisdiction: JURISDICTION });
+    const { result } = await evaluator.evaluate({ question: QUESTION, statementCode: 'K.CC.A.1', jurisdiction: JURISDICTION });
     expect(result.statementCode).toBe('K.CC.A.1');
   });
 
@@ -239,7 +267,7 @@ describe('MathStandardsAlignmentEvaluator - evaluate', () => {
       },
     });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
-    const result = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
+    const { result } = await evaluator.evaluate({ question: QUESTION, statementCode: STATEMENT_CODE, jurisdiction: JURISDICTION });
     expect(result.alignedCount).toBe(1);
     expect(result.totalCount).toBe(2);
     expect(result.learningComponents[1].aligned).toBe(false);


### PR DESCRIPTION
`math-standards-alignment` was the only evaluator whose `evaluate()` returned its payload bare instead of the `{ evaluator, result, metadata }` envelope every other evaluator returns. A caller could not ask which model ran, how long it took, or what it cost — and generic code over evaluators had to special-case math.

**Breaking:** `evaluate()` and `evaluateMathStandardsAlignment()` now resolve to `EvaluationResult<StandardAlignmentResult>`. Callers reach the old value at `.result`.

## What changed

- One construction site, `envelope()`, so the two return paths cannot drift. `model` is the provider that actually ran, so a `modelOverride` is reflected rather than a contract constant.
- A standard with **no learning components** resolves without calling a model. It reports `tokenUsage` of zero — reporting the configured model with a zero cost is the honest description of that path.
- The bulk paths (`evaluateItems`, `evaluateByGradeLevel`) still return per-standard payloads. One call fans out over many question × standard pairs, so there is no single model or duration to describe; they unwrap `.result` internally.
- The batch standards family spreads `result`, not the envelope. Its payload is written verbatim to `results.json`, so leaking `evaluator`/`metadata` would add columns to a partner-facing artefact — now asserted on the exact key set, which fails if the envelope is spread instead.

## Validation

- `typecheck`, `lint`, `test:unit` (1163, +2), `build`, `scripts/check.py`
- **Live: 4/4** across both math integration files (~35s of real Knowledge Graph + Anthropic calls). The case-driven file now asserts the envelope against a live call: the evaluator id, an `anthropic:` model, non-zero tokens in both directions, and a bounded duration.
- Every assertion confirmed load-bearing by reverting what it guards: constant zero tokens → 1 fails; the no-model path claiming tokens → 1; spreading the envelope into the batch payload → 1
- Mutation testing on both changed files. One survivor was on the new code and is now killed: `Date.now() - startTime` → `+` passed a bare `>= 0`, since a duration built by adding the epoch is still non-negative. Both duration assertions are now bounded above.

Two survivors remain around the changed lines, both pre-existing and both telemetry-only (`stageDetails` seeded with an element; `metadata: { stage_details }` emptied). Neither is reachable from this change — telemetry payload assertions are a separate gap.

## Not included

Math stays in `RESULT_NAME_GAPS`: that entry is about export naming (`StandardAlignmentResult`, not `MathStandardsAlignmentResult`) and is untouched here. It also stays out of the conformance `INVOKE` map, which would need a Knowledge Graph mock the other 15 evaluators do not use.

`demos/typescript` consumes the published SDK and will need `.result` when it next moves versions.
