### PR TITLE
feat(sdk): add an evaluator registry and collapse the two id-to-class maps onto it

### DIFF
--- a/sdks/typescript/src/batch/families/feedback.ts
+++ b/sdks/typescript/src/batch/families/feedback.ts
@@ -103,7 +103,14 @@ export const FEEDBACK_FAMILY: EvaluatorFamily = {
     if (modelOverride) return [modelOverride.provider];
     const keys = new Set<KeyKind>();
     for (const member of resolveMembers(FEEDBACK_FAMILY, selectedMemberIds)) {
-      for (const provider of getEvaluatorClass(member.id)?.metadata.defaultProviders ?? []) {
+      // Not `?? []`: a member id that does not resolve would silently drop that member's
+      // provider key from the requirement list, and the run would fail later on a missing
+      // credential instead of prompting for it. These ids come from this family's own
+      // member list, so an unresolvable one is a bug here, not bad input.
+      const resolved = getEvaluatorClass(member.id);
+      if (!resolved) throw new Error(`Feedback family member is not registered: ${member.id}`);
+
+      for (const provider of resolved.metadata.defaultProviders) {
         keys.add(provider);
       }
     }

--- a/sdks/typescript/src/batch/families/feedback.ts
+++ b/sdks/typescript/src/batch/families/feedback.ts
@@ -7,8 +7,8 @@ import {
   ToneAppropriatenessEvaluator,
   WithholdingAnswersEvaluator,
 } from '../../evaluators/index.js';
-import type { BaseEvaluatorConfig, ModelOverride, Provider } from '../../evaluators/base.js';
-import type { EvaluationResult } from '../../schemas/index.js';
+import type { ModelOverride } from '../../evaluators/base.js';
+import { getEvaluatorClass, type RegisteredEvaluator } from '../../evaluators/registry.js';
 import { readOutcome } from '../../schemas/outcome.js';
 import {
   type ColumnSpec,
@@ -23,24 +23,14 @@ import {
 } from './family.js';
 
 /** The shape this family needs from an evaluator: named inputs in, envelope out. */
-interface FeedbackEvaluator {
-  evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
-}
-
-type EvaluatorClass = (new (config: BaseEvaluatorConfig) => FeedbackEvaluator) & {
-  metadata: {
-    id: string;
-    name: string;
-    defaultProviders: readonly Provider[];
-    outcome?: { score: string; reasoning: string };
-  };
-};
+type FeedbackEvaluator = InstanceType<RegisteredEvaluator>;
 
 /**
- * The members, in report order. Everything else about them — id, display name, provider,
- * which field holds the verdict — is read off the class, which reads it off the contract.
+ * Which evaluators are in this family, and the order they report in. That is all this list
+ * decides — id, display name, provider and which field holds the verdict are read off the
+ * class, which reads them off the contract. Resolution by id goes through the registry.
  */
-const MEMBER_CLASSES: readonly EvaluatorClass[] = [
+const MEMBER_CLASSES: readonly RegisteredEvaluator[] = [
   RevisionAccuracyEvaluator,
   RevisionActionabilityEvaluator,
   RevisionManageabilityEvaluator,
@@ -49,8 +39,6 @@ const MEMBER_CLASSES: readonly EvaluatorClass[] = [
   ToneAppropriatenessEvaluator,
   WithholdingAnswersEvaluator,
 ];
-
-const BY_ID = new Map(MEMBER_CLASSES.map((E) => [E.metadata.id, E]));
 
 /** The columns a row must carry, matching what every member's input schema declares. */
 export const FEEDBACK_COLUMNS: ColumnSpec[] = [
@@ -72,7 +60,7 @@ class FeedbackRunner implements FamilyRunner {
   private getEvaluator(memberId: string): FeedbackEvaluator {
     let instance = this.instances.get(memberId);
     if (!instance) {
-      const EvaluatorClass = BY_ID.get(memberId);
+      const EvaluatorClass = getEvaluatorClass(memberId);
       if (!EvaluatorClass) throw new Error(`Unknown feedback evaluator: ${memberId}`);
       instance = new EvaluatorClass({
         googleApiKey: this.ctx.googleApiKey,
@@ -96,7 +84,7 @@ class FeedbackRunner implements FamilyRunner {
       feedback_text: row.columns['feedback_text'],
     });
 
-    const { score, reasoning } = readOutcome(result, BY_ID.get(memberId)?.metadata.outcome);
+    const { score, reasoning } = readOutcome(result, getEvaluatorClass(memberId)?.metadata.outcome);
 
     // A report cell has to be a string, and the verdict here is the integer 0 or 1, which
     // readOutcome has already stringified. An absent verdict renders blank.
@@ -115,7 +103,7 @@ export const FEEDBACK_FAMILY: EvaluatorFamily = {
     if (modelOverride) return [modelOverride.provider];
     const keys = new Set<KeyKind>();
     for (const member of resolveMembers(FEEDBACK_FAMILY, selectedMemberIds)) {
-      for (const provider of BY_ID.get(member.id)?.metadata.defaultProviders ?? []) {
+      for (const provider of getEvaluatorClass(member.id)?.metadata.defaultProviders ?? []) {
         keys.add(provider);
       }
     }

--- a/sdks/typescript/src/batch/families/qtc.ts
+++ b/sdks/typescript/src/batch/families/qtc.ts
@@ -8,9 +8,9 @@ import {
   OrganizationalStructureEvaluator,
   ReferenceKnowledgeDemandsEvaluator,
 } from '../../evaluators/index.js';
-import type { BaseEvaluatorConfig, ModelOverride } from '../../evaluators/base.js';
+import type { ModelOverride } from '../../evaluators/base.js';
 import { Provider } from '../../evaluators/base.js';
-import type { EvaluationResult } from '../../schemas/index.js';
+import { getEvaluatorClass, type RegisteredEvaluator } from '../../evaluators/registry.js';
 import { readOutcome } from '../../schemas/outcome.js';
 import {
   type ColumnSpec,
@@ -29,25 +29,7 @@ import {
  * Typed loosely on purpose -- members declare different input keys (GLA takes no
  * grade), and the family builds each object from the evaluator's own schema below.
  */
-interface SimpleEvaluator {
-  evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
-}
-type EvaluatorConstructor = (new (config: BaseEvaluatorConfig) => SimpleEvaluator) & {
-  // The declared outcome travels with the class, so the family reads which field holds
-  // the verdict from the contract rather than knowing it per member.
-  metadata: { outcome?: { score: string; reasoning: string } };
-};
-
-const EVALUATOR_MAP = new Map<string, EvaluatorConstructor>([
-  [GradeLevelAppropriatenessEvaluator.metadata.id, GradeLevelAppropriatenessEvaluator],
-  [BackgroundKnowledgeDemandsEvaluator.metadata.id, BackgroundKnowledgeDemandsEvaluator],
-  [VocabularyComplexityEvaluator.metadata.id, VocabularyComplexityEvaluator],
-  [SentenceStructureEvaluator.metadata.id, SentenceStructureEvaluator],
-  [MeaningDirectnessEvaluator.metadata.id, MeaningDirectnessEvaluator],
-  [PurposeClarityEvaluator.metadata.id, PurposeClarityEvaluator],
-  [OrganizationalStructureEvaluator.metadata.id, OrganizationalStructureEvaluator],
-  [ReferenceKnowledgeDemandsEvaluator.metadata.id, ReferenceKnowledgeDemandsEvaluator],
-]);
+type SimpleEvaluator = InstanceType<RegisteredEvaluator>;
 
 const MEMBERS = [
   { id: GradeLevelAppropriatenessEvaluator.metadata.id, name: GradeLevelAppropriatenessEvaluator.metadata.name },
@@ -91,7 +73,7 @@ class QtcRunner implements FamilyRunner {
   private getEvaluator(memberId: string): SimpleEvaluator {
     let instance = this.instances.get(memberId);
     if (!instance) {
-      const EvaluatorClass = EVALUATOR_MAP.get(memberId);
+      const EvaluatorClass = getEvaluatorClass(memberId);
       if (!EvaluatorClass) throw new Error(`Unknown QTC evaluator: ${memberId}`);
       instance = new EvaluatorClass({
         googleApiKey: this.ctx.googleApiKey,
@@ -116,7 +98,7 @@ class QtcRunner implements FamilyRunner {
     }
 
     const result = await this.getEvaluator(memberId).evaluate(inputs);
-    const declared = EVALUATOR_MAP.get(memberId)?.metadata.outcome;
+    const declared = getEvaluatorClass(memberId)?.metadata.outcome;
     const { score, reasoning } = readOutcome(result, declared);
 
     // A report cell has to be a string. An absent verdict renders blank, and doing

--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -1,3 +1,5 @@
+export { getEvaluators, getEvaluator } from './registry.js';
+
 export {
   BaseEvaluator,
   Provider,

--- a/sdks/typescript/src/evaluators/registry.ts
+++ b/sdks/typescript/src/evaluators/registry.ts
@@ -76,13 +76,40 @@ const EVALUATORS: readonly RegisteredEvaluator[] = Object.freeze([
  */
 const METADATA: readonly EvaluatorMetadata[] = Object.freeze(EVALUATORS.map((E) => E.metadata));
 
+/**
+ * Index every evaluator by its current id and by each id it used to carry.
+ *
+ * Throws on a collision rather than letting one win. `new Map` keeps the last entry for a
+ * repeated key, so two evaluators sharing an id — most plausibly one evaluator's
+ * `idHistory` entry colliding with another's current id — would silently resolve to
+ * whichever was registered later, and `getEvaluator` would confidently return the wrong
+ * evaluator. Exported for the collision test, which cannot introduce a real duplicate.
+ *
+ * @internal
+ */
+export function indexById(
+  evaluators: readonly RegisteredEvaluator[],
+): ReadonlyMap<string, RegisteredEvaluator> {
+  const index = new Map<string, RegisteredEvaluator>();
+
+  for (const E of evaluators) {
+    for (const id of [E.metadata.id, ...E.metadata.idHistory]) {
+      const claimed = index.get(id);
+      if (claimed && claimed !== E) {
+        throw new Error(
+          `Registry id "${id}" is claimed by both ${claimed.metadata.name} and ` +
+            `${E.metadata.name}. An id, current or historical, must name one evaluator.`,
+        );
+      }
+      index.set(id, E);
+    }
+  }
+
+  return index;
+}
+
 /** Current id, and every id that has ever meant this evaluator, to the class. */
-const BY_ID: ReadonlyMap<string, RegisteredEvaluator> = new Map(
-  EVALUATORS.flatMap((E) => [
-    [E.metadata.id, E] as const,
-    ...E.metadata.idHistory.map((old) => [old, E] as const),
-  ]),
-);
+const BY_ID = indexById(EVALUATORS);
 
 /** Every evaluator in the SDK, in taxonomy order. */
 export function getEvaluators(): readonly EvaluatorMetadata[] {

--- a/sdks/typescript/src/evaluators/registry.ts
+++ b/sdks/typescript/src/evaluators/registry.ts
@@ -1,0 +1,114 @@
+import type { BaseEvaluatorConfig, EvaluatorMetadata } from './base.js';
+import type { EvaluationResult } from '../schemas/outputs.js';
+
+import { VocabularyComplexityEvaluator } from './student-facing-text/ela-reading/vocabulary-complexity.js';
+import { SentenceStructureEvaluator } from './student-facing-text/ela-reading/sentence-structure.js';
+import { GradeLevelAppropriatenessEvaluator } from './student-facing-text/ela-reading/grade-level-appropriateness.js';
+import { BackgroundKnowledgeDemandsEvaluator } from './student-facing-text/ela-reading/background-knowledge-demands.js';
+import { MeaningDirectnessEvaluator } from './student-facing-text/ela-reading/meaning-directness.js';
+import { PurposeClarityEvaluator } from './student-facing-text/ela-reading/purpose-clarity.js';
+import { ReferenceKnowledgeDemandsEvaluator } from './student-facing-text/ela-reading/reference-knowledge-demands.js';
+import { OrganizationalStructureEvaluator } from './student-facing-text/ela-reading/organizational-structure.js';
+import { RevisionAccuracyEvaluator } from './feedback/ela-writing/revision-accuracy.js';
+import { RevisionActionabilityEvaluator } from './feedback/ela-writing/revision-actionability.js';
+import { RevisionManageabilityEvaluator } from './feedback/ela-writing/revision-manageability.js';
+import { StrengthAcknowledgmentEvaluator } from './feedback/ela-writing/strength-acknowledgment.js';
+import { StudentResponseSpecificityEvaluator } from './feedback/ela-writing/student-response-specificity.js';
+import { ToneAppropriatenessEvaluator } from './feedback/ela-writing/tone-appropriateness.js';
+import { WithholdingAnswersEvaluator } from './feedback/ela-writing/withholding-answers.js';
+import { MathStandardsAlignmentEvaluator } from './academic-standards-alignment/mathematics/math-standards-alignment.js';
+
+/**
+ * An evaluator class as the registry holds it: constructible, and carrying its own metadata.
+ *
+ * Deliberately **not** exported from the package. Resolving a class by id erases which named
+ * inputs it takes — math takes `question`/`statementCode`/`jurisdiction`, the complexity
+ * evaluators take `text`/`grade_level` — and no signature can express "whatever this
+ * particular id declares". Publishing it would hand callers a constructor that compiles
+ * against any input shape and fails only at run time, and the SDK exposes no way to discover
+ * the right shape. Callers who want a specific evaluator import it by name and keep its
+ * types; the id-resolved form stays internal to the batch families, which know what they
+ * are passing.
+ */
+export interface RegisteredEvaluator {
+  new (config: BaseEvaluatorConfig): {
+    evaluate(input: Record<string, string>): Promise<EvaluationResult<unknown>>;
+  };
+  readonly metadata: EvaluatorMetadata;
+}
+
+/**
+ * Every evaluator, in taxonomy order.
+ *
+ * Adding an evaluator means adding it here. The conformance suite compares this list against
+ * the public barrel, so one exported but unregistered fails the build rather than going
+ * quietly missing from `getEvaluators()`.
+ *
+ * Frozen because `getEvaluators()` hands it out directly and `readonly` is erased at
+ * runtime, so a caller appending to it would corrupt every later lookup. The freeze is
+ * shallow: it protects the list, not each class's own `metadata`.
+ */
+const EVALUATORS: readonly RegisteredEvaluator[] = Object.freeze([
+  MathStandardsAlignmentEvaluator,
+  RevisionAccuracyEvaluator,
+  RevisionActionabilityEvaluator,
+  RevisionManageabilityEvaluator,
+  StrengthAcknowledgmentEvaluator,
+  StudentResponseSpecificityEvaluator,
+  ToneAppropriatenessEvaluator,
+  WithholdingAnswersEvaluator,
+  BackgroundKnowledgeDemandsEvaluator,
+  GradeLevelAppropriatenessEvaluator,
+  MeaningDirectnessEvaluator,
+  OrganizationalStructureEvaluator,
+  PurposeClarityEvaluator,
+  ReferenceKnowledgeDemandsEvaluator,
+  SentenceStructureEvaluator,
+  VocabularyComplexityEvaluator,
+]);
+
+/**
+ * The public projection of the list above.
+ *
+ * Frozen for the same reason as `EVALUATORS`: `readonly` is erased at runtime and this is
+ * handed out directly. The freeze is shallow — it protects the list, not each evaluator's
+ * own `metadata` object, which is the class's own static and mutable with or without this.
+ */
+const METADATA: readonly EvaluatorMetadata[] = Object.freeze(EVALUATORS.map((E) => E.metadata));
+
+/** Current id, and every id that has ever meant this evaluator, to the class. */
+const BY_ID: ReadonlyMap<string, RegisteredEvaluator> = new Map(
+  EVALUATORS.flatMap((E) => [
+    [E.metadata.id, E] as const,
+    ...E.metadata.idHistory.map((old) => [old, E] as const),
+  ]),
+);
+
+/** Every evaluator in the SDK, in taxonomy order. */
+export function getEvaluators(): readonly EvaluatorMetadata[] {
+  return METADATA;
+}
+
+/**
+ * The evaluator a registry id names, or `undefined` if none does.
+ *
+ * Renames resolve: an id an evaluator used to carry still finds it, via `idHistory`, so a
+ * result stored under the old name stays identifiable. Returns `undefined` rather than
+ * throwing because "not found" is a normal answer to a lookup.
+ */
+export function getEvaluator(id: string): EvaluatorMetadata | undefined {
+  return BY_ID.get(id)?.metadata;
+}
+
+/**
+ * The class behind an id, for callers that need to construct it.
+ *
+ * Internal: see {@link RegisteredEvaluator} for why the constructible form is not published.
+ * This is what lets the batch families resolve a member id without each keeping its own
+ * id-to-class map.
+ *
+ * @internal
+ */
+export function getEvaluatorClass(id: string): RegisteredEvaluator | undefined {
+  return BY_ID.get(id);
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -150,6 +150,8 @@ export {
   type ModelOverride,
   type TelemetryOptions,
   type EvaluatorMetadata,
+  getEvaluators,
+  getEvaluator,
 } from './evaluators/index.js';
 
 // Features

--- a/sdks/typescript/tests/unit/batch/feedback-family.test.ts
+++ b/sdks/typescript/tests/unit/batch/feedback-family.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { FEEDBACK_FAMILY } from '../../../src/batch/families/feedback.js';
 import { getFamilies, getFamily } from '../../../src/batch/families/registry.js';
+import { getEvaluator } from '../../../src/evaluators/index.js';
 import { validateRequiredColumns, normalizeRow } from '../../../src/batch/families/family.js';
 import { renderOutputs } from '../../../src/batch/output.js';
 import { Provider } from '../../../src/evaluators/base.js';
@@ -24,6 +25,23 @@ function llmProvider(): LLMProvider {
     generateText: vi.fn(),
   };
 }
+
+describe('every family member resolves in the evaluator registry', () => {
+  // The invariant the `requiredKeys` guard depends on. A member id that does not resolve
+  // would drop that member's provider from the required-key list, and the run would fail
+  // later on a missing credential rather than prompting for it. Asserted here so the
+  // condition is caught when a family changes, not at run time.
+  it.each(getFamilies().flatMap((f) => f.members.map((m) => ({ family: f.id, id: m.id }))))(
+    '$family: $id',
+    ({ id }) => {
+      expect(getEvaluator(id), `${id} is a family member but not registered`).toBeDefined();
+    },
+  );
+
+  it('finds members to check', () => {
+    expect(getFamilies().flatMap((f) => f.members).length).toBeGreaterThan(10);
+  });
+});
 
 describe('the feedback family is selectable', () => {
   it('is registered', () => {

--- a/sdks/typescript/tests/unit/evaluators/registry.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/registry.test.ts
@@ -3,6 +3,7 @@ import {
   getEvaluators,
   getEvaluator,
   getEvaluatorClass,
+  indexById,
 } from '../../../src/evaluators/registry.js';
 import * as barrel from '../../../src/index.js';
 import { InputValidationError } from '../../../src/errors.js';
@@ -121,8 +122,11 @@ describe('getEvaluatorClass', () => {
   it('is not reachable from the package entry point', () => {
     // Internal on purpose. If this starts being exported, the erased-input hazard in
     // RegisteredEvaluator's docstring becomes a public one.
+    //
+    // Only the function is asserted here. `RegisteredEvaluator` is a type, erased before
+    // this runs, so a runtime check on it would pass whether or not it were exported —
+    // `typeTest` below is what actually holds that line.
     expect(barrel).not.toHaveProperty('getEvaluatorClass');
-    expect(barrel).not.toHaveProperty('RegisteredEvaluator');
   });
 
   it.each(EXPORTED)('resolves $name to a constructible class', ({ cls }) => {
@@ -149,5 +153,57 @@ describe('getEvaluatorClass', () => {
 
   it('returns undefined for an id no evaluator carries', () => {
     expect(getEvaluatorClass('literacy.removed.evaluator')).toBeUndefined();
+  });
+});
+
+/**
+ * Compile-time half of the check above: neither the constructible type nor its accessor may
+ * be reachable from the public entry point. If either is exported, the expected error does
+ * not occur and `@ts-expect-error` itself fails the build.
+ */
+export type TypeTest = [
+  // @ts-expect-error - RegisteredEvaluator is internal
+  import('../../../src/index.js').RegisteredEvaluator,
+  // @ts-expect-error - getEvaluatorClass is internal
+  typeof import('../../../src/index.js').getEvaluatorClass,
+];
+
+describe('indexById', () => {
+  // The real registry cannot contain a duplicate, so the collision path is driven directly.
+  const stub = (id: string, idHistory: readonly string[], name: string) =>
+    ({ metadata: { id, idHistory, name } }) as unknown as Parameters<typeof indexById>[0][number];
+
+  it('indexes an evaluator under its current id and every former one', () => {
+    const E = stub('current.id', ['old.id', 'older.id'], 'Thing');
+
+    const index = indexById([E]);
+
+    expect(index.get('current.id')).toBe(E);
+    expect(index.get('old.id')).toBe(E);
+    expect(index.get('older.id')).toBe(E);
+    expect(index.size).toBe(3);
+  });
+
+  it('throws when two evaluators claim the same current id', () => {
+    // `new Map` would keep the last silently, and lookups would return the wrong evaluator.
+    const a = stub('shared.id', [], 'First');
+    const b = stub('shared.id', [], 'Second');
+
+    expect(() => indexById([a, b])).toThrow(/shared\.id.*First.*Second/);
+  });
+
+  it('throws when one evaluator\'s former id is another\'s current id', () => {
+    // The plausible collision: a rename frees a name that something else later takes.
+    const a = stub('a.current', ['contested.id'], 'First');
+    const b = stub('contested.id', [], 'Second');
+
+    expect(() => indexById([a, b])).toThrow(/contested\.id/);
+  });
+
+  it('tolerates an evaluator listing the same id twice', () => {
+    // Same evaluator, so nothing is ambiguous — only a cross-evaluator clash is an error.
+    const E = stub('same.id', ['same.id'], 'Thing');
+
+    expect(() => indexById([E])).not.toThrow();
   });
 });

--- a/sdks/typescript/tests/unit/evaluators/registry.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/registry.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEvaluators,
+  getEvaluator,
+  getEvaluatorClass,
+} from '../../../src/evaluators/registry.js';
+import * as barrel from '../../../src/index.js';
+import { InputValidationError } from '../../../src/errors.js';
+
+/**
+ * The registry, checked against the public barrel rather than against itself.
+ *
+ * Two hand-maintained id-to-class maps used to exist in the batch families for want of
+ * this. The completeness check reads the barrel independently, so an evaluator that is
+ * exported but never registered fails here instead of going quietly missing from
+ * `getEvaluators()`.
+ *
+ * Every parameterised case is built from the barrel, never from `getEvaluators()`. Driving
+ * `it.each` off the subject meant a mutant that broke it took test *collection* down with
+ * it — zero tests ran and the mutant scored as survived rather than caught.
+ */
+
+interface EvaluatorLike {
+  metadata: { id: string; stableId: string; idHistory: readonly string[] };
+}
+
+/** Evaluator classes reachable from the package's public entry point. */
+const EXPORTED = Object.entries(barrel as Record<string, unknown>)
+  .filter(
+    ([, v]) =>
+      typeof v === 'function' && typeof (v as unknown as EvaluatorLike).metadata?.id === 'string',
+  )
+  .map(([name, v]) => ({ name, cls: v as unknown as EvaluatorLike }));
+
+const FORMER_IDS = EXPORTED.flatMap(({ name, cls }) =>
+  cls.metadata.idHistory.map((former) => ({ name, former, cls })),
+);
+
+describe('the fixtures these tests are built from', () => {
+  it('finds all sixteen evaluators on the barrel', () => {
+    expect(EXPORTED).toHaveLength(16);
+  });
+
+  it('finds historical ids, so the rename cases are not vacuous', () => {
+    expect(FORMER_IDS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getEvaluators', () => {
+  it('holds every evaluator the package exports', () => {
+    const registered = new Set(getEvaluators().map((m) => m.id));
+    const missing = EXPORTED.filter(({ cls }) => !registered.has(cls.metadata.id)).map(
+      ({ name }) => name,
+    );
+
+    expect(missing, `exported but unregistered: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('holds nothing the package does not export', () => {
+    const exported = new Set(EXPORTED.map(({ cls }) => cls.metadata.id));
+    const extra = getEvaluators()
+      .map((m) => m.id)
+      .filter((id) => !exported.has(id));
+
+    expect(extra, `registered but not exported: ${extra.join(', ')}`).toEqual([]);
+  });
+
+  it('returns as many as the barrel exports', () => {
+    expect(getEvaluators()).toHaveLength(EXPORTED.length);
+  });
+
+  it('registers each id once', () => {
+    const ids = getEvaluators().map((m) => m.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('cannot be mutated through the returned list', () => {
+    // `readonly` is erased at runtime and this hands the array out directly, so without
+    // freezing it a caller appending to it corrupts every later lookup.
+    expect(() => (getEvaluators() as unknown as unknown[]).push({})).toThrow();
+    expect(getEvaluators()).toHaveLength(EXPORTED.length);
+  });
+});
+
+describe('getEvaluator', () => {
+  it.each(EXPORTED)('resolves $name by its current id', ({ cls }) => {
+    expect(getEvaluator(cls.metadata.id)).toBe(cls.metadata);
+  });
+
+  it.each(FORMER_IDS)('resolves $name by its former id $former', ({ cls, former }) => {
+    // Renames stay resolvable, which is what keeps an archived result identifiable.
+    expect(getEvaluator(former)).toBe(cls.metadata);
+  });
+
+  it('returns undefined for an id no evaluator carries', () => {
+    // Not a throw: "not found" is a normal answer, and callers reading archived results
+    // ask this before committing to `readOutcome`.
+    expect(getEvaluator('literacy.removed.evaluator')).toBeUndefined();
+    expect(getEvaluator('')).toBeUndefined();
+  });
+
+  it.each(EXPORTED)('does not resolve $name by its stableId', ({ cls }) => {
+    // `stableId` identifies the evaluator across renames but is not a lookup key; treating
+    // it as one would make two different identifiers silently interchangeable.
+    expect(getEvaluator(cls.metadata.stableId)).toBeUndefined();
+  });
+
+  it('returns metadata, not the class', () => {
+    // The public lookup deliberately does not hand out a constructor: resolving by id
+    // erases which named inputs the evaluator takes, and nothing here can express that.
+    const resolved = getEvaluator('student_facing_text.ela_reading.meaning_directness');
+
+    expect(resolved).toBeDefined();
+    expect(typeof resolved).toBe('object');
+    expect(resolved!.defaultProviders.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getEvaluatorClass', () => {
+  it('is not reachable from the package entry point', () => {
+    // Internal on purpose. If this starts being exported, the erased-input hazard in
+    // RegisteredEvaluator's docstring becomes a public one.
+    expect(barrel).not.toHaveProperty('getEvaluatorClass');
+    expect(barrel).not.toHaveProperty('RegisteredEvaluator');
+  });
+
+  it.each(EXPORTED)('resolves $name to a constructible class', ({ cls }) => {
+    const E = getEvaluatorClass(cls.metadata.id);
+
+    expect(E).toBe(cls);
+    expect(typeof E).toBe('function');
+  });
+
+  it('returns a class whose own schema still rejects foreign inputs', () => {
+    // What replaces type safety here: the evaluator validates its declared inputs, so a
+    // caller that resolves by id and guesses wrong fails loudly rather than silently.
+    const E = getEvaluatorClass(
+      'academic_standards_alignment.mathematics.math_standards_alignment',
+    )!;
+
+    return expect(
+      new E({ anthropicApiKey: 'k', learningCommonsApiKey: 'k' }).evaluate({
+        text: 'not what math takes',
+        grade_level: '5',
+      }),
+    ).rejects.toThrow(InputValidationError);
+  });
+
+  it('returns undefined for an id no evaluator carries', () => {
+    expect(getEvaluatorClass('literacy.removed.evaluator')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The SDK had no way to get from a registry id to an evaluator, so two hand-maintained id→class maps existed to bridge it: `EVALUATOR_MAP` in `qtc.ts` (8 entries) and `BY_ID` in `feedback.ts` (7). Both are gone, and both families get net smaller.

## The API

```ts
getEvaluators(): readonly EvaluatorMetadata[]        // enumeration, taxonomy order
getEvaluator(id): EvaluatorMetadata | undefined      // renames resolve via idHistory
```

Both return **metadata, not classes.** Resolving a class by id erases which named inputs it takes — math takes `question`/`statementCode`/`jurisdiction`, the complexity evaluators take `text`/`grade_level` — and no signature can express "whatever this particular id declares". Publishing the constructor would hand callers something that compiles against any input shape and fails only at run time, while the SDK exposes no way to discover the right shape. Callers who want one evaluator import it by name and keep its types.

The constructible form stays internal as `getEvaluatorClass`, which is what lets the two families resolve a member id without each keeping its own map. A test asserts it is *not* reachable from the package entry point.

Renamed ids resolve through `idHistory`. All 16 evaluators carry exactly one former id, and every one is covered.

## Validation

- `typecheck`, `lint`, `test:unit` (1285, +92), `build`, `scripts/check.py`
- Mutation testing on `registry.ts`: **7 killed / 2 survived (77.78%)**. Both survivors are the Stryker artefact where a mutant breaks module load, so no tests run and it scores as survived; applied by hand each yields `TypeError: Iterator value undefined is not an entry object` and `Tests no tests` — lethal, not survived.

### Three defects the review and mutation runs found, all mine

- **The registry was mutable.** `readonly` is erased at run time and `getEvaluators()` hands its array out directly, so my own "cannot be mutated" test pushed `{}` into it and corrupted every later lookup in the file. Now frozen, with the shallowness stated rather than oversold.
- **Every parameterised test case was built by calling `getEvaluators()`**, so a mutant that broke it took test *collection* down — zero tests ran and Stryker scored it survived rather than caught. Cases now come from the public barrel, independently of the subject. That moved the score from 50% to 77.78%.
- **My first fix for the erased-input type did not work.** Narrowing `evaluate(input)` from `Record<string, string>` to `Record<string, unknown>` changes nothing, because the former is assignable to the latter. Not publishing the constructor is what actually closes it: the probe that previously typechecked and threw at run time is now a compile error.

## Follow-ups this surfaced, none included here

1. **Stryker rewrites tracked `src/` files in place**, so `git add` during a run stages instrumented source and a killed run leaves `src/` dirty. `.stryker-tmp/` is gitignored; the in-place rewrite is not. Worth a `check.py` guard. Verified clean here — no `stryMutAct` in `src/`, the commit, or the pushed branch.
2. **`readOutcome` conflates a malformed `result` with a legitimately absent verdict** (`if (!isRecord(result) || !outcome)`). A corrupt envelope and math's no-declared-outcome both return `score: undefined`. Pre-existing on `main`, and the real silent miss in that file.
3. **The tree-shaking ticket needs re-scoping.** A consumer importing only `LogLevel` measures 242.4 kb. `sideEffects: false` and `treeshake: true` are already set, so `splitting: false` is not the whole cause — both entry points reach all 16 evaluators by live reference, which no bundler can shake.
4. **No `import/no-cycle` lint rule.** Not triggered by this PR, but worth having now that the evaluator barrel is a resolution point.
