### PR TITLE
test(sdk): cover the logger's level gating and the telemetry client's failure paths

### DIFF
--- a/sdks/typescript/tests/unit/logger.test.ts
+++ b/sdks/typescript/tests/unit/logger.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createLogger, formatError, LogLevel, type Logger } from '../../src/logger.js';
+
+/**
+ * The logger had no tests: only `warn` and `error` were exercised, incidentally, by
+ * evaluators that happened to log. Level gating is the whole point of the module — a broken
+ * comparison either floods a partner's stdout or silences a warning they needed.
+ */
+
+let calls: Record<'debug' | 'info' | 'warn' | 'error', string[]>;
+
+beforeEach(() => {
+  calls = { debug: [], info: [], warn: [], error: [] };
+  for (const method of ['debug', 'info', 'warn', 'error'] as const) {
+    vi.spyOn(console, method).mockImplementation((msg) => void calls[method].push(String(msg)));
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createLogger level gating', () => {
+  it('emits everything at DEBUG', () => {
+    const logger = createLogger(undefined, LogLevel.DEBUG);
+
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(calls.debug).toEqual(['[DEBUG] d']);
+    expect(calls.info).toEqual(['[INFO] i']);
+    expect(calls.warn).toEqual(['[WARN] w']);
+    expect(calls.error).toEqual(['[ERROR] e']);
+  });
+
+  it('drops messages below the configured level', () => {
+    const logger = createLogger(undefined, LogLevel.WARN);
+
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+
+    expect(calls.debug).toEqual([]);
+    expect(calls.info).toEqual([]);
+    expect(calls.warn).toEqual(['[WARN] w']);
+  });
+
+  it('defaults to WARN', () => {
+    // The default matters: it is what every partner gets who never sets `logLevel`.
+    const logger = createLogger();
+
+    logger.info('i');
+    logger.warn('w');
+
+    expect(calls.info).toEqual([]);
+    expect(calls.warn).toEqual(['[WARN] w']);
+  });
+
+  it.each([
+    [LogLevel.DEBUG, 'debug'] as const,
+    [LogLevel.INFO, 'info'] as const,
+    [LogLevel.WARN, 'warn'] as const,
+    [LogLevel.ERROR, 'error'] as const,
+  ])('emits %s at exactly its own level', (level, method) => {
+    // The boundary, not just either side of it: each gate is `<=`, and a `<` would make the
+    // level you asked for the first one silently dropped.
+    createLogger(undefined, level)[method]('m');
+
+    expect(calls[method]).toHaveLength(1);
+  });
+
+  it('suppresses warnings but not errors at ERROR', () => {
+    // The highest level that still logs. `error`'s own gate can never be false here, since
+    // SILENT is handled by returning a different logger entirely.
+    const logger = createLogger(undefined, LogLevel.ERROR);
+
+    logger.warn('w');
+    logger.error('e');
+
+    expect(calls.warn).toEqual([]);
+    expect(calls.error).toEqual(['[ERROR] e']);
+  });
+
+  it('emits nothing at SILENT, including errors', () => {
+    const logger = createLogger(undefined, LogLevel.SILENT);
+
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(Object.values(calls).flat()).toEqual([]);
+  });
+
+  it.each(['debug', 'info', 'warn', 'error'] as const)(
+    '%s passes context through and substitutes empty string when absent',
+    (method) => {
+      // Logging `undefined` as the second argument prints the word "undefined" in most
+      // consoles, which reads as a value the caller supplied.
+      const logger = createLogger(undefined, LogLevel.DEBUG);
+      const spy = vi.mocked(console[method]);
+
+      logger[method]('with', { evaluator: 'x' });
+      logger[method]('without');
+
+      expect(spy.mock.calls[0][1]).toEqual({ evaluator: 'x' });
+      expect(spy.mock.calls[1][1]).toBe('');
+    },
+  );
+});
+
+describe('createLogger with a custom logger', () => {
+  function spyLogger(): Logger {
+    return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  }
+
+  it('returns the custom logger unwrapped', () => {
+    const custom = spyLogger();
+
+    expect(createLogger(custom)).toBe(custom);
+  });
+
+  it('does not apply level gating to a custom logger', () => {
+    // The level belongs to the console implementation. A partner passing their own logger
+    // filters on their side, so swallowing calls here would hide records they expected.
+    const custom = spyLogger();
+
+    createLogger(custom, LogLevel.SILENT).error('e');
+
+    expect(custom.error).toHaveBeenCalledWith('e');
+    expect(calls.error).toEqual([]);
+  });
+});
+
+describe('formatError', () => {
+  it('names the error type alongside the message', () => {
+    expect(formatError(new TypeError('bad input'))).toBe('TypeError: bad input');
+  });
+
+  it('keeps a custom error name', () => {
+    const error = new Error('boom');
+    error.name = 'RateLimitError';
+
+    expect(formatError(error)).toBe('RateLimitError: boom');
+  });
+
+  it('keeps the colon when the message is empty', () => {
+    // `String(error)` drops it, so this is what distinguishes formatting an Error from
+    // stringifying one — for every other Error the two happen to agree.
+    expect(formatError(new Error(''))).toBe('Error: ');
+  });
+
+  it('stringifies what was thrown when it is not an Error', () => {
+    // Providers throw strings and plain objects; the logger must not crash on them.
+    expect(formatError('just a string')).toBe('just a string');
+    expect(formatError(undefined)).toBe('undefined');
+    expect(formatError(null)).toBe('null');
+    expect(formatError(404)).toBe('404');
+  });
+});

--- a/sdks/typescript/tests/unit/telemetry/client.test.ts
+++ b/sdks/typescript/tests/unit/telemetry/client.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TelemetryClient } from '../../../src/telemetry/client.js';
+import type { TelemetryEvent } from '../../../src/telemetry/types.js';
+import type { Logger } from '../../../src/logger.js';
+
+/**
+ * The telemetry client had no tests of its own — every evaluator suite mocks it away. Its
+ * whole contract is negative: it must never throw into an evaluation, never block one, and
+ * never log noise for failures that are expected. None of that was covered.
+ */
+
+const EVENT = { event: 'evaluation_completed', status: 'success' } as unknown as TelemetryEvent;
+
+let logger: Logger;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return new TelemetryClient({
+    enabled: true,
+    endpoint: 'https://telemetry.example/v1/events',
+    clientId: 'client-abc',
+    logger,
+    ...overrides,
+  } as never);
+}
+
+beforeEach(() => {
+  logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('TelemetryClient.send', () => {
+  it('posts the event as JSON to the configured endpoint', async () => {
+    await makeClient().send(EVENT);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // A successful send is silent; warning here would fire on every evaluation.
+    expect(logger.warn).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://telemetry.example/v1/events');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual(EVENT);
+  });
+
+  it('identifies the client and declares the content type', async () => {
+    await makeClient().send(EVENT);
+
+    expect(fetchMock.mock.calls[0][1].headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Client-ID': 'client-abc',
+    });
+  });
+
+  it('sends no API key header when none is configured', async () => {
+    // Identified telemetry is opt-in, so an absent key must stay absent rather than
+    // becoming an empty or "undefined" header.
+    await makeClient().send(EVENT);
+
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('X-API-Key');
+  });
+
+  it('attaches the API key when one is configured', async () => {
+    await makeClient({ learningCommonsApiKey: 'partner-key' }).send(EVENT);
+
+    expect(fetchMock.mock.calls[0][1].headers['X-API-Key']).toBe('partner-key');
+  });
+
+  it('gives up rather than hanging on a slow network', async () => {
+    // Without a signal a stalled collector would keep an evaluation's process alive.
+    await makeClient().send(EVENT);
+
+    expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('does nothing at all when telemetry is disabled', async () => {
+    await makeClient({ enabled: false }).send(EVENT);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns with the status when the collector rejects the event', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' });
+
+    await makeClient().send(EVENT);
+
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('503 Service Unavailable');
+  });
+
+  it('resolves rather than throwing when the request fails outright', async () => {
+    // This is the whole point of the module: telemetry must never fail an evaluation.
+    fetchMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+
+    await expect(makeClient().send(EVENT)).resolves.toBeUndefined();
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toContain('getaddrinfo ENOTFOUND');
+  });
+
+  it.each(['TimeoutError', 'AbortError'])('stays quiet about an expected %s', async (name) => {
+    // A slow network is not a defect worth a line in a partner's logs on every evaluation.
+    const error = new Error('aborted');
+    error.name = name;
+    fetchMock.mockRejectedValue(error);
+
+    await expect(makeClient().send(EVENT)).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejection that is not an Error at all', async () => {
+    // `fetch` polyfills and mocks have been known to reject with strings.
+    fetchMock.mockRejectedValue('not an error object');
+
+    await expect(makeClient().send(EVENT)).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/typescript/tests/unit/telemetry/client.test.ts
+++ b/sdks/typescript/tests/unit/telemetry/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TelemetryClient } from '../../../src/telemetry/client.js';
-import type { TelemetryEvent } from '../../../src/telemetry/types.js';
+import type { TelemetryConfig, TelemetryEvent } from '../../../src/telemetry/types.js';
 import type { Logger } from '../../../src/logger.js';
 
 /**
@@ -9,19 +9,28 @@ import type { Logger } from '../../../src/logger.js';
  * never log noise for failures that are expected. None of that was covered.
  */
 
-const EVENT = { event: 'evaluation_completed', status: 'success' } as unknown as TelemetryEvent;
+/** A complete event, so a required field added to the type shows up here as a build error. */
+const EVENT: TelemetryEvent = {
+  timestamp: '2026-08-29T00:00:00.000Z',
+  sdk_version: '0.8.0',
+  evaluator_type: 'student_facing_text.ela_reading.vocabulary_complexity',
+  status: 'success',
+  latency_ms: 1234,
+  text_length_chars: 512,
+  provider: 'google:gemini-2.5-flash',
+};
 
 let logger: Logger;
 let fetchMock: ReturnType<typeof vi.fn>;
 
-function makeClient(overrides: Record<string, unknown> = {}) {
+function makeClient(overrides: Partial<TelemetryConfig> = {}): TelemetryClient {
   return new TelemetryClient({
     enabled: true,
     endpoint: 'https://telemetry.example/v1/events',
     clientId: 'client-abc',
     logger,
     ...overrides,
-  } as never);
+  });
 }
 
 beforeEach(() => {
@@ -45,7 +54,10 @@ describe('TelemetryClient.send', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://telemetry.example/v1/events');
     expect(init.method).toBe('POST');
+    // Byte-for-byte: the collector's schema is the wire format, so a field silently
+    // dropped or renamed in transit is the failure this catches.
     expect(JSON.parse(init.body)).toEqual(EVENT);
+    expect(init.body).toBe(JSON.stringify(EVENT));
   });
 
   it('identifies the client and declares the content type', async () => {


### PR DESCRIPTION
Two modules every evaluation runs through had almost no coverage of their own: `telemetry/client.ts` (64% stmts / 33% branch) and `logger.ts` (74% / 50%). Neither had a test file — the client is mocked away by every evaluator suite, and the logger was only exercised incidentally by evaluators that happened to warn.

Tests only. No source changes.

| | before | after |
| --- | --- | --- |
| `telemetry/client.ts` | 64% stmts / 33% branch | **100% / 100%** |
| `logger.ts` | 74% / 50% | **100% / 96%** |

## What is now pinned

The telemetry client's contract is entirely negative, and none of it was covered: it must never throw into an evaluation, never block one, and never log noise for failures that are expected. Covered now — a rejected request resolves rather than throwing; `TimeoutError`/`AbortError` are silent while a real failure warns; a non-`Error` rejection is swallowed; `enabled: false` makes no request at all; the API key header is present only when a key is configured, since identified telemetry is opt-in.

For the logger, level gating **at each boundary** rather than either side of it, `formatError` on non-`Error` throws, and that a custom logger is returned unwrapped and un-gated — the level belongs to the console implementation, so filtering a partner's own logger would drop records they expected.

## Validation

- `typecheck`, `lint`, `test:unit` (1193, +30), `build`, `scripts/check.py`
- Mutation testing: `client.ts` **100%** (35/35 killed), `logger.ts` 89%, combined **96.74%**

### Two gaps the mutation run found, both real

- `logger.ts` gates are `<=`, and my first tests only checked either side of each boundary, so `<=` → `<` survived — the level you asked for would have become the first one silently dropped. Now asserted at exactly each level.
- `formatError`'s `instanceof Error` branch survived being deleted, because `String(error)` and `` `${name}: ${message}` `` agree for every ordinary Error. They diverge only on an empty message, where `String` drops the colon. That case now pins the branch.

### Three surviving mutants, all equivalent

Worth recording because they say something about the source, not the tests:

- `if (this.level <= LogLevel.ERROR)` → `if (true)`: `createLogger` returns a different logger for `SILENT`, so `ERROR` is the highest level `ConsoleLogger` ever sees and the gate cannot be false.
- Deleting the `SILENT` → `SilentLogger` branch, and inverting its condition: both fall through to `new ConsoleLogger(SILENT)`, whose four gates are then all false. It logs nothing either way.

That last pair means `SilentLogger` and its branch are redundant — `ConsoleLogger(SILENT)` is already silent. Left alone here since this PR is tests only.
