### PR TITLE
fix(sdk): publish supportedGrades from the contract that declares it

### DIFF
--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -179,7 +179,13 @@ export interface EvaluatorMetadata {
   readonly name: string;
   /** Brief description of what the evaluator does */
   readonly description: string;
-  /** Supported grade levels (e.g., ['3', '4', '5', ...]) */
+  /**
+   * The grades this evaluator is built for, as its contract declares them.
+   *
+   * Not a validation set, and not necessarily the grades you may pass: an evaluator that
+   * takes no grade at all still reports what it targets. Where a `grade_level` input
+   * exists, the accepted values are its schema enum, and that is what rejects a bad one.
+   */
   readonly supportedGrades: readonly string[];
   /**
    * Which output properties carry the verdict and its rationale, as the evaluator's

--- a/sdks/typescript/src/evaluators/multi-step.ts
+++ b/sdks/typescript/src/evaluators/multi-step.ts
@@ -39,6 +39,8 @@ export interface MultiStepContract extends CredentialDeclaringConfig {
     id_history: string[];
     name: string;
     description: string;
+    /** Required of every contract, so a config.json omitting it fails to compile here. */
+    supported_grades: string[];
   };
   steps: Array<{
     id: string;
@@ -256,7 +258,11 @@ export function defineMultiStepEvaluator<TInput extends Record<string, string>, 
     description: contract.evaluator.description,
     outcome: contract.outcome,
     requiredCredentials: declaredCredentials(contract),
-    supportedGrades: (inputSchema.properties.grade_level?.enum ?? []) as readonly string[],
+    // What the evaluator targets, which its contract states outright. Deriving it from the
+    // grade input instead published `[]` for every evaluator that takes no grade — the
+    // feedback family and Grade Level Appropriateness — asserting they target no grades.
+    // The accepted set is still the input enum, and `validateInputs` is what enforces it.
+    supportedGrades: contract.evaluator.supported_grades as readonly string[],
     defaultProviders: VENDORS as readonly Provider[],
   };
 

--- a/sdks/typescript/src/evaluators/single-step.ts
+++ b/sdks/typescript/src/evaluators/single-step.ts
@@ -25,6 +25,8 @@ export interface SingleStepContract extends CredentialDeclaringConfig {
     id_history: string[];
     name: string;
     description: string;
+    /** Required of every contract, so a config.json omitting it fails to compile here. */
+    supported_grades: string[];
   };
   steps: Array<{
     id: string;
@@ -147,7 +149,11 @@ export function defineSingleStepEvaluator<TInput extends Record<string, string>,
     description: contract.evaluator.description,
     outcome: contract.outcome,
     requiredCredentials: declaredCredentials(contract),
-    supportedGrades: (inputSchema.properties.grade_level?.enum ?? []) as readonly string[],
+    // What the evaluator targets, which its contract states outright. Deriving it from the
+    // grade input instead published `[]` for every evaluator that takes no grade — the
+    // feedback family and Grade Level Appropriateness — asserting they target no grades.
+    // The accepted set is still the input enum, and `validateInputs` is what enforces it.
+    supportedGrades: contract.evaluator.supported_grades as readonly string[],
     defaultProviders: [VENDOR] as const,
   };
 

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
@@ -19,8 +19,9 @@ export type GradeLevelAppropriatenessInput = InputsOf<typeof INPUT_SCHEMA>;
  * band reachable with scaffolding.
  *
  * Takes no grade level: unlike the complexity evaluators, which judge a text *against* a
- * grade, this one determines the grade. Its `input_schema` declares only `text`, so
- * `metadata.supportedGrades` is empty by derivation rather than by assertion.
+ * grade, this one determines the grade. Its `input_schema` declares only `text`, so there is
+ * no accepted grade set; `metadata.supportedGrades` reports the K-12 span of the bands it
+ * can return, which is what its contract declares.
  *
  * One model call, so the flow comes from {@link defineSingleStepEvaluator} and the model,
  * temperature and prompt inputs are read from `config.json`.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -95,7 +95,7 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
     description: CONFIG.evaluator.description,
     outcome: CONFIG.outcome,
     requiredCredentials: declaredCredentials(CONFIG),
