### PR TITLE
fix(sdk): classify a missing adapter by structured signal only

### DIFF
--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -14,13 +14,14 @@ const NOT_INSTALLED = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND']);
  * not-installed case keeps the original as `cause` either way.
  */
 function adapterImportError(error: unknown, vendor: string, pkg: string): unknown {
-  // Walked, not read off the top: bundlers and test loaders wrap an import failure in their
-  // own error and keep the real one as `cause`, so the resolution code is often one level down.
+  // Structured signal only, per SPEC §6.5: wording is not a contract, and matching on it
+  // would reclassify an adapter that failed to load for some other reason. Walked rather
+  // than read off the top, because bundlers and test loaders wrap an import failure in their
+  // own error and keep the real one as `cause`, so the code sits one level down.
   const missing = (function isMissing(e: unknown, depth = 0): boolean {
     if (e === null || typeof e !== 'object' || depth > 4) return false;
-    const { code, message, cause } = e as { code?: unknown; message?: unknown; cause?: unknown };
+    const { code, cause } = e as { code?: unknown; cause?: unknown };
     if (typeof code === 'string' && NOT_INSTALLED.has(code)) return true;
-    if (typeof message === 'string' && /cannot find (module|package)/i.test(message)) return true;
     return isMissing(cause, depth + 1);
   })(error);
 

--- a/sdks/typescript/src/providers/ai-sdk-provider.ts
+++ b/sdks/typescript/src/providers/ai-sdk-provider.ts
@@ -17,7 +17,8 @@ function adapterImportError(error: unknown, vendor: string, pkg: string): unknow
   // Structured signal only, per SPEC §6.5: wording is not a contract, and matching on it
   // would reclassify an adapter that failed to load for some other reason. Walked rather
   // than read off the top, because bundlers and test loaders wrap an import failure in their
-  // own error and keep the real one as `cause`, so the code sits one level down.
+  // own error and keep the real one as `cause` — sometimes through more than one layer, hence
+  // walking the chain rather than checking a fixed depth.
   const missing = (function isMissing(e: unknown, depth = 0): boolean {
     if (e === null || typeof e !== 'object' || depth > 4) return false;
     const { code, cause } = e as { code?: unknown; cause?: unknown };


### PR DESCRIPTION
SPEC §6.5: *"Classify by **structured signals only** … Free-text message matching MUST NOT reclassify an error: wording is not a contract, and a misclassification is worse than the catch-all."*

The adapter-import classifier added in #254 matched on message text as a fallback:

```ts
if (typeof message === 'string' && /cannot find (module|package)/i.test(message)) return true;
```

So an adapter that **is** installed but throws while loading — with a message that happens to mention a module it could not find, which is exactly what a missing transitive dependency looks like — was reported as `ConfigurationError: install its adapter`. That is the misclassification #254 set out to remove, reintroduced one layer down and driven by wording.

## Fix

Structured signal only: the resolution `code` (`ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND`), still walked through the `cause` chain because bundlers and loaders wrap import failures and keep the real error underneath.

The message check turns out to have been unnecessary as well as non-conformant — I added it when the test harness threw an uncoded error, before discovering the harness preserves the coded original as `cause`. All 42 provider tests pass without it.

## Validation

- `typecheck`, `lint`, `test:unit` (1364), `verify:dist` (6/6), `scripts/check.py`
- the missing-adapter path re-verified against a clean `npm pack` install with only `@ai-sdk/google` present: still `ConfigurationError`, still `instanceof DependencyError === false`, same message
- the installed-but-broken cases still assert they are *not* `ConfigurationError`

Found by auditing the SDK against `sdks/SPEC.md` (PR #162) rather than by a failing test.
