### PR TITLE
fix(sdk)!: make zod a peer dependency so consumers own the single copy

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -17,10 +17,25 @@ npm error Found: ai@6.0.271
 One command, not two:
 
 ```bash
-npm install @learning-commons/evaluators@^1 ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
+npm install @learning-commons/evaluators@^1 zod@^4 ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
 ```
 
 Install only the adapters you use. Node's minimum is unchanged at `>=20.19.0`.
+
+**`zod` is now a peer dependency and must be added.** In 0.8.0 it was bundled, so npm
+installed a copy for us; now your project declares it, which is what guarantees there is only
+one copy. If you already depend on zod it must be **version 4** — the exported evaluator
+schemas are zod 4 values, and with zod 3 in your tree npm keeps a second copy, so composing
+one of our schemas with your own fails:
+
+```
+error TS2322: Type 'ZodObject<…, $strict>' is not assignable to type 'ZodTypeAny'.
+  missing the following properties from type 'ZodType<any, any, any>': _type, _parse, …
+```
+
+Nothing you can do at the call site fixes that; the two copies are structurally different
+types. Note that `ai@7` accepts `zod@^3.25.76 || ^4.1.8`, so a project pinned to zod 3 for
+`ai`'s sake now has to move to zod 4.
 
 ## 1. `evaluate()` takes named inputs
 
@@ -262,6 +277,7 @@ Covered by step 0 above, which has to happen first. For reference:
 | --- | --- | --- |
 | `ai` | `>=6.0.0` | `>=7.0.0` |
 | `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0` |
+| `zod` | *(bundled as a dependency)* | `^4.0.0` — now a peer you declare |
 
 ## 8. Math standards alignment: named inputs, and the envelope
 

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -24,18 +24,33 @@ Install only the adapters you use. Node's minimum is unchanged at `>=20.19.0`.
 
 **`zod` is now a peer dependency and must be added.** In 0.8.0 it was bundled, so npm
 installed a copy for us; now your project declares it, which is what guarantees there is only
-one copy. If you already depend on zod it must be **version 4** — the exported evaluator
-schemas are zod 4 values, and with zod 3 in your tree npm keeps a second copy, so composing
-one of our schemas with your own fails:
+one copy.
+
+It must be **version 4** — the exported evaluator schemas are zod 4 values. A project on zod 3
+fails the install rather than the build:
+
+```
+npm error ERESOLVE unable to resolve dependency tree
+npm error Found: zod@3.25.76
+```
+
+That is the intended outcome: it names the problem before any code runs. Bypassing it with
+`--legacy-peer-deps` or `--force` installs zod 3 anyway, and the build then fails on our
+declarations — `Namespace '…/zod/v3/external' has no exported member 'core'`.
+
+For contrast, 0.8.0 gave **no** install-time signal: it bundled its own zod 4 alongside your
+zod 3, and the two copies were structurally different types, so composing one of our schemas
+with your own failed at your call site with nothing fixable there:
 
 ```
 error TS2322: Type 'ZodObject<…, $strict>' is not assignable to type 'ZodTypeAny'.
   missing the following properties from type 'ZodType<any, any, any>': _type, _parse, …
 ```
 
-Nothing you can do at the call site fixes that; the two copies are structurally different
-types. Note that `ai@7` accepts `zod@^3.25.76 || ^4.1.8`, so a project pinned to zod 3 for
-`ai`'s sake now has to move to zod 4.
+That silent-two-copies state is what this change removes.
+
+Note that `ai@7` accepts `zod@^3.25.76 || ^4.1.8`, so a project pinned to zod 3 for `ai`'s
+sake now has to move to zod 4.
 
 ## 1. `evaluate()` takes named inputs
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -40,11 +40,16 @@ Each evaluator's argument and payload types are exported — `VocabularyComplexi
 
 ## Installation
 