-    supportedGrades: (INPUT_SCHEMA.properties.grade_level?.enum ?? []) as readonly string[],
+    supportedGrades: CONFIG.evaluator.supported_grades as readonly string[],
     defaultProviders: [Provider.Google, Provider.OpenAI] as const,
   };
 

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -4,7 +4,6 @@ import CONFIG from '../../../../../evals/student-facing-text/ela-reading/organiz
 import { OrganizationalStructureEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/organizational-structure.js';
 import { Provider } from '../../../src/evaluators/base.js';
 import type { LLMProvider } from '../../../src/providers/base.js';
-import INPUT_SCHEMA from '../../../../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json';
 
 const STEP = CONFIG.steps[0];
 
@@ -94,11 +93,11 @@ describe('OrganizationalStructureEvaluator - Metadata', () => {
     );
   });
 
-  // Bound to the contract, not a copy of it: the schema's enum is the declared
-  // set, so a change there must show up here rather than drifting silently.
-  it('derives supportedGrades from input_schema.json', () => {
+  // Bound to the contract, not a copy of it, so a change there must show up here rather
+  // than drifting silently.
+  it('derives supportedGrades from config.json', () => {
     expect(OrganizationalStructureEvaluator.metadata.supportedGrades).toEqual(
-      INPUT_SCHEMA.properties.grade_level.enum,
+      CONFIG.evaluator.supported_grades,
     );
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/single-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/single-step.test.ts
@@ -63,6 +63,10 @@ function contract(overrides: Record<string, unknown> = {}) {
       id_history: ['demo.area.old_thing'],
       name: 'Thing Evaluator',
       description: 'Demonstration contract.',
+      // Deliberately wider than the grade input's enum, which is what the factory used to
+      // publish: the two are allowed to differ for an evaluator that takes no grade, and
+      // this is the only way to tell which source the factory actually read.
+      supported_grades: ['3', '4', '5', '6'],
     },
     steps: [
       {
@@ -142,8 +146,10 @@ describe('defineSingleStepEvaluator reads its behaviour from the contract', () =
     expect(E.metadata.name).toBe('Thing Evaluator');
   });
 
-  it('takes supported grades from the input schema enum', () => {
-    expect(define().metadata.supportedGrades).toEqual(['3', '4', '5']);
+  it('takes supported grades from the contract, not the grade input', () => {
+    // The contract declares four grades and the input enum three, so this fails if the
+    // factory goes back to deriving the field from the input schema.
+    expect(define().metadata.supportedGrades).toEqual(['3', '4', '5', '6']);
   });
 
   it('takes the default provider from the declared step, not a hardcoded vendor', () => {

--- a/sdks/typescript/tests/unit/evaluators/single-step.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/single-step.test.ts
@@ -63,9 +63,10 @@ function contract(overrides: Record<string, unknown> = {}) {
       id_history: ['demo.area.old_thing'],
       name: 'Thing Evaluator',
       description: 'Demonstration contract.',
-      // Deliberately wider than the grade input's enum, which is what the factory used to
-      // publish: the two are allowed to differ for an evaluator that takes no grade, and
-      // this is the only way to tell which source the factory actually read.
+      // Deliberately wider than this contract's own grade enum, which is the only way to
+      // tell which of the two the factory read. A real contract may not do this — the
+      // conformance suite requires them to agree wherever both exist — but this one is
+      // synthetic and never reaches that check.
       supported_grades: ['3', '4', '5', '6'],
     },
     steps: [

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -150,12 +150,9 @@ const MODEL_GAPS = new Set<string>([
   // Empty: every evaluator constructs the model its contract declares.
 ]);
 
-/** Evaluators whose `supportedGrades` does not describe their declared inputs. */
+/** Evaluators whose `supportedGrades` does not match the grades their contract declares. */
 const GRADE_GAPS = new Set<string>([
-  // `supported_grades` here describes what `evaluateByGradeLevel` accepts — a bulk
-  // capability outside the one-to-one contract, whose shape is still open (Q-12).
-  // `evaluate()` itself takes no grade, and the input schema correctly declares none.
-  MATH_ID,
+  // Empty: every evaluator publishes the grades its contract declares.
 ]);
 
 
@@ -449,20 +446,34 @@ describe('identity matches the contract', () => {
 
 describe('supported grades match the contract', () => {
   it.each(cases)('$name', ({ E }) => {
-    const { inputSchema } = contractFor(E.metadata.id);
+    const { config } = contractFor(E.metadata.id);
 
-    // `supported_grades` states what the evaluator is built for; the accepted set is
-    // the grade input's own enum. Comparing against the enum is the whole point -- an
-    // evaluator taking no grade accepts none, and asserting that by hardcoding `[]`
-    // would just restate the assumption.
-    const accepted = (inputSchema.properties.grade_level?.enum as string[]) ?? [];
-
+    // What the evaluator targets, which the contract states outright rather than implying.
+    // The grade input's enum is a different question -- the set a caller may pass -- and it
+    // is absent for the evaluators that take no grade, which is why deriving this field
+    // from it published `[]` for eight of them.
     expectAgainstContract(
       GRADE_GAPS.has(E.metadata.id),
       [...E.metadata.supportedGrades],
-      accepted,
-      `${E.metadata.name} supportedGrades vs the grades its input schema accepts`,
+      config.evaluator.supported_grades,
+      `${E.metadata.name} supportedGrades vs the grades its contract declares`,
     );
+  });
+
+  // The two are separate fields with separate jobs, and `config.schema.json` requires them
+  // to agree wherever both exist: "when the evaluator accepts one,
+  // `input_schema.properties.grade_level.enum` is the accepted set and the two must agree".
+  // Nothing checked that directly, so the field the SDK no longer reads could drift.
+  it.each(cases)('$name accepts exactly the grades it declares support for', ({ E }) => {
+    const { config, inputSchema } = contractFor(E.metadata.id);
+    const accepted = inputSchema.properties.grade_level?.enum as string[] | undefined;
+
+    if (accepted === undefined) return;
+
+    expect(
+      [...accepted].sort(),
+      `${E.metadata.name}: grade_level enum vs evaluator.supported_grades`,
+    ).toEqual([...config.evaluator.supported_grades].sort());
   });
 });
 


### PR DESCRIPTION
`metadata.supportedGrades` was derived from `input_schema.properties.grade_level?.enum ?? []`, so the eight evaluators that take no grade published `[]` — asserting they target no grades at all.

Measured by instantiating the exported classes, before and after:

| evaluator | contract | published before | after |
| --- | --- | --- | --- |
| `feedback.*` (all seven) | 7 | **0** | 7 |
| `grade_level_appropriateness` | 13 | **0** | 13 |
| `math_standards_alignment` | 13 | 13 | 13 |
| the other seven | 10 | 10 | 10 |

**0 of 16 now contradict their contract**, up from 8 of 16. Math was already right because it is the one place that read `supported_grades` directly.

## Why the contract is the right source

`evals/_schemas/config.schema.json` requires the field of every evaluator (`minItems: 1`) and says what it is for: *"Declared for every evaluator, including those that take no grade as input — for those it is the only record of what the evaluator targets. This is NOT what validates a caller's grade: when the evaluator accepts one, `input_schema.properties.grade_level.enum` is the accepted set and the two must agree."*

The two fields answer different questions, which is why deriving one from the other lost information. Nothing about validation changes here — `validateInputs` has always used the input schema, and no code path reads `metadata.supportedGrades`. For the eight evaluators that do take a grade, the enum already equals `supported_grades`, so their published values are untouched.

`supported_grades` is now a required member of `SingleStepContract`/`MultiStepContract`, so a contract omitting it fails to compile rather than silently publishing `[]`.

## The invariant nobody was checking

The schema's "the two must agree" rule had no direct assertion — the SDK read only the enum, so the field it ignored was free to drift. Added as a conformance case over all 16 evaluators: where a `grade_level` enum exists it must equal `supported_grades`. Verified by setting one contract's `supported_grades` to `['3','4','5']` against its 3–12 enum, which fails that case alone.

`GRADE_GAPS` is now empty and math's entry is gone — it existed only to allowlist the one evaluator that read the contract while everything else read the enum.

## Two comments that argued for the old behaviour

Both were reasoning from "accepted" to "supported", which is the conflation that caused this:

- `grade-level-appropriateness.ts` said `supportedGrades` is *"empty by derivation rather than by assertion"* — presented as a property of the design. Its own contract declares 13, so the SDK was contradicting it.
- The conformance test asserted *"an evaluator taking no grade accepts none, and asserting that by hardcoding `[]` would just restate the assumption."* True of accepted grades, but the field is not named `acceptedGrades`.

The field's own JSDoc was `Supported grade levels (e.g., ['3', '4', '5', ...])`, which is what left this open to interpretation; it now states that it is not a validation set.

## Validation

- `typecheck`, `lint`, `test:unit` (1209, +16 — the new invariant case per evaluator), `build`, `scripts/check.py`
- Each factory confirmed load-bearing by reverting it: single-step → 9 fail, multi-step → 1, vocabulary-complexity → 1
- The synthetic contract in `single-step.test.ts` now declares four grades against a three-grade input enum, so that test fails if the factory goes back to the enum. Previously both were `['3','4','5']` and the test could not tell the sources apart.
- Mutation testing on both factories: no surviving mutants on the changed lines
