### PR TITLE
test(sdk): check the declarations through a project file, not a file argument

### DIFF
--- a/sdks/typescript/tests/declarations/published.test.ts
+++ b/sdks/typescript/tests/declarations/published.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -50,7 +51,10 @@ describe('the published declarations typecheck on their own', () => {
     // line. TypeScript 7 errors (`TS5112`) when a file argument is combined with a tsconfig
     // being present, so the command-line form would break the moment the pinned compiler
     // moves major — while saying nothing about the declarations themselves.
-    const project = join(tmpdir(), `lc-dts-${entry.replace(/\W/g, '-')}.json`);
+    const project = join(
+      tmpdir(),
+      `lc-dts-${entry.replace(/\W/g, '-')}-${process.pid}-${randomUUID()}.json`,
+    );
     writeFileSync(
       project,
       JSON.stringify({
@@ -60,7 +64,8 @@ describe('the published declarations typecheck on their own', () => {
           target: 'es2022',
           module: 'nodenext',
           moduleResolution: 'nodenext',
-          // Absent on purpose: checking the declarations is the whole point.
+          // Set explicitly rather than left to the default: checking the declarations is
+          // the whole point, so this must not drift with whatever tsc decides to default to.
           skipLibCheck: false,
         },
         files: [join(TS_ROOT, entry)],
@@ -68,9 +73,13 @@ describe('the published declarations typecheck on their own', () => {
     );
 
     // tsc exits non-zero on any error, so the assertion is that this does not throw.
-    expect(() =>
-      execFileSync(TSC, ['-p', project], { cwd: TS_ROOT, stdio: 'pipe', encoding: 'utf-8' }),
-    ).not.toThrow();
+    try {
+      expect(() =>
+        execFileSync(TSC, ['-p', project], { cwd: TS_ROOT, stdio: 'pipe', encoding: 'utf-8' }),
+      ).not.toThrow();
+    } finally {
+      rmSync(project, { force: true });
+    }
   }, 180_000);
 
   it.each(ENTRIES)('%s declares no values', (entry) => {

--- a/sdks/typescript/tests/declarations/published.test.ts
+++ b/sdks/typescript/tests/declarations/published.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 /**
@@ -45,24 +46,30 @@ describe('the published declarations typecheck on their own', () => {
   it.each(ENTRIES)('%s reports no errors under a consumer-default tsc', (entry) => {
     read(entry); // fail loudly if the build is missing
 
-    // No `skipLibCheck`: that is the whole point. tsc exits non-zero on any error, so the
-    // assertion is that this call does not throw.
+    // Checked through a generated project file rather than by naming the entry on the command
+    // line. TypeScript 7 errors (`TS5112`) when a file argument is combined with a tsconfig
+    // being present, so the command-line form would break the moment the pinned compiler
+    // moves major — while saying nothing about the declarations themselves.
+    const project = join(tmpdir(), `lc-dts-${entry.replace(/\W/g, '-')}.json`);
+    writeFileSync(
+      project,
+      JSON.stringify({
+        compilerOptions: {
+          noEmit: true,
+          strict: true,
+          target: 'es2022',
+          module: 'nodenext',
+          moduleResolution: 'nodenext',
+          // Absent on purpose: checking the declarations is the whole point.
+          skipLibCheck: false,
+        },
+        files: [join(TS_ROOT, entry)],
+      }),
+    );
+
+    // tsc exits non-zero on any error, so the assertion is that this does not throw.
     expect(() =>
-      execFileSync(
-        TSC,
-        [
-          '--noEmit',
-          '--strict',
-          '--target',
-          'es2022',
-          '--module',
-          'nodenext',
-          '--moduleResolution',
-          'nodenext',
-          entry,
-        ],
-        { cwd: TS_ROOT, stdio: 'pipe', encoding: 'utf-8' },
-      ),
+      execFileSync(TSC, ['-p', project], { cwd: TS_ROOT, stdio: 'pipe', encoding: 'utf-8' }),
     ).not.toThrow();
   }, 180_000);
 


### PR DESCRIPTION
The declaration check added in #255 names the entry file on the tsc command line. TypeScript 7 rejects that when a `tsconfig.json` is present:

```
error TS5112: tsconfig.json is present but will not be loaded if files are specified on
              commandline. Use '--ignoreConfig' to skip this error.
```

So `npm run verify:dist` fails the moment the pinned compiler moves major — **and it fails while saying nothing about the declarations**, which is the worst kind of guard failure: it looks like the artefact broke when the harness did.

Found by trying #137 (`typescript` 5.9.3 → 7.0.2) against it rather than waiting for that PR to turn CI red.

## The declarations themselves are fine under TS 7

Verified directly with `--ignoreConfig`: **0 errors** on `dist/index.d.ts` under TypeScript 7.0.2, strict, NodeNext. #255's fix holds across the major.

## Fix

The check now generates a small project file and runs `tsc -p`, so no file argument is involved and the behaviour is the same on both majors. `skipLibCheck: false` is set explicitly rather than left to the default, since checking the declarations is the entire point.

## Validation

- passes under **TypeScript 7.0.2** (6/6) and under the pinned **5.9.3** (6/6)
- still load-bearing on both: injecting `var injected$y = { a: 1 };` into the built `dist/index.d.ts` fails the tsc case and the `var` case, and the tsc run takes ~1s, so it is genuinely compiling
- `typecheck`, `lint`, `test:unit` (1364), `verify:dist`, `scripts/check.py`

Unblocks #137 as far as this check is concerned; I have not assessed the rest of that bump.