-Install the `@learning-commons/evaluators` and [Vercel AI](https://sdk.vercel.ai) SDKs:
+Install the SDK alongside [Vercel AI](https://sdk.vercel.ai) and [zod](https://zod.dev):
 
 ```bash
-npm install @learning-commons/evaluators ai
+npm install @learning-commons/evaluators ai zod
 ```
+
+`ai` and `zod` are peer dependencies, so your project owns their versions. `zod` must be
+version 4: the evaluator schemas this package exports are zod 4 values, and a second copy in
+your tree makes them incompatible with your own — a mismatch that shows up as
+`Type 'ZodObject<…>' is not assignable to type 'ZodTypeAny'` rather than as an install error.
 
 Next, install the provider adapter(s) for the evaluators you plan to run — the table below gives each evaluator's provider:
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -47,9 +47,17 @@ npm install @learning-commons/evaluators ai zod
 ```
 
 `ai` and `zod` are peer dependencies, so your project owns their versions. `zod` must be
-version 4: the evaluator schemas this package exports are zod 4 values, and a second copy in
-your tree makes them incompatible with your own — a mismatch that shows up as
-`Type 'ZodObject<…>' is not assignable to type 'ZodTypeAny'` rather than as an install error.
+version 4 — the evaluator schemas this package exports are zod 4 values. Installing against
+zod 3 fails at install time, naming zod:
+
+```
+npm error ERESOLVE unable to resolve dependency tree
+npm error Found: zod@3.25.76
+```
+
+Forcing past it with `--legacy-peer-deps` or `--force` installs zod 3 anyway, and the build
+then fails on our declarations instead — `Namespace '…/zod/v3/external' has no exported member
+'core'`. Either way the answer is zod 4; there is nothing to fix at the call site.
 
 Next, install the provider adapter(s) for the evaluators you plan to run — the table below gives each evaluator's provider:
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -15,8 +15,7 @@
         "p-limit": "^7.3.0",
         "prompts": "^2.4.2",
         "syllable": "^5.0.1",
-        "text-readability": "^1.1.1",
-        "zod": "^4.4.3"
+        "text-readability": "^1.1.1"
       },
       "bin": {
         "evaluators-batch": "dist/batch/cli.js"
@@ -39,7 +38,8 @@
         "tsup": "^8.0.1",
         "tsx": "^4.21.0",
         "typescript": "^5.3.3",
-        "vitest": "^4.0.17"
+        "vitest": "^4.0.17",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -48,7 +48,8 @@
         "@ai-sdk/anthropic": ">=4.0.0",
         "@ai-sdk/google": ">=4.0.0",
         "@ai-sdk/openai": ">=4.0.0",
-        "ai": ">=7.0.0"
+        "ai": ">=7.0.0",
+        "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/anthropic": {
@@ -1111,9 +1112,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,9 +1129,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1146,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1163,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1180,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3246,9 +3229,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3270,9 +3250,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3294,9 +3271,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3318,9 +3292,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5147,6 +5118,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -70,7 +70,8 @@
     "@ai-sdk/anthropic": ">=4.0.0",
     "@ai-sdk/google": ">=4.0.0",
     "@ai-sdk/openai": ">=4.0.0",
-    "ai": ">=7.0.0"
+    "ai": ">=7.0.0",
+    "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/openai": {
@@ -90,16 +91,15 @@
     "p-limit": "^7.3.0",
     "prompts": "^2.4.2",
     "syllable": "^5.0.1",
-    "text-readability": "^1.1.1",
-    "zod": "^4.4.3"
+    "text-readability": "^1.1.1"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^4.0.2",
     "@ai-sdk/google": "^4.0.2",
     "@ai-sdk/openai": "^4.0.3",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^26.0.0",
     "@types/prompts": "^2.4.9",
-    "@eslint/js": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vitest/coverage-v8": "^4.0.17",
@@ -111,7 +111,8 @@
     "tsup": "^8.0.1",
     "tsx": "^4.21.0",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@redocly/openapi-core": {


### PR DESCRIPTION
`zod` was a regular `dependencies` entry while leaking heavily into the published API — **364 zod type references** in `dist/index.d.ts`, including `z.core` internals, all sixteen `*OutputSchema` values, and `LLMRequest.schema`.

A consumer on zod 3 therefore gets two copies, and they are structurally incompatible.

## Reproduced, both directions

Fresh installs against the packed tarball:

```
zod 3 consumer:  top-level 3.25.76  +  nested @learning-commons/evaluators/node_modules/zod 4.5.4
```

Composing an exported schema with their own zod:

```ts
const mine = z.object({ wrapped: PurposeClarityOutputSchema });
// error TS2322: Type 'ZodObject<…, $strict>' is not assignable to type 'ZodTypeAny'.
//   missing: _type, _parse, _getType, _getOrReturnCtx, and 7 more
```

With zod 4 it dedupes and compiles clean — **which is why our CI never saw it**: we pin zod 4.

I also checked whether the consumer could work around it. They cannot: an `overrides` entry forcing zod 3 either conflicts (`EOVERRIDE`) or is ignored, because our `^4` dependency cannot be satisfied by zod 3. The second copy is unavoidable while zod is a hard dependency.

## Fix

`zod` moves to `peerDependencies` at `^4.0.0`, and to `devDependencies` for our own build.

`^4.0.0` rather than something wider, deliberately. Our generated schemas and published declarations are zod 4 shaped: `zod@3.25.x` ships v4 only under a `zod/v4` subpath, and its default export — what we import — has no `core`. A wider range would let a future zod 5 break consumers silently, which is the class of bug this PR exists to remove.

## What changes for a consumer

| | before | after |
| --- | --- | --- |
| zod 4 in the tree | worked | works, single copy, composition compiles |
| zod 3 in the tree | **two copies, `TS2322` at the call site** | `ERESOLVE` at install, naming zod |
| no zod declared | bundled silently | npm installs the peer |

The failure moves from a confusing compile error deep in a consumer's own code to an actionable install error. Verified all three.

## Documented

The install path and the migration guide both had to change, so both did:

- **README** — `npm install @learning-commons/evaluators ai zod`, with a note that `zod` must be version 4 and what the mismatch looks like if it is not
- **MIGRATION** — `zod@^4` added to step 0's single install command, plus an explanation that 0.8.0 bundled it and 1.0 does not, the exact `TS2322` text, and the note that `ai@7` accepts `zod@^3.25.76 || ^4.1.8`, so a project pinned to zod 3 for `ai`'s sake must now move
- the peer table in §7 gains a `zod` row with the declared range

The `docs.test.ts` guard requiring every declared peer range to be quoted in MIGRATION caught this omission before I did.

## Validation

`typecheck`, `lint`, `test:unit` (1364), `verify:dist` (6/6), `scripts/check.py`, plus the three consumer scenarios above against `npm pack`.

**Breaking:** consumers must declare `zod` themselves. That is why it precedes 1.0 — after the freeze this fix would itself be the breaking change.
