### PR TITLE
fix(sdk): resolve symlinks in the batch CLI entry-point guard

### DIFF
--- a/sdks/typescript/src/batch/cli.ts
+++ b/sdks/typescript/src/batch/cli.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { pathToFileURL } from 'url';
+import { pathToFileURL, fileURLToPath } from 'url';
 import prompts from 'prompts';
 import {
   BatchEvaluator,
@@ -466,15 +466,30 @@ async function main() {
  *
  * `main()` runs at module scope, so without this an `import` of this file — which the tests
  * need in order to reach anything in it — starts a batch run and blocks on the interactive
- * prompts. Comparison is on resolved URLs because `argv[1]` may be a relative path.
+ * prompts.
  *
- * `node --entry-url` passes the entry point through as a URL rather than a path; running it
- * through `pathToFileURL` would mangle it and leave the CLI doing nothing at all.
+ * Three forms of `argv[1]` have to compare equal to this module's URL, and missing any one
+ * of them leaves `evaluators-batch` exiting 0 having done nothing:
+ *
+ * - a path, possibly relative, hence `pathToFileURL`;
+ * - a **symlink** to this file, which is how npm installs a `bin` — `argv[1]` is then
+ *   `node_modules/.bin/evaluators-batch` while `import.meta.url` is the resolved target,
+ *   so the two never match textually;
+ * - a `file:` URL, which `node --entry-url` passes through verbatim and which
+ *   `pathToFileURL` would mangle.
  */
 export function isEntryPoint(moduleUrl: string, argv1: string | undefined): boolean {
   if (argv1 === undefined) return false;
+
   const entryUrl = argv1.startsWith('file:') ? new URL(argv1).href : pathToFileURL(argv1).href;
-  return moduleUrl === entryUrl;
+  if (moduleUrl === entryUrl) return true;
+
+  try {
+    return moduleUrl === pathToFileURL(fs.realpathSync(fileURLToPath(entryUrl))).href;
+  } catch {
+    // argv[1] names something unreadable or absent; it is not this module.
+    return false;
+  }
 }
 
 if (isEntryPoint(import.meta.url, process.argv[1])) main();

--- a/sdks/typescript/tests/unit/batch/cli.test.ts
+++ b/sdks/typescript/tests/unit/batch/cli.test.ts
@@ -4,7 +4,9 @@ import {
   mkdirSync,
   mkdtempSync,
   readdirSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -191,6 +193,39 @@ describe('isEntryPoint', () => {
 
   it('canonicalises a non-normalised file URL entry point', () => {
     expect(isEntryPoint('file:///tmp/cli.js', 'file:/tmp/cli.js')).toBe(true);
+  });
+
+  it('matches a symlink pointing at the module, as an installed bin does', () => {
+    // The regression this test exists for: `npm install` puts the bin in
+    // node_modules/.bin as a symlink, so argv[1] is the link and import.meta.url is the
+    // resolved target. Comparing them textually leaves the CLI exiting 0 in silence.
+    const real = join(workspace, 'cli.js');
+    const link = join(workspace, 'evaluators-batch');
+    writeFileSync(real, '');
+    symlinkSync(real, link);
+
+    // realpathSync on the target too: macOS resolves /tmp through /private/tmp, and
+    // import.meta.url would already be the fully resolved form.
+    const moduleUrl = pathToFileURL(realpathSync(real)).href;
+
+    expect(isEntryPoint(moduleUrl, link)).toBe(true);
+  });
+
+  it('is false for a symlink pointing at a different file', () => {
+    // Resolving links must not turn every link into a match.
+    const real = join(workspace, 'cli.js');
+    const other = join(workspace, 'other.js');
+    const link = join(workspace, 'link-to-other');
+    writeFileSync(real, '');
+    writeFileSync(other, '');
+    symlinkSync(other, link);
+
+    expect(isEntryPoint(pathToFileURL(realpathSync(real)).href, link)).toBe(false);
+  });
+
+  it('is false when argv[1] names something that does not exist', () => {
+    // Resolution fails rather than throwing out of the guard and crashing at import.
+    expect(isEntryPoint(pathToFileURL(installed).href, join(workspace, 'absent.js'))).toBe(false);
   });
 
   it('is false when there is no entry point at all', () => {


### PR DESCRIPTION
`evaluators-batch` did nothing when installed. It printed no output and **exited 0**.

Regression from #248, which added an entry-point guard so importing `cli.ts` in tests would stop starting a batch run. The guard compared an unresolved `argv[1]` against a resolved `import.meta.url`, and npm installs a `bin` as a **symlink**:

```
argv[1]             /tmp/app/node_modules/.bin/evaluators-batch
import.meta.url     file:///tmp/app/node_modules/@learning-commons/evaluators/dist/batch/cli.js
equal?              false
```

So `main()` never ran. This is the exact silent no-op #248's own PR body warned about — I tested the direct path and `node --entry-url`, but never the installed shim, which is the only form partners use.

## Fix

`isEntryPoint` now falls back to comparing the realpath of `argv[1]`, and its docstring enumerates all three forms that must match: a path (possibly relative), a symlink to this file, and a `file:` URL from `node --entry-url`. Resolution failure returns `false` rather than throwing out of a module-scope guard.

## Validation

Against a real `npm pack` install in a clean project — the scenario that found it:

| invocation | before | after |
| --- | --- | --- |
| `npx evaluators-batch --help` | *silence, exit 0* | prints usage |
| `node …/dist/batch/cli.js --version` | `0.8.0` | `0.8.0` |
| `node --entry-url file://…/cli.js --version` | `0.8.0` | `0.8.0` |

And past `--help`, to confirm `main()` really runs: a one-row CSV through `--family text-complexity -y` parses the CSV, resolves the family and all eight members, then correctly refuses on the missing credential — `Missing Google API Key. Provide --google-api-key or set GOOGLE_API_KEY (running non-interactively)`.

- `typecheck`, `lint`, `test:unit` (1309, +3), `build`, `scripts/check.py`
- Three new cases: a symlink pointing at the module (**fails if the fix is reverted**), a symlink pointing elsewhere, and an `argv[1]` naming a file that does not exist
- Mutation testing on `cli.ts`: **96.46% on covered code** (109 killed / 4 survived). The realpath branch's mutants are all killed; the four survivors are the ones already documented in #248 — the write-probe's content and the `EACCES` branch (both need an `EROFS` mount or are equivalent), the `startsWith` mutant that breaks module load so no tests run, and the guard's own call site, which no unit test can observe because observing it means running the CLI. The `dist` invocations above are what cover that one.

## Why the unit tests could not have caught this alone

A symlink is a filesystem fact, and the guard is exercised for real only when something invokes the built artefact through one. The new unit case pins the logic, but the check that matters is the packed-install run in the table — worth wiring into CI as a smoke test on the tarball, since this is the second entry-point defect in two PRs.
