### PR TITLE
docs(sdk): fix the broken quickstart, document all sixteen evaluators, add a 0.8.0 migration guide

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -111,6 +111,14 @@ function toRow(dimension: string, evaluation: EvaluationResult, outcome: Declare
 | `evaluator.evaluateByGrade(...)` | `evaluator.evaluateByGradeLevel(...)` |
 | `Providers` (redundant alias; `Provider` already existed and is unchanged) | use `Provider` |
 
+Removed outright, so a `TS2305` on any of these has an entry here:
+
+| removed | replacement |
+| --- | --- |
+| `ComplexityClassification`, `ComplexityClassificationSchema` | each evaluator's own `<Evaluator>Result` / `<Evaluator>OutputSchema`, generated from its contract |
+| `PurposeComplexityLevel` | `PurposeClarityResult["complexity_score"]` |
+| `VocabularyInternal`, `SmkInternal`, `ConventionalityInternal`, `PurposeInternal`, `SentenceStructureInternal`, `GradeLevelAppropriatenessInternal` | the matching `<Evaluator>Result` |
+
 `TextComplexityEvaluator`, `evaluateTextComplexity`, `TextComplexityResult` and `TextComplexityLevel` are **removed with no replacement.** The composite ran several evaluators and merged their verdicts, which hid which model produced what. Call the evaluators you want and combine the results yourself, or use the `text-complexity` batch family, which does this with a report.
 
 It ran four, whose 1.0 names are:

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -4,6 +4,24 @@
 
 Twenty-six exported names are gone and seventy-three are new. Work through the sections below in order — the first four affect every caller.
 
+## 0. Upgrade the package and the peers together
+
+The peer ranges moved a major version, so installing the SDK on its own fails before you can
+change a line of code:
+
+```
+npm error ERESOLVE unable to resolve dependency tree
+npm error Found: ai@6.0.271
+```
+
+One command, not two:
+
+```bash
+npm install @learning-commons/evaluators@^1 ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
+```
+
+Install only the adapters you use. Node's minimum is unchanged at `>=20.19.0`.
+
 ## 1. `evaluate()` takes named inputs
 
 Positional arguments are gone. Each evaluator declares its inputs in `input_schema.json`, and those names are the argument keys.
@@ -82,6 +100,36 @@ const { score, reasoning } = readOutcome(evaluation, MyEvaluator.metadata.outcom
 
 `TextComplexityEvaluator`, `evaluateTextComplexity`, `TextComplexityResult` and `TextComplexityLevel` are **removed with no replacement.** The composite ran several evaluators and merged their verdicts, which hid which model produced what. Call the evaluators you want and combine the results yourself, or use the `text-complexity` batch family, which does this with a report.
 
+It ran four, whose 1.0 names are:
+
+| composite key | 1.0 evaluator |
+| --- | --- |
+| `vocabulary` | `VocabularyComplexityEvaluator` |
+| `sentenceStructure` | `SentenceStructureEvaluator` |
+| `subjectMatterKnowledge` | `BackgroundKnowledgeDemandsEvaluator` |
+| `conventionality` | `MeaningDirectnessEvaluator` |
+
+**Mind the failure semantics.** The composite returned `{ error }` in place of any dimension
+that failed and still gave you the rest. `Promise.all` does not — one failed dimension rejects
+the whole call — so use `Promise.allSettled` if you want the old behaviour:
+
+```typescript
+const settled = await Promise.allSettled(
+  DIMENSIONS.map(([, E]) => new E(keys).evaluate({ text, grade_level: grade })),
+);
+
+return settled.map((outcome, i) => {
+  const [dimension, E] = DIMENSIONS[i];
+  return {
+    dimension,
+    score:
+      outcome.status === 'fulfilled'
+        ? (readOutcome(outcome.value, E.metadata.outcome).score ?? null)
+        : null,
+  };
+});
+```
+
 ## 4. Errors are grouped by fault domain
 
 `EvaluatorError` is still the root, but the middle of the hierarchy is new — you can now catch by who is at fault.
@@ -118,16 +166,12 @@ Both `partnerKey` and `platformApiKey` are gone. `learningCommonsApiKey` on the 
 
 ## 7. Peer dependencies moved a major version
 
-```bash
-npm install ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
-```
+Covered by step 0 above, which has to happen first. For reference:
 
 | Peer | 0.8.0 | 1.0.0 |
 | --- | --- | --- |
 | `ai` | `>=6.0.0` | `>=7.0.0` |
 | `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0` |
-
-Node's minimum is unchanged at `>=20.19.0`.
 
 ## 8. Math standards alignment returns the envelope
 

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -2,7 +2,7 @@
 
 1.0.0 moves every evaluator onto the shared, language-neutral contracts under `evals/`, so the SDK reads its models, prompts, grades, inputs and output shapes from the same declarations the Python SDK and the notebooks use. The payoff is that a result is now identical across our SDKs; the cost is that most of the public surface changed at once.
 
-Twenty-six exported names are gone and seventy-one are new. Work through the sections below in order — the first four affect every caller.
+Twenty-six exported names are gone and seventy-three are new. Work through the sections below in order — the first four affect every caller.
 
 ## 1. `evaluate()` takes named inputs
 
@@ -154,5 +154,8 @@ It was the last evaluator returning its payload bare.
 - **Seven feedback evaluators** judging teacher comments on student writing, and `OrganizationalStructureEvaluator` and `ReferenceKnowledgeDemandsEvaluator` are now public.
 - **`llmProvider`** — bring your own provider. Inject any `LLMProvider` and no API keys are needed, for Vertex AI, Bedrock, a gateway or an eval framework's model system. Mutually exclusive with `modelOverride`.
 - **The `feedback` batch family**, alongside `text-complexity` and `math-standards-alignment`.
+- **`getEvaluators()` / `getEvaluator(id)`** — a registry over all sixteen, for enumeration and
+  for resolving a stored result's id back to the evaluator that produced it. Renamed ids
+  resolve through `idHistory`, so a result written under an old name stays identifiable.
 
 The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both existed in 0.8.0; they are documented in the [README](./README.md) now, which is the change.

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -77,6 +77,18 @@ const { score, reasoning } = readOutcome(evaluation, MyEvaluator.metadata.outcom
 
 `score` is stringified, and is `undefined` for an evaluator whose output is not a single judgement.
 
+Writing one helper across several evaluators — the case this replaces — needs a name for that
+second argument. It is exported as `DeclaredOutcome`:
+
+```typescript
+import { readOutcome, type DeclaredOutcome, type EvaluationResult } from "@learning-commons/evaluators";
+
+function toRow(dimension: string, evaluation: EvaluationResult, outcome: DeclaredOutcome | undefined) {
+  const { score, reasoning } = readOutcome(evaluation, outcome);
+  return { dimension, score, reasoning };
+}
+```
+
 **Token counts moved** into a nested object:
 
 ```diff
@@ -96,7 +108,8 @@ const { score, reasoning } = readOutcome(evaluation, MyEvaluator.metadata.outcom
 | `VocabularyEvaluator` / `evaluateVocabulary` | `VocabularyComplexityEvaluator` / `evaluateVocabularyComplexity` |
 | `<Evaluator>Internal` types | `<Evaluator>Result` |
 | `GradeLevelAppropriatenessSchema` | `GradeLevelAppropriatenessOutputSchema` |
-| `Providers` | `Provider` |
+| `evaluator.evaluateByGrade(...)` | `evaluator.evaluateByGradeLevel(...)` |
+| `Providers` (redundant alias; `Provider` already existed and is unchanged) | use `Provider` |
 
 `TextComplexityEvaluator`, `evaluateTextComplexity`, `TextComplexityResult` and `TextComplexityLevel` are **removed with no replacement.** The composite ran several evaluators and merged their verdicts, which hid which model produced what. Call the evaluators you want and combine the results yourself, or use the `text-complexity` batch family, which does this with a report.
 
@@ -152,7 +165,14 @@ The word "grade" meant three things across the API, the Knowledge Graph boundary
 
 - Evaluator input: `grade` → `grade_level`
 - Result and report fields: `grade` → `gradeLevel`
-- Batch CSV column: `grade` → `grade_level` — **existing input files need the header renamed**
+- Batch CSV column: `grade` → `grade_level` — **existing input files need the header renamed**:
+
+  ```diff
+  - text,grade
+  + text,grade_level
+  ```
+
+  The other families' columns are in the [README](./README.md#batch).
 
 ## 6. The Learning Commons key is one option
 
@@ -164,6 +184,17 @@ The word "grade" meant three things across the API, the Knowledge Graph boundary
 
 Both `partnerKey` and `platformApiKey` are gone. `learningCommonsApiKey` on the evaluator config authorizes Learning Commons API calls such as the Knowledge Graph. Identified telemetry is a separate, opt-in setting: `telemetry: { learningCommonsApiKey: key }`.
 
+**TypeScript will not always catch this.** Excess-property checking only applies to an object
+literal written at the call site. If your keys come from a shared variable — the common case —
+the removed property is silently ignored and identified telemetry just stops:
+
+```typescript
+const keys = { googleApiKey, partnerKey };   // no error; partnerKey is simply dropped
+new VocabularyComplexityEvaluator(keys);
+```
+
+Grep for `partnerKey` and `platformApiKey` rather than relying on the compiler.
+
 ## 7. Peer dependencies moved a major version
 
 Covered by step 0 above, which has to happen first. For reference:
@@ -173,33 +204,60 @@ Covered by step 0 above, which has to happen first. For reference:
 | `ai` | `>=6.0.0` | `>=7.0.0` |
 | `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0` |
 
-## 8. Math standards alignment returns the envelope
+## 8. Math standards alignment: named inputs, and the envelope
 
-It was the last evaluator returning its payload bare.
+Both the arguments and the return value changed. It was also the last evaluator returning its
+payload bare.
 
 ```diff
-- const alignment = await evaluator.evaluate({ ... });
+- const alignment = await evaluator.evaluate(question, statementCode, jurisdiction);
 - console.log(alignment.alignedCount);
-+ const { result } = await evaluator.evaluate({ ... });
++ const { result } = await evaluator.evaluate({ question, statementCode, jurisdiction });
 + console.log(result.alignedCount);
 ```
 
-`evaluateItems` and `evaluateByGradeLevel` are unchanged: one call fans out over many question × standard pairs, so there is no single model or duration to report.
+`statementCode` is the bare dotted code, **not** the full CCSS URI: `"5.NF.A.1"`, not
+`"CCSS.MATH.CONTENT.5.NF.A.1"`. The long form raises `StandardNotFoundError`.
+
+`evaluateItems` keeps its name and arguments. **`evaluateByGrade` is now
+`evaluateByGradeLevel`** — arguments unchanged. Neither returns an envelope: one call fans out
+over many question × standard pairs, so there is no single model or duration to report.
 
 ## 9. Smaller behaviour changes
 
-- **`metadata.supportedGrades`** now reports what the contract says the evaluator targets. Previously it was derived from the grade input's enum, so the seven feedback evaluators and Grade Level Appropriateness published `[]`. It is not a validation set — where a `grade_level` input exists, its schema enum is what rejects a bad value.
+- **`supportedGrades`** — read as `SomeEvaluator.metadata.supportedGrades`, the static; the
+  instance member is protected. It now reports what the contract says the evaluator targets. Previously it was derived from the grade input's enum, so the seven feedback evaluators and Grade Level Appropriateness published `[]`. It is not a validation set — where a `grade_level` input exists, its schema enum is what rejects a bad value.
 - **Vocabulary Complexity** reports the model that actually ran for grades 3–4, which differs from the 5–12 branch. If you asserted one model string for all grades, it will now differ.
 - **Grade Level Appropriateness and Sentence Structure** emit exactly the fields their contracts declare. GLA returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`.
 - **The three complexity-score schemas** are generated from their contracts, so field descriptions and enum values follow the contract rather than a hand-written copy.
 
 ## What is new in 1.0.0
 
-- **Seven feedback evaluators** judging teacher comments on student writing, and `OrganizationalStructureEvaluator` and `ReferenceKnowledgeDemandsEvaluator` are now public.
+- **Seven feedback evaluators** judging teacher comments on student writing, each taking
+  `{ student_text, feedback_text }` and returning a binary `quality_score`:
+  `RevisionAccuracyEvaluator`, `RevisionActionabilityEvaluator`,
+  `RevisionManageabilityEvaluator`, `StrengthAcknowledgmentEvaluator`,
+  `StudentResponseSpecificityEvaluator`, `ToneAppropriatenessEvaluator`,
+  `WithholdingAnswersEvaluator`. Also newly public:
+  `OrganizationalStructureEvaluator`, `ReferenceKnowledgeDemandsEvaluator`, and
+  `StandardNotFoundError` (see section 4 — it was not exported in 0.8.0).
 - **`llmProvider`** — bring your own provider. Inject any `LLMProvider` and no API keys are needed, for Vertex AI, Bedrock, a gateway or an eval framework's model system. Mutually exclusive with `modelOverride`.
 - **The `feedback` batch family**, alongside `text-complexity` and `math-standards-alignment`.
-- **`getEvaluators()` / `getEvaluator(id)`** — a registry over all sixteen, for enumeration and
-  for resolving a stored result's id back to the evaluator that produced it. Renamed ids
-  resolve through `idHistory`, so a result written under an old name stays identifiable.
+- **`getEvaluators()` / `getEvaluator(id)`** — a registry over all sixteen. Both return
+  **metadata, not a constructor**: `{ id, stableId, idHistory, name, description, outcome,
+  requiredCredentials, supportedGrades, defaultProviders }`. To run an evaluator, import it by
+  name. Every id 0.8.0 ever wrote into a result still resolves:
+
+  | id stored by 0.8.0 | resolves to |
+  | --- | --- |
+  | `vocabulary` | `student_facing_text.ela_reading.vocabulary_complexity` |
+  | `sentence-structure` | `student_facing_text.ela_reading.sentence_structure` |
+  | `subject-matter-knowledge` | `student_facing_text.ela_reading.background_knowledge_demands` |
+  | `conventionality` | `student_facing_text.ela_reading.meaning_directness` |
+  | `literacy.gla.purpose` | `student_facing_text.ela_reading.purpose_clarity` |
+  | `grade-level-appropriateness` | `student_facing_text.ela_reading.grade_level_appropriateness` |
+  | `math.standards-alignment` | `academic_standards_alignment.mathematics.math_standards_alignment` |
+
+  `text-complexity` does not resolve — that was the removed composite, not an evaluator.
 
 The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both existed in 0.8.0; they are documented in the [README](./README.md) now, which is the change.

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -75,7 +75,10 @@ const evaluation = await evaluator.evaluate({ text, grade_level: "5" });
 const { score, reasoning } = readOutcome(evaluation, MyEvaluator.metadata.outcome);
 ```
 
-`score` is stringified, and is `undefined` for an evaluator whose output is not a single judgement.
+`score` is stringified, and is `undefined` for an evaluator whose output is not a single
+judgement. `reasoning` is always a `string` — empty rather than absent — so it needs no
+optional handling. `metadata.tokenUsage.inputTokens` and `outputTokens` are likewise always
+present numbers.
 
 Writing one helper across several evaluators — the case this replaces — needs a name for that
 second argument. It is exported as `DeclaredOutcome`:
@@ -98,6 +101,29 @@ function toRow(dimension: string, evaluation: EvaluationResult, outcome: Declare
 + metadata.tokenUsage.outputTokens;
 ```
 
+## 2a. The verdict *values* changed — check your stored data
+
+Nothing in the compiler will tell you about this, because `readOutcome` returns `score:
+string`. Every complexity verdict changed case and separator, and the top grade band was
+relabelled:
+
+| | 0.8.0 | 1.0.0 |
+| --- | --- | --- |
+| complexity score | `"Slightly complex"` | `"slightly_complex"` |
+| | `"Moderately complex"` | `"moderately_complex"` |
+| | `"Very complex"` | `"very_complex"` |
+| | `"Exceedingly complex"` | `"exceedingly_complex"` |
+| Purpose Clarity's fifth value | `"More context needed"` | `"more_context_needed"` |
+| top grade band | `"11-CCR"` | `"11-12"` |
+
+The other bands (`K-1`, `2-3`, `4-5`, `6-8`, `9-10`) are unchanged, and the feedback family's
+`0`/`1` is unchanged.
+
+So `if (score === "Very complex")` silently stops matching, a dashboard filter silently returns
+nothing, and a `GROUP BY score` silently splits into old and new buckets. **Grep for the old
+strings, and backfill anything you have persisted.** Values now come straight from each
+evaluator's contract, which is what makes them identical across our SDKs.
+
 ## 3. Evaluators renamed onto the taxonomy
 
 | 0.8.0 | 1.0.0 |
@@ -109,13 +135,14 @@ function toRow(dimension: string, evaluation: EvaluationResult, outcome: Declare
 | `<Evaluator>Internal` types | `<Evaluator>Result` |
 | `GradeLevelAppropriatenessSchema` | `GradeLevelAppropriatenessOutputSchema` |
 | `evaluator.evaluateByGrade(...)` | `evaluator.evaluateByGradeLevel(...)` |
+| `GradeBand` as a **value** (it was a Zod enum, so `GradeBand.options` worked) | type only. For the runtime list use `GradeLevelAppropriatenessOutputSchema.shape.grade_band` |
 | `Providers` (redundant alias; `Provider` already existed and is unchanged) | use `Provider` |
 
 Removed outright, so a `TS2305` on any of these has an entry here:
 
 | removed | replacement |
 | --- | --- |
-| `ComplexityClassification`, `ComplexityClassificationSchema` | each evaluator's own `<Evaluator>Result` / `<Evaluator>OutputSchema`, generated from its contract |
+| `ComplexityClassification`, `ComplexityClassificationSchema` | each evaluator's own `<Evaluator>Result` / `<Evaluator>OutputSchema`, generated from its contract — all fifteen are exported, e.g. `PurposeClarityOutputSchema` |
 | `PurposeComplexityLevel` | `PurposeClarityResult["complexity_score"]` |
 | `VocabularyInternal`, `SmkInternal`, `ConventionalityInternal`, `PurposeInternal`, `SentenceStructureInternal`, `GradeLevelAppropriatenessInternal` | the matching `<Evaluator>Result` |
 
@@ -172,7 +199,10 @@ New: `DependencyError`, `LLMProviderError`, `LLMOutputProcessingError` (an `Eval
 The word "grade" meant three things across the API, the Knowledge Graph boundary and the batch CSV. It is now `gradeLevel` in camelCase contexts and `grade_level` in the wire and CSV formats.
 
 - Evaluator input: `grade` → `grade_level`
-- Result and report fields: `grade` → `gradeLevel`
+- Batch and report fields: `grade` → `gradeLevel`
+- **Result payloads are snake_case and always have been**, so no `gradeLevel` appears in one.
+  Grade Level Appropriateness renamed its payload field `grade` → **`grade_band`** (see
+  section 9); the complexity evaluators' verdict field is `complexity_score`
 - Batch CSV column: `grade` → `grade_level` — **existing input files need the header renamed**:
 
   ```diff
@@ -266,6 +296,8 @@ over many question × standard pairs, so there is no single model or duration to
   | `grade-level-appropriateness` | `student_facing_text.ela_reading.grade_level_appropriateness` |
   | `math.standards-alignment` | `academic_standards_alignment.mathematics.math_standards_alignment` |
 
-  `text-complexity` does not resolve — that was the removed composite, not an evaluator.
+  `getEvaluator` returns `undefined` for anything it cannot resolve rather than throwing, so
+  check before use. `text-complexity` returns `undefined` — that was the removed composite,
+  not an evaluator.
 
 The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both existed in 0.8.0; they are documented in the [README](./README.md) now, which is the change.

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -1,0 +1,158 @@
+# Migrating from 0.8.0 to 1.0.0
+
+1.0.0 moves every evaluator onto the shared, language-neutral contracts under `evals/`, so the SDK reads its models, prompts, grades, inputs and output shapes from the same declarations the Python SDK and the notebooks use. The payoff is that a result is now identical across our SDKs; the cost is that most of the public surface changed at once.
+
+Twenty-six exported names are gone and seventy-one are new. Work through the sections below in order — the first four affect every caller.
+
+## 1. `evaluate()` takes named inputs
+
+Positional arguments are gone. Each evaluator declares its inputs in `input_schema.json`, and those names are the argument keys.
+
+```diff
+- await evaluator.evaluate(text, "5");
++ await evaluator.evaluate({ text, grade_level: "5" });
+```
+
+Input names by family:
+
+| Family | Inputs |
+| --- | --- |
+| Text complexity (7 evaluators) | `{ text, grade_level }` |
+| `GradeLevelAppropriatenessEvaluator` | `{ text }` |
+| Feedback (7 evaluators) | `{ student_text, feedback_text }` |
+| `MathStandardsAlignmentEvaluator` | `{ question, statementCode, jurisdiction }` |
+
+Unknown keys, missing keys and out-of-range values now throw `InputValidationError` before any model runs. Text is bounded at 1–10,000 characters, measured as you sent it.
+
+## 2. The result envelope changed shape
+
+```diff
+- interface EvaluationResult<TScore, TInternal> {
+-   score: TScore;
+-   reasoning: string;
+-   metadata: EvaluationMetadata;
+-   _internal?: TInternal;
+- }
++ interface EvaluationResult<TResult> {
++   evaluator: string;   // the registry id
++   result: TResult;     // the payload, exactly as output_schema.json declares it
++   metadata: EvaluationMetadata;
++ }
+```
+
+There is no hoisted `score` and no `_internal`. The payload is the model's structured output with keys and values unaltered, which is what makes it byte-identical across SDKs.
+
+```diff
+- const { score, reasoning, _internal } = await evaluator.evaluate(text, "5");
++ const { result } = await evaluator.evaluate({ text, grade_level: "5" });
++ const { complexity_score, reasoning } = result;
+```
+
+If you had generic code over several evaluators that relied on `score`, use `readOutcome`, which reads whichever fields the contract nominates as the verdict and its rationale:
+
+```typescript
+import { readOutcome } from "@learning-commons/evaluators";
+
+const evaluation = await evaluator.evaluate({ text, grade_level: "5" });
+const { score, reasoning } = readOutcome(evaluation, MyEvaluator.metadata.outcome);
+```
+
+`score` is stringified, and is `undefined` for an evaluator whose output is not a single judgement.
+
+**Token counts moved** into a nested object:
+
+```diff
+- metadata.inputTokens;
+- metadata.outputTokens;
++ metadata.tokenUsage.inputTokens;
++ metadata.tokenUsage.outputTokens;
+```
+
+## 3. Evaluators renamed onto the taxonomy
+
+| 0.8.0 | 1.0.0 |
+| --- | --- |
+| `SmkEvaluator` / `evaluateSmk` | `BackgroundKnowledgeDemandsEvaluator` / `evaluateBackgroundKnowledgeDemands` |
+| `ConventionalityEvaluator` / `evaluateConventionality` | `MeaningDirectnessEvaluator` / `evaluateMeaningDirectness` |
+| `PurposeEvaluator` / `evaluatePurpose` | `PurposeClarityEvaluator` / `evaluatePurposeClarity` |
+| `VocabularyEvaluator` / `evaluateVocabulary` | `VocabularyComplexityEvaluator` / `evaluateVocabularyComplexity` |
+| `<Evaluator>Internal` types | `<Evaluator>Result` |
+| `GradeLevelAppropriatenessSchema` | `GradeLevelAppropriatenessOutputSchema` |
+| `Providers` | `Provider` |
+
+`TextComplexityEvaluator`, `evaluateTextComplexity`, `TextComplexityResult` and `TextComplexityLevel` are **removed with no replacement.** The composite ran several evaluators and merged their verdicts, which hid which model produced what. Call the evaluators you want and combine the results yourself, or use the `text-complexity` batch family, which does this with a report.
+
+## 4. Errors are grouped by fault domain
+
+`EvaluatorError` is still the root, but the middle of the hierarchy is new — you can now catch by who is at fault.
+
+| 0.8.0 | 1.0.0 |
+| --- | --- |
+| `ValidationError` | `InputValidationError` |
+| `TimeoutError` | `RequestTimeoutError` |
+| `APIError` | **removed** — catch `DependencyError` instead |
+
+`AuthenticationError`, `RateLimitError` and `NetworkError` kept their names but now extend `DependencyError` rather than `APIError`. `KnowledgeGraphError` also moved under `DependencyError`.
+
+One reparenting is easy to miss: **`StandardNotFoundError` now extends `InputValidationError`**, not `KnowledgeGraphError`. A code that does not resolve is a bad input, not an upstream failure, so a `catch (e) { if (e instanceof KnowledgeGraphError) ... }` that used to see it no longer will.
+
+New: `DependencyError`, `LLMProviderError`, `LLMOutputProcessingError` (an `EvaluationError`, for a response that arrived but could not be used).
+
+## 5. `grade` is `gradeLevel` everywhere
+
+The word "grade" meant three things across the API, the Knowledge Graph boundary and the batch CSV. It is now `gradeLevel` in camelCase contexts and `grade_level` in the wire and CSV formats.
+
+- Evaluator input: `grade` → `grade_level`
+- Result and report fields: `grade` → `gradeLevel`
+- Batch CSV column: `grade` → `grade_level` — **existing input files need the header renamed**
+
+## 6. The Learning Commons key is one option
+
+```diff
+- new MathStandardsAlignmentEvaluator({ platformApiKey: key });
+- new SomeEvaluator({ partnerKey: key });
++ new MathStandardsAlignmentEvaluator({ learningCommonsApiKey: key });
+```
+
+Both `partnerKey` and `platformApiKey` are gone. `learningCommonsApiKey` on the evaluator config authorizes Learning Commons API calls such as the Knowledge Graph. Identified telemetry is a separate, opt-in setting: `telemetry: { learningCommonsApiKey: key }`.
+
+## 7. Peer dependencies moved a major version
+
+```bash
+npm install ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
+```
+
+| Peer | 0.8.0 | 1.0.0 |
+| --- | --- | --- |
+| `ai` | `>=6.0.0` | `>=7.0.0` |
+| `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0` |
+
+Node's minimum is unchanged at `>=20.19.0`.
+
+## 8. Math standards alignment returns the envelope
+
+It was the last evaluator returning its payload bare.
+
+```diff
+- const alignment = await evaluator.evaluate({ ... });
+- console.log(alignment.alignedCount);
++ const { result } = await evaluator.evaluate({ ... });
++ console.log(result.alignedCount);
+```
+
+`evaluateItems` and `evaluateByGradeLevel` are unchanged: one call fans out over many question × standard pairs, so there is no single model or duration to report.
+
+## 9. Smaller behaviour changes
+
+- **`metadata.supportedGrades`** now reports what the contract says the evaluator targets. Previously it was derived from the grade input's enum, so the seven feedback evaluators and Grade Level Appropriateness published `[]`. It is not a validation set — where a `grade_level` input exists, its schema enum is what rejects a bad value.
+- **Vocabulary Complexity** reports the model that actually ran for grades 3–4, which differs from the 5–12 branch. If you asserted one model string for all grades, it will now differ.
+- **Grade Level Appropriateness and Sentence Structure** emit exactly the fields their contracts declare. GLA returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`.
+- **The three complexity-score schemas** are generated from their contracts, so field descriptions and enum values follow the contract rather than a hand-written copy.
+
+## What is new in 1.0.0
+
+- **Seven feedback evaluators** judging teacher comments on student writing, and `OrganizationalStructureEvaluator` and `ReferenceKnowledgeDemandsEvaluator` are now public.
+- **`llmProvider`** — bring your own provider. Inject any `LLMProvider` and no API keys are needed, for Vertex AI, Bedrock, a gateway or an eval framework's model system. Mutually exclusive with `modelOverride`.
+- **The `feedback` batch family**, alongside `text-complexity` and `math-standards-alignment`.
+
+The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both existed in 0.8.0; they are documented in the [README](./README.md) now, which is the change.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/@learning-commons/evaluators)](https://www.npmjs.com/package/@learning-commons/evaluators)
 
-TypeScript SDK for [Learning Commons evaluators](https://docs.learningcommons.org/evaluators/understanding-evaluators/introduction).
+TypeScript SDK for [Learning Commons evaluators](https://docs.learningcommons.org/evaluators/understanding-evaluators/introduction) — sixteen LLM-backed evaluators for the complexity of text students read, the quality of feedback they receive, and the alignment of math items to standards.
+
+Requires Node >= 20.19.0.
 
 ## Installation
 
@@ -12,7 +14,7 @@ Install the `@learning-commons/evaluators` and [Vercel AI](https://sdk.vercel.ai
 npm install @learning-commons/evaluators ai
 ```
 
-Next, install the provider adapter(s) for your LLM(s):
+Next, install the provider adapter(s) for the evaluators you plan to run — the table below gives each evaluator's provider:
 
 ```bash
 npm install @ai-sdk/openai     # OpenAI
@@ -29,24 +31,161 @@ const evaluator = new GradeLevelAppropriatenessEvaluator({
   googleApiKey: process.env.GOOGLE_API_KEY,
 });
 
-const result = await evaluator.evaluate({ text: "The cat's out of the bag now." });
-console.log(result.result.grade); // 4-5
+const { result, metadata } = await evaluator.evaluate({
+  text: "The cat's out of the bag now.",
+});
+
+console.log(result.grade_band); // "4-5"
+console.log(result.alternative_grade_band); // "2-3", reachable with scaffolding
+console.log(metadata.model); // "google:gemini-3.6-flash"
+```
+
+Every evaluator resolves to the same three-part envelope, so generic code works across all sixteen:
+
+```typescript
+{
+  evaluator: string;   // registry id, e.g. "student_facing_text.ela_reading.vocabulary_complexity"
+  result: TResult;     // the evaluator's own payload, exactly as its output schema declares it
+  metadata: {
+    model: string;             // "provider:model" for the model that actually ran
+    processingTimeMs: number;
+    tokenUsage: { inputTokens: number; outputTokens: number };
+  };
+}
+```
+
+`result` is the model's structured output with keys and values unaltered, so the payload is identical across our SDKs. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
+
+```typescript
+import { readOutcome, VocabularyComplexityEvaluator } from "@learning-commons/evaluators";
+
+const evaluation = await new VocabularyComplexityEvaluator({
+  googleApiKey: process.env.GOOGLE_API_KEY,
+  openaiApiKey: process.env.OPENAI_API_KEY,
+}).evaluate({ text, grade_level: "5" });
+
+const { score, reasoning } = readOutcome(evaluation, VocabularyComplexityEvaluator.metadata.outcome);
+```
+
+## Evaluators
+
+Text complexity — how demanding a text is for a given grade. Each takes `{ text, grade_level }` and returns a `complexity_score` on a four-level scale — `slightly_complex`, `moderately_complex`, `very_complex`, `exceedingly_complex` — with `reasoning`. Purpose Clarity can also answer `more_context_needed`.
+
+| Evaluator | Grades | Provider | Docs |
+| --- | --- | --- | --- |
+| `BackgroundKnowledgeDemandsEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/subject-matter-knowledge/about-this-evaluator) |
+| `MeaningDirectnessEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/conventionality/about-this-evaluator) |
+| `OrganizationalStructureEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/organizational-structure) |
+| `PurposeClarityEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/purpose/about-this-evaluator) |
+| `ReferenceKnowledgeDemandsEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/intertextuality) |
+| `SentenceStructureEvaluator` | 3–12 | OpenAI | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/sentence-structure-evaluator/about-this-evaluator) |
+| `VocabularyComplexityEvaluator` | 3–12 | Google + OpenAI | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/vocabulary-evaluator/about-this-evaluator) |
+
+Grade band — takes `{ text }` only, and determines the grade rather than judging against one. Returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`.
+
+| Evaluator | Grades | Provider | Docs |
+| --- | --- | --- | --- |
+| `GradeLevelAppropriatenessEvaluator` | K–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/grade-level-appropriateness-evaluator/about-this-evaluator) |
+
+Feedback quality — judges a teacher comment on a student's writing. Each takes `{ student_text, feedback_text }` and returns a binary `quality_score` with `reasoning`, `key_features` and `proposed_adjustment`.
+
+| Evaluator | Grades | Provider |
+| --- | --- | --- |
+| `RevisionAccuracyEvaluator` | 6–12 | OpenAI |
+| `RevisionActionabilityEvaluator` | 6–12 | OpenAI |
+| `RevisionManageabilityEvaluator` | 6–12 | OpenAI |
+| `StrengthAcknowledgmentEvaluator` | 6–12 | OpenAI |
+| `StudentResponseSpecificityEvaluator` | 6–12 | OpenAI |
+| `ToneAppropriatenessEvaluator` | 6–12 | OpenAI |
+| `WithholdingAnswersEvaluator` | 6–12 | OpenAI |
+
+Standards alignment — checks a math item against a standard, component by component.
+
+| Evaluator | Grades | Provider | Also needs |
+| --- | --- | --- | --- |
+| `MathStandardsAlignmentEvaluator` | K–12 | Anthropic | `learningCommonsApiKey` (Knowledge Graph) |
+
+```typescript
+import { MathStandardsAlignmentEvaluator, Jurisdiction } from "@learning-commons/evaluators";
+
+const { result } = await new MathStandardsAlignmentEvaluator({
+  anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  learningCommonsApiKey: process.env.LEARNING_COMMONS_API_KEY,
+}).evaluate({
+  question: "A playground is shaped like an L. What is its area?",
+  statementCode: "3.MD.C.7.d",
+  jurisdiction: Jurisdiction.MultiState,
+});
+
+console.log(`${result.alignedCount}/${result.totalCount} learning components aligned`);
+```
+
+Each evaluator is also available as a function — `evaluateGradeLevelAppropriateness(input, config)` and so on — for callers who would rather not hold an instance.
+
+## Configuration
+
+Every evaluator takes the same options:
+
+| Option | Purpose |
+| --- | --- |
+| `googleApiKey` / `openaiApiKey` / `anthropicApiKey` | Keys for the providers the evaluator uses |
+| `learningCommonsApiKey` | Authorizes Learning Commons API calls, such as the Knowledge Graph |
+| `modelOverride` | Run every call on a different `{ provider, model }` |
+| `llmProvider` | Bring your own provider (see below) |
+| `maxRetries` | Retries per failed call (default 2, so 3 attempts) |
+| `telemetry` | `true`, `false`, or `TelemetryOptions` (default on, without input recording) |
+| `logger` / `logLevel` | Inject a logger, or set the console logger's level (default `WARN`) |
+
+### Bring your own provider
+
+Pass any object implementing `LLMProvider` and the evaluator routes every call through it, skipping the built-in API-key adapters entirely — useful for Google Vertex AI, Amazon Bedrock, an AI-SDK gateway, or an eval framework's model system. No provider API keys are needed, and any ambient ones go unused.
+
+```typescript
+const evaluator = new SentenceStructureEvaluator({ llmProvider: myProvider });
+```
+
+It is mutually exclusive with `modelOverride`: setting both throws `ConfigurationError`.
+
+## Batch
+
+`@learning-commons/evaluators/batch` runs a CSV of rows through a family of evaluators, with concurrency, retries, and CSV/JSON/HTML output.
+
+```typescript
+import { BatchEvaluator, getFamily, parseCSV } from "@learning-commons/evaluators/batch";
+```
+
+The same thing is available as a command, installed as `evaluators-batch`:
+
+```bash
+npx evaluators-batch input.csv --family text-complexity --output-dir ./results
+npx evaluators-batch --help
+```
+
+## Errors
+
+Errors are grouped by fault domain, so you can catch by who is at fault rather than by individual failure. All extend `EvaluatorError`.
+
+| Class | Meaning |
+| --- | --- |
+| `ConfigurationError` | The SDK was set up wrong — missing key, conflicting options, a model the provider rejects |
+| `InputValidationError` | The input was rejected before any model ran; `StandardNotFoundError` is a subclass |
+| `EvaluationError` | The evaluation ran but could not be completed; `LLMOutputProcessingError` is a subclass |
+| `DependencyError` | Something the SDK depends on failed. Subclasses: `AuthenticationError`, `RateLimitError`, `NetworkError`, `RequestTimeoutError`, `LLMProviderError`, `KnowledgeGraphError` |
+
+```typescript
+try {
+  await evaluator.evaluate({ text, grade_level: "5" });
+} catch (error) {
+  if (error instanceof RateLimitError) retryLater();
+  else if (error instanceof DependencyError) reportUpstreamOutage(error);
+  else if (error instanceof InputValidationError) fixTheRow(error);
+  else throw error;
+}
 ```
 
 ## Documentation
 
-| Evaluator                   | Documentation                                                                                                                      |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Grade Level Appropriateness | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/grade-level-appropriateness-evaluator/about-this-evaluator) |
-| Background Knowledge Demands | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/subject-matter-knowledge/about-this-evaluator)              |
-| Vocabulary Complexity       | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/vocabulary-evaluator/about-this-evaluator)                  |
-| Sentence Structure          | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/sentence-structure-evaluator/about-this-evaluator)          |
-| Meaning Directness          | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/conventionality/about-this-evaluator)                       |
-| Purpose Clarity             | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/purpose/about-this-evaluator)                               |
-| Reference Knowledge Demands | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/intertextuality)                                            |
-| Organizational Structure    | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/organizational-structure)                                   |
-
-For more implementation details, visit [our docs site](https://docs.learningcommons.org/evaluators/sdk-api-reference/overview).
+Full reference at [our docs site](https://docs.learningcommons.org/evaluators/sdk-api-reference/overview). Upgrading from 0.8.0? See [MIGRATION.md](./MIGRATION.md).
 
 ## License
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -6,6 +6,11 @@ TypeScript SDK for [Learning Commons evaluators](https://docs.learningcommons.or
 
 Requires Node >= 20.19.0.
 
+TypeScript consumers currently need `"skipLibCheck": true` in `tsconfig.json`. The bundled
+declaration file inlines the evaluator contracts as value declarations, which `tsc` rejects
+in an ambient context; without the flag a build fails on the SDK's own types rather than
+yours. Tracked as a package defect, not a permanent requirement.
+
 ## Installation
 
 Install the `@learning-commons/evaluators` and [Vercel AI](https://sdk.vercel.ai) SDKs:
@@ -48,14 +53,16 @@ Every evaluator resolves to the same three-part envelope, so generic code works 
   evaluator: string;   // registry id, e.g. "student_facing_text.ela_reading.vocabulary_complexity"
   result: TResult;     // the evaluator's own payload, exactly as its output schema declares it
   metadata: {
-    model: string;             // "provider:model" for the model that actually ran
+    model: string;             // "provider:model" that ran; "a+b" when several did
     processingTimeMs: number;
     tokenUsage: { inputTokens: number; outputTokens: number };
   };
 }
 ```
 
-`result` is the model's structured output with keys and values unaltered, so the payload is identical across our SDKs. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
+`result` is the model's structured output with keys and values unaltered, so the payload is identical across our SDKs. Payloads carry more than the verdict — Vocabulary Complexity also returns its `tier_2_words`, `tier_3_words`, `archaic_words` and `other_complex_words`, and the feedback family's `key_features` maps each criterion to `{ met, justification }`.
+
+`metadata.model` names every model that ran, joined by `+` when an evaluator uses more than one — so a multi-step evaluator reports e.g. `openai:gpt-4o-…+openai:gpt-4.1-…`. Which models run can also depend on the input: Vocabulary Complexity takes a different branch for grades 3-4 than for 5-12. The **Required key** column below is what you must supply, not a promise about which provider serves a given call. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
 
 ```typescript
 import { readOutcome, VocabularyComplexityEvaluator } from "@learning-commons/evaluators";
@@ -72,7 +79,7 @@ const { score, reasoning } = readOutcome(evaluation, VocabularyComplexityEvaluat
 
 Text complexity — how demanding a text is for a given grade. Each takes `{ text, grade_level }` and returns a `complexity_score` on a four-level scale — `slightly_complex`, `moderately_complex`, `very_complex`, `exceedingly_complex` — with `reasoning`. Purpose Clarity can also answer `more_context_needed`.
 
-| Evaluator | Grades | Provider | Docs |
+| Evaluator | Grades | Required key | Docs |
 | --- | --- | --- | --- |
 | `BackgroundKnowledgeDemandsEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/subject-matter-knowledge/about-this-evaluator) |
 | `MeaningDirectnessEvaluator` | 3–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/conventionality/about-this-evaluator) |
@@ -84,13 +91,13 @@ Text complexity — how demanding a text is for a given grade. Each takes `{ tex
 
 Grade band — takes `{ text }` only, and determines the grade rather than judging against one. Returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`. Bands are `K-1`, `2-3`, `4-5`, `6-8`, `9-10`, `11-12` — spans on the CCSS text-complexity scale, not single grades.
 
-| Evaluator | Grades | Provider | Docs |
+| Evaluator | Grades | Required key | Docs |
 | --- | --- | --- | --- |
 | `GradeLevelAppropriatenessEvaluator` | K–12 | Google | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/grade-level-appropriateness-evaluator/about-this-evaluator) |
 
 Feedback quality — judges a teacher comment on a student's writing. Each takes `{ student_text, feedback_text }` and returns a binary `quality_score` with `reasoning`, `key_features` and `proposed_adjustment`.
 
-| Evaluator | Grades | Provider |
+| Evaluator | Grades | Required key |
 | --- | --- | --- |
 | `RevisionAccuracyEvaluator` | 6–12 | OpenAI |
 | `RevisionActionabilityEvaluator` | 6–12 | OpenAI |
@@ -102,7 +109,7 @@ Feedback quality — judges a teacher comment on a student's writing. Each takes
 
 Standards alignment — checks a math item against a standard, component by component.
 
-| Evaluator | Grades | Provider | Also needs |
+| Evaluator | Grades | Required key | Also needs |
 | --- | --- | --- | --- |
 | `MathStandardsAlignmentEvaluator` | K–12 | Anthropic | `learningCommonsApiKey` (Knowledge Graph) |
 
@@ -138,7 +145,7 @@ for (const { id, name, supportedGrades } of getEvaluators()) {
 getEvaluator("conventionality")?.name; // "Meaning Directness Evaluator"
 ```
 
-Both return metadata — `id`, `stableId`, `idHistory`, `name`, `description`, `supportedGrades`, `defaultProviders`, and `outcome` where the evaluator declares a single verdict. To *run* an evaluator, import it by name: the metadata does not tell you which named inputs it takes, and each evaluator's are different.
+Both return metadata — `id`, `stableId`, `idHistory`, `name`, `description`, `supportedGrades`, `defaultProviders`, `requiredCredentials`, and `outcome` where the evaluator declares a single verdict. `requiredCredentials` is the authoritative answer to "which keys does this one need", e.g. `["learning_commons_api_key"]` for math standards alignment. To *run* an evaluator, import it by name: the metadata does not tell you which named inputs it takes, and each evaluator's are different.
 
 ## Configuration
 
@@ -154,13 +161,32 @@ Every evaluator takes the same options:
 | `telemetry` | `true`, `false`, or `TelemetryOptions` (default on, without input recording) |
 | `logger` / `logLevel` | Inject a logger, or set the console logger's level (default `WARN`) |
 
+Keys are read from this object only. There is no environment-variable fallback: setting
+`GOOGLE_API_KEY` in the environment does not satisfy `googleApiKey`, and omitting a key an
+evaluator needs throws `ConfigurationError` at construction. (The `evaluators-batch` command
+is the exception — it does read the environment, as its `--help` describes.)
+
 ### Bring your own provider
 
-Pass any object implementing `LLMProvider` and the evaluator routes every call through it, skipping the built-in API-key adapters entirely — useful for Google Vertex AI, Amazon Bedrock, an AI-SDK gateway, or an eval framework's model system. No provider API keys are needed, and any ambient ones go unused.
+Pass any object implementing `LLMProvider` and the evaluator routes every call through it, skipping the built-in API-key adapters entirely — useful for Google Vertex AI, Amazon Bedrock, an AI-SDK gateway, or an eval framework's model system. No provider API keys are needed.
 
 ```typescript
+import { SentenceStructureEvaluator, type LLMProvider } from "@learning-commons/evaluators";
+
+const myProvider: LLMProvider = {
+  label: "vertex:gemini-2.5-flash", // "provider:model", surfaced as metadata.model
+  generateStructured: async ({ messages, schema, temperature }) => {
+    /* return { data, model, usage: { inputTokens, outputTokens }, latencyMs } */
+  },
+  generateText: async ({ messages, temperature }) => {
+    /* return { text, model, usage: { inputTokens, outputTokens }, latencyMs } */
+  },
+};
+
 const evaluator = new SentenceStructureEvaluator({ llmProvider: myProvider });
 ```
+
+All three members are required; an object missing any of them throws `ConfigurationError`.
 
 It is mutually exclusive with `modelOverride`: setting both throws `ConfigurationError`.
 
@@ -175,9 +201,21 @@ import { BatchEvaluator, getFamily, parseCSV } from "@learning-commons/evaluator
 The same thing is available as a command, installed as `evaluators-batch`:
 
 ```bash
-npx evaluators-batch input.csv --family text-complexity --output-dir ./results
+npx evaluators-batch input.csv --family text-complexity --output-dir ./results -y
 npx evaluators-batch --help
 ```
+
+`-y` makes it non-interactive: without it, it prompts for anything missing, which hangs a CI
+job. Keys come from `--google-api-key` and friends or from the matching environment
+variables. Each family has a row limit; `--bypass-row-limit` lifts it.
+
+The CSV's columns depend on the family. `getFamily(id).columns` is authoritative:
+
+| Family | Required columns | Optional |
+| --- | --- | --- |
+| `text-complexity` | `text`, `grade_level` | — |
+| `feedback` | `student_text`, `feedback_text` | — |
+| `math-standards-alignment` | `question` (or `text`), `statementCode` (or `statement_code`, `standard`) | `jurisdiction` (default Multi-State), `grade_level`, `id` |
 
 ## Errors
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -295,11 +295,22 @@ It is mutually exclusive with `modelOverride`: setting both throws `Configuratio
 `@learning-commons/evaluators/batch` runs a CSV of rows through a family of evaluators, with concurrency and retries, writing CSV and JSON (and HTML for some families — see below).
 
 ```typescript
-import { BatchEvaluator, getFamily, parseCSV } from "@learning-commons/evaluators/batch";
+import { BatchEvaluator, parseCSV } from "@learning-commons/evaluators/batch";
 
 const rows = parseCSV("./input.csv"); // a path, not CSV text
-const family = getFamily("text-complexity");
+
+const output = await new BatchEvaluator({
+  googleApiKey: process.env.GOOGLE_API_KEY,
+  openaiApiKey: process.env.OPENAI_API_KEY,
+  concurrency: 3,
+}).evaluate(rows, "text-complexity", {
+  onProgress: (result) => console.log(result.evaluatorId, result.status),
+});
+
+console.log(`${output.summary.successful}/${output.summary.totalTasks} succeeded`);
 ```
+
+`getFamily(id)` gives you a family's members and column spec if you need to inspect it first.
 
 The same thing is available as a command, installed as `evaluators-batch`:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -35,8 +35,9 @@ const { result, metadata } = await evaluator.evaluate({
   text: "The cat's out of the bag now.",
 });
 
-console.log(result.grade_band); // "4-5"
-console.log(result.alternative_grade_band); // "2-3", reachable with scaffolding
+console.log(result.grade_band); // a CCSS band, e.g. "2-3"
+console.log(result.alternative_grade_band); // the band reachable with scaffolding
+console.log(result.scaffolding_needed); // what that band would need
 console.log(metadata.model); // "google:gemini-3.6-flash"
 ```
 
@@ -81,7 +82,7 @@ Text complexity — how demanding a text is for a given grade. Each takes `{ tex
 | `SentenceStructureEvaluator` | 3–12 | OpenAI | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/sentence-structure-evaluator/about-this-evaluator) |
 | `VocabularyComplexityEvaluator` | 3–12 | Google + OpenAI | [Link](https://docs.learningcommons.org/evaluators/literacy-evaluators/vocabulary-evaluator/about-this-evaluator) |
 
-Grade band — takes `{ text }` only, and determines the grade rather than judging against one. Returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`.
+Grade band — takes `{ text }` only, and determines the grade rather than judging against one. Returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`. Bands are `K-1`, `2-3`, `4-5`, `6-8`, `9-10`, `11-12` — spans on the CCSS text-complexity scale, not single grades.
 
 | Evaluator | Grades | Provider | Docs |
 | --- | --- | --- | --- |

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -123,6 +123,23 @@ console.log(`${result.alignedCount}/${result.totalCount} learning components ali
 
 Each evaluator is also available as a function — `evaluateGradeLevelAppropriateness(input, config)` and so on — for callers who would rather not hold an instance.
 
+## Discovering evaluators
+
+Every evaluator is listed in a registry, keyed by the registry id that appears on each result:
+
+```typescript
+import { getEvaluators, getEvaluator } from "@learning-commons/evaluators";
+
+for (const { id, name, supportedGrades } of getEvaluators()) {
+  console.log(`${name} (${id}) — grades ${supportedGrades.join(", ")}`);
+}
+
+// Renamed ids still resolve, so a stored result stays identifiable.
+getEvaluator("conventionality")?.name; // "Meaning Directness Evaluator"
+```
+
+Both return metadata — `id`, `stableId`, `idHistory`, `name`, `description`, `supportedGrades`, `defaultProviders`, and `outcome` where the evaluator declares a single verdict. To *run* an evaluator, import it by name: the metadata does not tell you which named inputs it takes, and each evaluator's are different.
+
 ## Configuration
 
 Every evaluator takes the same options:

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -6,10 +6,27 @@ TypeScript SDK for [Learning Commons evaluators](https://docs.learningcommons.or
 
 Requires Node >= 20.19.0.
 
-TypeScript consumers currently need `"skipLibCheck": true` in `tsconfig.json`. The bundled
-declaration file inlines the evaluator contracts as value declarations, which `tsc` rejects
-in an ambient context; without the flag a build fails on the SDK's own types rather than
-yours. Tracked as a package defect, not a permanent requirement.
+The SDK is ESM-first and the examples below use top-level `await`, so a TypeScript project
+needs `"type": "module"` in `package.json`, `@types/node`, and:
+
+```json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  }
+}
+```
+
+`skipLibCheck` is currently required, not merely advisable: the bundled declaration file
+inlines the evaluator contracts as value declarations, which `tsc` rejects in an ambient
+context, so without it a build fails on the SDK's own types rather than yours. That is a
+package defect being fixed, not a permanent requirement. CommonJS consumers can `require`
+the package but will need to rewrite the top-level `await` in these snippets.
 
 ## Installation
 
@@ -60,7 +77,17 @@ Every evaluator resolves to the same three-part envelope, so generic code works 
 }
 ```
 
-`result` is the model's structured output with keys and values unaltered, so the payload is identical across our SDKs. Payloads carry more than the verdict — Vocabulary Complexity also returns its `tier_2_words`, `tier_3_words`, `archaic_words` and `other_complex_words`, and the feedback family's `key_features` maps each criterion to `{ met, justification }`.
+`result` is the model's structured output with keys and values unaltered, so the payload is identical across our SDKs. Payloads carry more than the verdict, and how much varies by evaluator: Background Knowledge
+Demands returns `identified_topics`, `curriculum_check`, `assumptions_and_scaffolding` and
+`friction_analysis`; Meaning Directness returns `conventionality_features`, `grade_context` and
+`instructional_insights`; Organizational Structure, Purpose Clarity and Reference Knowledge
+Demands each return a nested `details`; Vocabulary Complexity returns `tier_2_words`,
+`tier_3_words`, `archaic_words` and `other_complex_words` as comma-joined strings. Only
+Sentence Structure returns just the score and reasoning. Each evaluator exports its payload
+type (`VocabularyComplexityResult` and so on) — that is the authoritative shape.
+
+The feedback family's `quality_score` is the **number** `0` or `1`, and its `key_features` maps
+each criterion to `{ met: 0 | 1, justification: string }` — `met` is a number, not a boolean.
 
 `metadata.model` names every model that ran, joined by `+` when an evaluator uses more than one — so a multi-step evaluator reports e.g. `openai:gpt-4o-…+openai:gpt-4.1-…`. Which models run can also depend on the input: Vocabulary Complexity takes a different branch for grades 3-4 than for 5-12. The **Required key** column below is what you must supply, not a promise about which provider serves a given call. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
 
@@ -74,6 +101,13 @@ const evaluation = await new VocabularyComplexityEvaluator({
 
 const { score, reasoning } = readOutcome(evaluation, VocabularyComplexityEvaluator.metadata.outcome);
 ```
+
+`score` is **always a string**, or `undefined` when the evaluator declares no single verdict.
+That matters for the feedback family, whose verdict is the number `0` or `1`: `readOutcome`
+returns `"0"`, and `"0"` is truthy in JavaScript. Compare explicitly — `score === "1"` — or read
+the payload field directly (`evaluation.result.quality_score`, a real number) when you want
+arithmetic. The second argument's type is exported as `DeclaredOutcome`, so you can write one
+helper across several evaluators.
 
 ## Evaluators
 
@@ -145,7 +179,10 @@ for (const { id, name, supportedGrades } of getEvaluators()) {
 getEvaluator("conventionality")?.name; // "Meaning Directness Evaluator"
 ```
 
-Both return metadata — `id`, `stableId`, `idHistory`, `name`, `description`, `supportedGrades`, `defaultProviders`, `requiredCredentials`, and `outcome` where the evaluator declares a single verdict. `requiredCredentials` is the authoritative answer to "which keys does this one need", e.g. `["learning_commons_api_key"]` for math standards alignment. To *run* an evaluator, import it by name: the metadata does not tell you which named inputs it takes, and each evaluator's are different.
+Both return metadata — `id`, `stableId`, `idHistory`, `name`, `description`, `supportedGrades`, `defaultProviders`, `requiredCredentials`, and `outcome` where the evaluator declares a single verdict. `requiredCredentials` lists only **non-LLM** services — it is `["learning_commons_api_key"]` for
+math standards alignment and `[]` for the other fifteen, so it is not the answer to "which keys
+does this need". Provider keys follow `defaultProviders`: `["google"]` means supply
+`googleApiKey`. To *run* an evaluator, import it by name: the metadata does not tell you which named inputs it takes, and each evaluator's are different.
 
 ## Configuration
 
@@ -155,11 +192,24 @@ Every evaluator takes the same options:
 | --- | --- |
 | `googleApiKey` / `openaiApiKey` / `anthropicApiKey` | Keys for the providers the evaluator uses |
 | `learningCommonsApiKey` | Authorizes Learning Commons API calls, such as the Knowledge Graph |
-| `modelOverride` | Run every call on a different `{ provider, model }` |
+| `modelOverride` | Run every call on a different `{ provider, model }`; `provider` is the exported `Provider` enum |
 | `llmProvider` | Bring your own provider (see below) |
 | `maxRetries` | Retries per failed call (default 2, so 3 attempts) |
 | `telemetry` | `true`, `false`, or `TelemetryOptions` (default on, without input recording) |
-| `logger` / `logLevel` | Inject a logger, or set the console logger's level (default `WARN`) |
+| `logger` / `logLevel` | Inject a logger, or set the console logger's level with the exported `LogLevel` enum (default `LogLevel.WARN`) |
+
+`Provider` and `LogLevel` are enums, not strings — `provider: "google"` and
+`logLevel: "ERROR"` do not compile:
+
+```typescript
+import { Provider, LogLevel, VocabularyComplexityEvaluator } from "@learning-commons/evaluators";
+
+new VocabularyComplexityEvaluator({
+  googleApiKey, openaiApiKey,
+  modelOverride: { provider: Provider.Google, model: "gemini-2.5-flash" },
+  logLevel: LogLevel.ERROR,
+});
+```
 
 Keys are read from this object only. There is no environment-variable fallback: setting
 `GOOGLE_API_KEY` in the environment does not satisfy `googleApiKey`, and omitting a key an
@@ -170,32 +220,85 @@ is the exception — it does read the environment, as its `--help` describes.)
 
 Pass any object implementing `LLMProvider` and the evaluator routes every call through it, skipping the built-in API-key adapters entirely — useful for Google Vertex AI, Amazon Bedrock, an AI-SDK gateway, or an eval framework's model system. No provider API keys are needed.
 
+Three members are required, and the two methods are **not symmetrical**: `generateStructured`
+takes one object and must return a `model`, while `generateText` takes positional arguments and
+must not. `messages` includes the `system` turn, which most backends want as a separate
+argument. A `temperature` of `null` means *send no temperature at all* — some models reject an
+explicit value — so forward it conditionally rather than coercing it with `?? undefined`.
+
 ```typescript
-import { SentenceStructureEvaluator, type LLMProvider } from "@learning-commons/evaluators";
+import { generateText, Output } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { SentenceStructureEvaluator, type LLMProvider, type Message } from "@learning-commons/evaluators";
+
+/** `ai` takes the system turn as its own option; leaving it in `messages` is rejected. */
+function split(messages: Message[]) {
+  const system = messages.find((m) => m.role === "system");
+  return {
+    ...(system ? { system: system.content } : {}),
+    messages: messages.filter((m) => m.role !== "system"),
+  };
+}
 
 const myProvider: LLMProvider = {
-  label: "vertex:gemini-2.5-flash", // "provider:model", surfaced as metadata.model
-  generateStructured: async ({ messages, schema, temperature }) => {
-    /* return { data, model, usage: { inputTokens, outputTokens }, latencyMs } */
+  // "provider:model" — this is what the SDK reports as metadata.model.
+  label: "byo:gpt-4o-mini",
+
+  async generateStructured({ messages, schema, temperature }) {
+    const started = Date.now();
+    const { output, usage } = await generateText({
+      model: openai("gpt-4o-mini"),
+      ...split(messages),
+      output: Output.object({ schema }),
+      ...(temperature != null ? { temperature } : {}),
+    });
+
+    return {
+      data: output,
+      model: "gpt-4o-mini",
+      usage: { inputTokens: usage.inputTokens ?? 0, outputTokens: usage.outputTokens ?? 0 },
+      latencyMs: Date.now() - started,
+    };
   },
-  generateText: async ({ messages, temperature }) => {
-    /* return { text, model, usage: { inputTokens, outputTokens }, latencyMs } */
+
+  async generateText(messages, temperature) {
+    const started = Date.now();
+    const { text, usage } = await generateText({
+      model: openai("gpt-4o-mini"),
+      ...split(messages),
+      ...(temperature != null ? { temperature } : {}),
+    });
+
+    return {
+      text,
+      usage: { inputTokens: usage.inputTokens ?? 0, outputTokens: usage.outputTokens ?? 0 },
+      latencyMs: Date.now() - started,
+    };
   },
 };
 
-const evaluator = new SentenceStructureEvaluator({ llmProvider: myProvider });
+const evaluation = await new SentenceStructureEvaluator({ llmProvider: myProvider }).evaluate({
+  text: "The dog ran. It was fast. The children laughed at the sight of it.",
+  grade_level: "5",
+});
+// evaluation.metadata.model === "byo:gpt-4o-mini"
 ```
 
-All three members are required; an object missing any of them throws `ConfigurationError`.
+`schema` is a Zod schema. `zod` is bundled with this package rather than being a peer, so a
+backend that needs the schema in another form should convert it rather than expect a matching
+`zod` of its own. An object missing any of the three members throws `ConfigurationError`.
 
 It is mutually exclusive with `modelOverride`: setting both throws `ConfigurationError`.
 
 ## Batch
 
-`@learning-commons/evaluators/batch` runs a CSV of rows through a family of evaluators, with concurrency, retries, and CSV/JSON/HTML output.
+`@learning-commons/evaluators/batch` runs a CSV of rows through a family of evaluators, with concurrency and retries, writing CSV and JSON (and HTML for some families — see below).
 
 ```typescript
 import { BatchEvaluator, getFamily, parseCSV } from "@learning-commons/evaluators/batch";
+
+const rows = parseCSV("./input.csv"); // a path, not CSV text
+const family = getFamily("text-complexity");
 ```
 
 The same thing is available as a command, installed as `evaluators-batch`:
@@ -215,7 +318,12 @@ The CSV's columns depend on the family. `getFamily(id).columns` is authoritative
 | --- | --- | --- |
 | `text-complexity` | `text`, `grade_level` | — |
 | `feedback` | `student_text`, `feedback_text` | — |
-| `math-standards-alignment` | `question` (or `text`), `statementCode` (or `statement_code`, `standard`) | `jurisdiction` (default Multi-State), `grade_level`, `id` |
+| `math-standards-alignment` | `question` (or `text`), `statementCode` (or `statement_code`, `ccss_standard`, `standard`) | `jurisdiction` (default Multi-State), `grade_level`, `id` (or `item_id`) |
+
+The outputs are a flattened per-row summary — score, reasoning and status — not the full
+payloads, and their shape differs between the standards family and the others. `results.html`
+is written for `text-complexity` and `math-standards-alignment` only; `feedback` gets CSV and
+JSON. For full payloads, call the evaluators directly.
 
 ## Errors
 
@@ -241,7 +349,7 @@ try {
 
 ## Documentation
 
-Full reference at [our docs site](https://docs.learningcommons.org/evaluators/sdk-api-reference/overview). Upgrading from 0.8.0? See [MIGRATION.md](./MIGRATION.md).
+Full reference at [our docs site](https://docs.learningcommons.org/evaluators/sdk-api-reference/overview). Migrating from 0.8.x? See [MIGRATION.md](./MIGRATION.md).
 
 ## License
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -23,6 +23,7 @@
   "files": [
     "dist",
     "README.md",
+    "MIGRATION.md",
     "CHANGELOG.md",
     "LICENSE",
     "src/batch/README.md"

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -79,6 +79,12 @@ export type { MeaningDirectnessResult } from './schemas/student-facing-text/ela-
 export type { GradeLevelAppropriatenessResult } from './schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
 
 export { GradeLevelAppropriatenessOutputSchema } from './schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
+export { BackgroundKnowledgeDemandsOutputSchema } from './schemas/student-facing-text/ela-reading/background-knowledge-demands.js';
+export { MeaningDirectnessOutputSchema } from './schemas/student-facing-text/ela-reading/meaning-directness.js';
+export { OrganizationalStructureOutputSchema } from './schemas/student-facing-text/ela-reading/organizational-structure.js';
+export { PurposeClarityOutputSchema } from './schemas/student-facing-text/ela-reading/purpose-clarity.js';
+export { ReferenceKnowledgeDemandsOutputSchema } from './schemas/student-facing-text/ela-reading/reference-knowledge-demands.js';
+export { VocabularyComplexityOutputSchema } from './schemas/student-facing-text/ela-reading/vocabulary-complexity.js';
 
 // Purpose Clarity exports
 export type { PurposeClarityResult } from './schemas/student-facing-text/ela-reading/purpose-clarity.js';

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -5,7 +5,7 @@ export type {
   EvaluationTokenUsage,
 } from './schemas/index.js';
 export type { GradeBand } from './schemas/index.js';
-export { readOutcome, type Outcome } from './schemas/index.js';
+export { readOutcome, type Outcome, type DeclaredOutcome } from './schemas/index.js';
 
 // Error types
 export {

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -1,5 +1,36 @@
 import { generateText as aiGenerateText, Output } from 'ai';
 import { ConfigurationError } from '../errors.js';
+
+/** Node's resolution codes for "that package is not there", ESM and CJS. */
+const NOT_INSTALLED = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND']);
+
+/**
+ * Turn a failed adapter import into the right error.
+ *
+ * Only an unresolvable module is the caller's setup. An adapter that *is* installed but
+ * throws while loading — a syntax error, a missing transitive dependency — is a real failure,
+ * and reporting "install its adapter" for it would send the reader somewhere useless. That
+ * case rethrows unchanged so the evaluator wraps it as a dependency failure, and the
+ * not-installed case keeps the original as `cause` either way.
+ */
+function adapterImportError(error: unknown, vendor: string, pkg: string): unknown {
+  // Walked, not read off the top: bundlers and test loaders wrap an import failure in their
+  // own error and keep the real one as `cause`, so the resolution code is often one level down.
+  const missing = (function isMissing(e: unknown, depth = 0): boolean {
+    if (e === null || typeof e !== 'object' || depth > 4) return false;
+    const { code, message, cause } = e as { code?: unknown; message?: unknown; cause?: unknown };
+    if (typeof code === 'string' && NOT_INSTALLED.has(code)) return true;
+    if (typeof message === 'string' && /cannot find (module|package)/i.test(message)) return true;
+    return isMissing(cause, depth + 1);
+  })(error);
+
+  return missing
+    ? new ConfigurationError(
+        `To use the ${vendor} provider, install its adapter: npm install ${pkg}`,
+        error,
+      )
+    : error;
+}
 import type {
   LLMProvider,
   LLMRequest,
@@ -117,30 +148,24 @@ export class VercelAIProvider implements LLMProvider {
       case 'openai': {
         const { createOpenAI } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/openai'
-        ).catch(() => {
-          throw new ConfigurationError(
-            'To use the OpenAI provider, install its adapter: npm install @ai-sdk/openai'
-          );
+        ).catch((error: unknown) => {
+          throw adapterImportError(error, 'OpenAI', '@ai-sdk/openai');
         });
         return createOpenAI(apiKey ? { apiKey } : {})(this.model);
       }
       case 'anthropic': {
         const { createAnthropic } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/anthropic'
-        ).catch(() => {
-          throw new ConfigurationError(
-            'To use the Anthropic provider, install its adapter: npm install @ai-sdk/anthropic'
-          );
+        ).catch((error: unknown) => {
+          throw adapterImportError(error, 'Anthropic', '@ai-sdk/anthropic');
         });
         return createAnthropic(apiKey ? { apiKey } : {})(this.model);
       }
       case 'google': {
         const { createGoogleGenerativeAI } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/google'
-        ).catch(() => {
-          throw new ConfigurationError(
-            'To use the Google provider, install its adapter: npm install @ai-sdk/google'
-          );
+        ).catch((error: unknown) => {
+          throw adapterImportError(error, 'Google', '@ai-sdk/google');
         });
         return createGoogleGenerativeAI(apiKey ? { apiKey } : {})(this.model);
       }

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -1,4 +1,5 @@
 import { generateText as aiGenerateText, Output } from 'ai';
+import { ConfigurationError } from '../errors.js';
 import type {
   LLMProvider,
   LLMRequest,
@@ -117,7 +118,7 @@ export class VercelAIProvider implements LLMProvider {
         const { createOpenAI } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/openai'
         ).catch(() => {
-          throw new Error(
+          throw new ConfigurationError(
             'To use the OpenAI provider, install its adapter: npm install @ai-sdk/openai'
           );
         });
@@ -127,7 +128,7 @@ export class VercelAIProvider implements LLMProvider {
         const { createAnthropic } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/anthropic'
         ).catch(() => {
-          throw new Error(
+          throw new ConfigurationError(
             'To use the Anthropic provider, install its adapter: npm install @ai-sdk/anthropic'
           );
         });
@@ -137,7 +138,7 @@ export class VercelAIProvider implements LLMProvider {
         const { createGoogleGenerativeAI } = await import(
           /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ '@ai-sdk/google'
         ).catch(() => {
-          throw new Error(
+          throw new ConfigurationError(
             'To use the Google provider, install its adapter: npm install @ai-sdk/google'
           );
         });

--- a/sdks/typescript/src/schemas/index.ts
+++ b/sdks/typescript/src/schemas/index.ts
@@ -18,4 +18,4 @@ export {
   type PurposeClarityResult,
 } from './student-facing-text/ela-reading/purpose-clarity.js';
 
-export { readOutcome, type Outcome } from './outcome.js';
+export { readOutcome, type Outcome, type DeclaredOutcome } from './outcome.js';

--- a/sdks/typescript/tests/integration/readme-quickstart.integration.test.ts
+++ b/sdks/typescript/tests/integration/readme-quickstart.integration.test.ts
@@ -37,10 +37,16 @@ describeIntegration('README quickstart', () => {
 
       const { result, metadata } = await evaluator.evaluate({ text: QUICKSTART_TEXT });
 
-      // Every field the snippet reads has to exist and be populated.
+      // Every field the snippet reads has to exist and be populated — all three, not just
+      // the first. `scaffolding_needed` is what makes the alternative band actionable, and
+      // an empty string for any of them would render as a blank line in the documented
+      // output while still typing as a string.
       expect(typeof result.grade_band).toBe('string');
       expect(result.grade_band).not.toBe('');
       expect(typeof result.alternative_grade_band).toBe('string');
+      expect(result.alternative_grade_band).not.toBe('');
+      expect(typeof result.scaffolding_needed).toBe('string');
+      expect(result.scaffolding_needed).not.toBe('');
       expect(metadata.model).toMatch(/^google:/);
 
       // And the field it used to read must still not exist, so the old snippet cannot
@@ -49,7 +55,8 @@ describeIntegration('README quickstart', () => {
 
       console.log(
         `  quickstart: grade_band=${result.grade_band} ` +
-          `alternative=${result.alternative_grade_band} model=${metadata.model}`,
+          `alternative=${result.alternative_grade_band} model=${metadata.model}\n` +
+          `  scaffolding: ${result.scaffolding_needed}`,
       );
     },
     120_000,

--- a/sdks/typescript/tests/integration/readme-quickstart.integration.test.ts
+++ b/sdks/typescript/tests/integration/readme-quickstart.integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  GradeLevelAppropriatenessEvaluator,
+  readOutcome,
+} from '../../src/index.js';
+
+/**
+ * The README's quickstart, run for real.
+ *
+ * It shipped `result.result.grade`, a field no schema has ever declared, so the first code
+ * anyone ran returned `undefined`. A snippet nothing executes goes stale silently, so this
+ * runs the documented call and checks the documented fields against the live response.
+ */
+
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+if (RUN_INTEGRATION) {
+  if (!process.env.GOOGLE_API_KEY) {
+    throw new Error('GOOGLE_API_KEY is required when RUN_INTEGRATION_TESTS=true');
+  }
+}
+
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+/** The exact text the README passes. */
+const QUICKSTART_TEXT = "The cat's out of the bag now.";
+
+describeIntegration('README quickstart', () => {
+  it(
+    'returns the fields the README prints',
+    async () => {
+      const evaluator = new GradeLevelAppropriatenessEvaluator({
+        googleApiKey: process.env.GOOGLE_API_KEY,
+      });
+
+      const { result, metadata } = await evaluator.evaluate({ text: QUICKSTART_TEXT });
+
+      // Every field the snippet reads has to exist and be populated.
+      expect(typeof result.grade_band).toBe('string');
+      expect(result.grade_band).not.toBe('');
+      expect(typeof result.alternative_grade_band).toBe('string');
+      expect(metadata.model).toMatch(/^google:/);
+
+      // And the field it used to read must still not exist, so the old snippet cannot
+      // quietly start "working" against a schema that never declared it.
+      expect(result).not.toHaveProperty('grade');
+
+      console.log(
+        `  quickstart: grade_band=${result.grade_band} ` +
+          `alternative=${result.alternative_grade_band} model=${metadata.model}`,
+      );
+    },
+    120_000,
+  );
+
+  it('prints a model string the README actually shows', async () => {
+    const evaluator = new GradeLevelAppropriatenessEvaluator({
+      googleApiKey: process.env.GOOGLE_API_KEY,
+    });
+
+    const { metadata } = await evaluator.evaluate({ text: QUICKSTART_TEXT });
+
+    // The README comments a concrete model. A contract bump would leave it stale, and a
+    // stale model string is how a reader concludes the SDK is not doing what it says.
+    const readme = readFileSync(join(import.meta.dirname, '../../README.md'), 'utf-8');
+    expect(readme).toContain(`// "${metadata.model}"`);
+  }, 120_000);
+
+  it('readOutcome reads the verdict the quickstart section describes', async () => {
+    const evaluation = await new GradeLevelAppropriatenessEvaluator({
+      googleApiKey: process.env.GOOGLE_API_KEY,
+    }).evaluate({ text: QUICKSTART_TEXT });
+
+    const { score, reasoning } = readOutcome(
+      evaluation,
+      GradeLevelAppropriatenessEvaluator.metadata.outcome,
+    );
+
+    expect(score).toBe(evaluation.result.grade_band);
+    expect(reasoning.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/sdks/typescript/tests/unit/docs.test.ts
+++ b/sdks/typescript/tests/unit/docs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as sdk from '../../src/index.js';
 
@@ -83,6 +83,34 @@ describe('README', () => {
         `${grades[0]}–${grades[grades.length - 1]}`,
       );
     }
+  });
+});
+
+describe('the README on npm', () => {
+  // Rendered on npmjs.com and browsable in node_modules, where only what `files` lists
+  // exists. A relative link to something unpublished is dead in both places.
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
+    files: string[];
+  };
+
+  /** Relative markdown link targets, minus any anchor. */
+  const RELATIVE_LINKS = [...README.matchAll(/\]\((\.\/[^)#]+)/g)].map((m) =>
+    m[1].replace(/^\.\//, ''),
+  );
+
+  it('makes relative links, so this is not vacuous', () => {
+    expect(RELATIVE_LINKS.length).toBeGreaterThan(0);
+  });
+
+  it.each(RELATIVE_LINKS)('%s exists on disk', (target) => {
+    expect(existsSync(join(root, target)), `${target} is linked but missing`).toBe(true);
+  });
+
+  it.each(RELATIVE_LINKS)('%s is in the published files allowlist', (target) => {
+    // Covered either by its own entry or by a directory entry that contains it.
+    const published = pkg.files.some((entry) => target === entry || target.startsWith(`${entry}/`));
+
+    expect(published, `${target} is linked from the README but \`files\` omits it`).toBe(true);
   });
 });
 

--- a/sdks/typescript/tests/unit/docs.test.ts
+++ b/sdks/typescript/tests/unit/docs.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as sdk from '../../src/index.js';
+
+/**
+ * The README and MIGRATION guide, checked against the SDK they describe.
+ *
+ * The README shipped `result.result.grade` — a field no schema has ever declared — as the
+ * first code anyone runs, and listed 8 of the 16 evaluators. Prose goes stale silently, so
+ * the claims that can be mechanically checked are checked here.
+ */
+
+const root = join(import.meta.dirname, '../..');
+const README = readFileSync(join(root, 'README.md'), 'utf-8');
+const MIGRATION = readFileSync(join(root, 'MIGRATION.md'), 'utf-8');
+
+/** Every evaluator class the barrel exports. */
+type EvaluatorLike = { metadata: { id: string; supportedGrades: readonly string[] } };
+
+const EVALUATORS = Object.entries(sdk as Record<string, unknown>)
+  .filter(
+    ([, v]) =>
+      typeof v === 'function' && typeof (v as unknown as EvaluatorLike).metadata?.id === 'string',
+  )
+  .map(([name, v]) => ({ name, metadata: (v as unknown as EvaluatorLike).metadata }));
+
+describe('README', () => {
+  it('finds the evaluators to check', () => {
+    expect(EVALUATORS).toHaveLength(16);
+  });
+
+  it.each(EVALUATORS)('names $name', ({ name }) => {
+    // The old README documented 8 of 16, omitting the whole feedback family and math.
+    expect(README).toContain(`\`${name}\``);
+  });
+
+  it('states the count it actually documents', () => {
+    expect(README).toContain('sixteen');
+  });
+
+  it('does not reference the removed exports', () => {
+    // Renamed in 1.0.0; a stale name here sends readers to an import that throws.
+    for (const gone of [
+      'SmkEvaluator',
+      'ConventionalityEvaluator',
+      'PurposeEvaluator',
+      'VocabularyEvaluator',
+      'TextComplexityEvaluator',
+      'ValidationError',
+      'TimeoutError',
+    ]) {
+      expect(README, `README still mentions ${gone}`).not.toContain(`\`${gone}\``);
+    }
+  });
+
+  it('reads the payload off the envelope, not off the result', () => {
+    // The exact defect the audit found: `result.result.grade` on the first snippet.
+    expect(README).not.toContain('result.result.');
+    expect(README).not.toMatch(/\.grade\b(?!_)/);
+  });
+
+  it('documents every option the base config accepts', () => {
+    const config = readFileSync(join(root, 'src/evaluators/base.ts'), 'utf-8');
+    const block = config.slice(config.indexOf('export interface BaseEvaluatorConfig'));
+    const options = [
+      ...block.slice(0, block.indexOf('\n}')).matchAll(/^\s{2}(\w+)\?:/gm),
+    ].map((m) => m[1]);
+
+    expect(options.length).toBeGreaterThan(5);
+    for (const option of options) {
+      expect(README, `README does not document \`${option}\``).toContain(`\`${option}\``);
+    }
+  });
+
+  it('names each evaluator with a grade range its contract supports', () => {
+    for (const { name, metadata } of EVALUATORS) {
+      const grades = metadata.supportedGrades;
+      const row = README.split('\n').find((line) => line.includes(`\`${name}\``) && line.includes('|'));
+      expect(row, `no table row for ${name}`).toBeDefined();
+      // en dash, as the tables use
+      expect(row, `${name} row does not show ${grades[0]}-${grades[grades.length - 1]}`).toContain(
+        `${grades[0]}–${grades[grades.length - 1]}`,
+      );
+    }
+  });
+});
+
+describe('MIGRATION', () => {
+  it('every name in a rename table\'s current column is exported', () => {
+    // Rows read `| `old` | `new` |`, so only the last cell names something that exists now.
+    const claimed = MIGRATION.split('\n')
+      .filter((line) => line.startsWith('| `') && line.split('|').length === 4)
+      .flatMap((line) => {
+        const current = line.split('|')[2];
+        return [...current.matchAll(/`(\w+)`/g)].map((m) => m[1]);
+      });
+
+    expect(claimed.length).toBeGreaterThan(5);
+
+    const missing = [...new Set(claimed)].filter((n) => !(n in sdk));
+    expect(missing, `MIGRATION names exports that do not exist: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every name it presents as removed really is gone', () => {
+    for (const gone of [
+      'SmkEvaluator',
+      'ConventionalityEvaluator',
+      'PurposeEvaluator',
+      'VocabularyEvaluator',
+      'TextComplexityEvaluator',
+      'evaluateTextComplexity',
+      'ValidationError',
+      'TimeoutError',
+      'APIError',
+      'Providers',
+    ]) {
+      expect(MIGRATION, `MIGRATION should mention ${gone}`).toContain(gone);
+      expect(gone in sdk, `${gone} is documented as removed but is still exported`).toBe(false);
+    }
+  });
+
+  it('the reparenting it warns about is real', () => {
+    // The subtle one: a caller catching KnowledgeGraphError used to see this.
+    expect(MIGRATION).toContain('StandardNotFoundError');
+
+    const error = new sdk.StandardNotFoundError('no such code', '9.ZZ.9');
+    expect(error).toBeInstanceOf(sdk.InputValidationError);
+    expect(error).not.toBeInstanceOf(sdk.KnowledgeGraphError);
+  });
+
+  it('the error parents it describes are the real ones', () => {
+    for (const name of [
+      'AuthenticationError',
+      'RateLimitError',
+      'NetworkError',
+      'RequestTimeoutError',
+      'LLMProviderError',
+      'KnowledgeGraphError',
+    ]) {
+      const Cls = sdk[name as keyof typeof sdk] as new (
+        m: string,
+        o: { dependency: string },
+      ) => Error;
+      expect(
+        new Cls('x', { dependency: 'openai' }),
+        `${name} extends DependencyError`,
+      ).toBeInstanceOf(sdk.DependencyError);
+    }
+  });
+
+  it('quotes the peer ranges the package actually declares', () => {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
+      peerDependencies: Record<string, string>;
+      engines: { node: string };
+    };
+
+    for (const [dep, range] of Object.entries(pkg.peerDependencies)) {
+      expect(MIGRATION, `MIGRATION omits the ${dep} range`).toContain(`\`${range}\``);
+    }
+    expect(MIGRATION).toContain(`\`${pkg.engines.node}\``);
+  });
+});

--- a/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
+++ b/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
@@ -19,7 +19,9 @@ type AdapterName = 'openai' | 'anthropic' | 'google';
 const buildModel = (provider: string) =>
   vi.fn((model: string) => ({ provider, model }));
 
-async function loadProvider(opts: { failImports?: AdapterName[] } = {}) {
+async function loadProvider(
+  opts: { failImports?: AdapterName[]; brokenImports?: AdapterName[] } = {},
+) {
   vi.resetModules();
 
   const generateText = vi.fn().mockResolvedValue({
@@ -37,21 +39,38 @@ async function loadProvider(opts: { failImports?: AdapterName[] } = {}) {
   const createGoogleGenerativeAI = vi.fn(() => buildModel('google'));
 
   const fails = (name: AdapterName) => opts.failImports?.includes(name) ?? false;
+  const broken = (name: AdapterName) => opts.brokenImports?.includes(name) ?? false;
+
+  /** What Node throws when the package is not installed, code and all. */
+  const notInstalled = (pkg: string) =>
+    Object.assign(new Error(`Cannot find package '${pkg}'`), { code: 'ERR_MODULE_NOT_FOUND' });
 
   if (fails('openai')) {
-    vi.doMock('@ai-sdk/openai', () => { throw new Error('Cannot find module'); });
+    vi.doMock('@ai-sdk/openai', () => { throw notInstalled('@ai-sdk/openai'); });
+  } else if (broken('openai')) {
+    // Installed, but fails while loading — a syntax error or a missing
+    // transitive dependency. Not the caller's setup.
+    vi.doMock('@ai-sdk/openai', () => { throw new SyntaxError('Unexpected token in adapter'); });
   } else {
     vi.doMock('@ai-sdk/openai', () => ({ createOpenAI }));
   }
 
   if (fails('anthropic')) {
-    vi.doMock('@ai-sdk/anthropic', () => { throw new Error('Cannot find module'); });
+    vi.doMock('@ai-sdk/anthropic', () => { throw notInstalled('@ai-sdk/anthropic'); });
+  } else if (broken('anthropic')) {
+    // Installed, but fails while loading — a syntax error or a missing
+    // transitive dependency. Not the caller's setup.
+    vi.doMock('@ai-sdk/anthropic', () => { throw new SyntaxError('Unexpected token in adapter'); });
   } else {
     vi.doMock('@ai-sdk/anthropic', () => ({ createAnthropic }));
   }
 
   if (fails('google')) {
-    vi.doMock('@ai-sdk/google', () => { throw new Error('Cannot find module'); });
+    vi.doMock('@ai-sdk/google', () => { throw notInstalled('@ai-sdk/google'); });
+  } else if (broken('google')) {
+    // Installed, but fails while loading — a syntax error or a missing
+    // transitive dependency. Not the caller's setup.
+    vi.doMock('@ai-sdk/google', () => { throw new SyntaxError('Unexpected token in adapter'); });
   } else {
     vi.doMock('@ai-sdk/google', () => ({ createGoogleGenerativeAI }));
   }
@@ -161,6 +180,39 @@ describe('VercelAIProvider - getModel adapter resolution', () => {
       expect(error).not.toHaveProperty('dependency');
     },
   );
+
+  it.each(['openai', 'anthropic', 'google'] as const)(
+    'does not blame the caller when the %s adapter is installed but broken',
+    async (type) => {
+      // "install its adapter" would send the reader somewhere useless, and swallowing the
+      // syntax error would hide the only useful detail. Converting *every* import failure
+      // into ConfigurationError did both.
+      const ctx = await loadProvider({ brokenImports: [type] });
+      const provider = new ctx.mod.VercelAIProvider({ type, model: 'm' });
+
+      const error = await provider
+        .generateText([{ role: 'user', content: 'hi' }])
+        .then(() => undefined)
+        .catch((e: unknown) => e as Error);
+
+      expect(error?.name).not.toBe('ConfigurationError');
+      expect(error?.message).not.toMatch(/install its adapter/);
+    },
+  );
+
+  it('keeps the original failure as the cause when the adapter is absent', async () => {
+    // Losing it makes a resolution problem indistinguishable from any other.
+    const ctx = await loadProvider({ failImports: ['openai'] });
+    const provider = new ctx.mod.VercelAIProvider({ type: 'openai', model: 'm' });
+
+    const error = await provider
+      .generateText([{ role: 'user', content: 'hi' }])
+      .then(() => undefined)
+      .catch((e: unknown) => e as Error & { cause?: unknown });
+
+    expect(error?.name).toBe('ConfigurationError');
+    expect(error?.cause).toBeDefined();
+  });
 
   it('throws on an unsupported provider type', async () => {
     const ctx = await loadProvider();

--- a/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
+++ b/sdks/typescript/tests/unit/providers/ai-sdk-provider.test.ts
@@ -139,6 +139,29 @@ describe('VercelAIProvider - getModel adapter resolution', () => {
     }
   });
 
+  it.each(['openai', 'anthropic', 'google'] as const)(
+    'blames the caller, not the dependency, for a missing %s adapter',
+    async (type) => {
+      // A forgotten devDependency is setup, not an upstream failure. Thrown as a plain
+      // Error it was wrapped into LLMProviderError — a DependencyError — so a caller
+      // catching by fault domain reported an outage for their own missing package. The
+      // tests above pin only the message, which is why that survived.
+      const ctx = await loadProvider({ failImports: [type] });
+      const provider = new ctx.mod.VercelAIProvider({ type, model: 'm' });
+
+      const error = await provider
+        .generateText([{ role: 'user', content: 'hi' }])
+        .then(() => undefined)
+        .catch((e: unknown) => e as Error);
+
+      // Asserted by name, not `instanceof`: `loadProvider` resets the module graph, so the
+      // class the provider throws is a different object from the one this file imported.
+      expect(error?.name).toBe('ConfigurationError');
+      // Every DependencyError carries the dependency it blames. This must not.
+      expect(error).not.toHaveProperty('dependency');
+    },
+  );
+
   it('throws on an unsupported provider type', async () => {
     const ctx = await loadProvider();
     // Bypass the constructor's type union to reach the switch default.

--- a/sdks/typescript/tests/unit/registry-conformance.test.ts
+++ b/sdks/typescript/tests/unit/registry-conformance.test.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 import * as exported from '../../src/evaluators/index.js';
+import * as packageRoot from '../../src/index.js';
 import {
   GradeLevelAppropriatenessEvaluator,
   BackgroundKnowledgeDemandsEvaluator,
@@ -429,6 +430,14 @@ describe('the payload type is named after the evaluator', () => {
 
     expect(declaresSchema, `${module} does not export ${className}OutputSchema`).toBe(true);
     expect(declaresResult, `${module} does not export ${className}Result`).toBe(true);
+
+    // Declaring it is not the same as publishing it. Nine of the fifteen schemas reached the
+    // barrel and six did not, so callers of those six dimensions had no runtime schema at
+    // all — and nothing here noticed, because this test only ever read the schema module.
+    expect(
+      `${className}OutputSchema` in packageRoot,
+      `${className}OutputSchema is declared but not exported from the package`,
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
The README's quickstart printed `result.result.grade` — a field no schema declares, on an envelope with no such nesting — as the first code anyone runs. It documented 8 of the 16 evaluators, and nothing about the envelope, `/batch`, `llmProvider`, or the error taxonomy.

Adds `MIGRATION.md` for 0.8.0 → 1.0.0: **26 published exports gone, 73 new**, measured by diffing the published 0.8.0 tarball against this build.

## How this was validated

Four independent agents in fresh environments, each given **only** one of the two documents and the packed tarball — no repo access. Two set up from scratch and ran live evaluations; two took a real 0.8.0 app to 0 type errors, then migrated it following only the guide (0 → 29 errors → **0**) and made live calls. Anything they had to invent, guess, or read out of a `.d.ts` counted as a gap. **43 gaps found; 42 fixed here.**

Every snippet in both documents now compiles in a consumer project under `strict` and, where it makes a call, has been run.

## Three product defects the doc testing uncovered

Not documentation changes — real bugs, each with a test-shaped reason it survived:

| defect | why nothing caught it |
| --- | --- |
| A missing provider adapter threw `LLMProviderError` (a `DependencyError`), so a forgotten devDependency reported as an upstream outage. Now `ConfigurationError`. | the existing tests asserted the message, never the class |
| Six of fifteen `*OutputSchema`s were built but never exported, leaving those dimensions with no runtime schema at all. | the conformance test checked each schema *module*, never the barrel |
| `DeclaredOutcome` — the parameter type of the public `readOutcome` — wasn't exported, so no one could write a generic helper. | nothing asserted a public signature's types are nameable |

Both gaps in the tests are now closed; un-exporting one schema fails the new conformance check.

## The most serious documentation gap

**The verdict *values* changed and no compiler can tell you.** `readOutcome` returns `score: string`, so `"Slightly complex"` → `"slightly_complex"` and `"11-CCR"` → `"11-12"` are invisible to `tsc`: stored rows, dashboard filters and `GROUP BY score` all break silently. This had been a passing remark; it is now section 2a with the full table and a backfill warning.

Runners-up, all verified: the peer bump had to become **step 0** (installing the SDK first dies on `ERESOLVE`); the removed `TextComplexityEvaluator` isolated per-dimension failures that `Promise.all` does not; losing `partnerKey` is **silent** when config comes from a shared variable; `evaluateByGrade` → `evaluateByGradeLevel` was documented as "unchanged" under its new name.

## Guards so it cannot rot

`tests/unit/docs.test.ts` checks both documents against the SDK: every exported evaluator appears in the README, no removed export is named, `result.result.` never returns, every config option is documented, every migration rename resolves, every removed name is findable, the error parents are real, the peer ranges match `package.json`, and every relative README link ships in the `files` allowlist. Reintroducing the original defects fails three checks.

`tests/integration/readme-quickstart.integration.test.ts` runs the quickstart live and asserts every field it prints.

## Validation

`typecheck`, `lint`, `test:unit` (1342), `build`, `scripts/check.py`. Live: 3/3 on the quickstart, plus the batch CLI verified from a clean install both with args and interactively.

## One blocker for 1.0, not fixed here

The published `dist/index.d.ts` is malformed — **141 errors** for consumers type-checking without `skipLibCheck` (`TS1039`, "Initializers are not allowed in ambient contexts"), because tsup's dts bundler inlines the JSON contracts as `var` declarations. Both install agents hit it independently; one rated the README "Yes for a JS user, No for a TypeScript user with default settings." The README documents the required flag as an interim. The fix is to emit declarations with `tsc --emitDeclarationOnly`, which wants its own PR.
