### PR TITLE
feat(sdk)!: generate input types from the contracts, with literal enum values

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -154,6 +154,42 @@ nothing, and a `GROUP BY score` silently splits into old and new buckets. **Grep
 strings, and backfill anything you have persisted.** Values now come straight from each
 evaluator's contract, which is what makes them identical across our SDKs.
 
+## 2b. Declared input values are literal unions
+
+`grade_level` was typed `string`, so a typo compiled and failed at run time on a paid call. It
+is now the union its contract declares, generated from the same file the runtime check reads:
+
+```diff
+- evaluate({ text, grade_level: string })
++ evaluate({ text, grade_level: '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' })
+```
+
+Passing a literal is unaffected. **Passing a `string` variable no longer compiles**, which is
+the one place this costs you:
+
+```typescript
+const grade: string = row.grade_level;
+await evaluator.evaluate({ text, grade_level: grade });
+//                                            ^ string is not assignable
+```
+
+Narrow it where the external value enters your system:
+
+```typescript
+const GRADES = ['3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] as const;
+type Grade = (typeof GRADES)[number];
+
+function toGrade(value: string): Grade {
+  if (!GRADES.includes(value as Grade)) throw new Error(`Unsupported grade: ${value}`);
+  return value as Grade;
+}
+```
+
+Only declared enums changed. Text inputs remain `string` — their length bounds are not
+expressible in the type system and stay with the run-time check. The affected fields are
+`grade_level` on the seven text-complexity evaluators; math's `jurisdiction` was already the
+`Jurisdiction` enum.
+
 ## 3. Evaluators renamed onto the taxonomy
 
 | 0.8.0 | 1.0.0 |

--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -156,16 +156,20 @@ evaluator's contract, which is what makes them identical across our SDKs.
 
 ## 2b. Declared input values are literal unions
 
-`grade_level` was typed `string`, so a typo compiled and failed at run time on a paid call. It
-is now the union its contract declares, generated from the same file the runtime check reads:
+You will meet this while doing section 1, not separately. 0.8.0 took the grade as a positional
+`string`; 1.0 takes it as a named input typed to the union its contract declares, generated
+from the same file the runtime check reads:
 
 ```diff
-- evaluate({ text, grade_level: string })
-+ evaluate({ text, grade_level: '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' })
+- await evaluator.evaluate(text, grade);            // grade: string
++ await evaluator.evaluate({ text, grade_level: grade });
+//                                        ^ '3' | '4' | … | '12'
 ```
 
-Passing a literal is unaffected. **Passing a `string` variable no longer compiles**, which is
-the one place this costs you:
+So a typo that used to compile and fail at run time on a paid call is now a compile error.
+
+Passing a literal is unaffected. **Passing the `string` variable you already had no longer
+compiles** — which, since 0.8.0 typed it `string`, is most of what you are converting:
 
 ```typescript
 const grade: string = row.grade_level;

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -36,7 +36,19 @@ CommonJS consumers can `require` the package but will need to rewrite the top-le
 in these snippets.
 
 Each evaluator's argument and payload types are exported — `VocabularyComplexityInput`,
-`VocabularyComplexityResult` and so on — so you can name them in your own signatures.
+`VocabularyComplexityResult` and so on — so you can name them in your own signatures. Both are
+generated from the evaluator's contract, so an input's declared values are a literal union
+rather than `string`:
+
+```typescript
+const ok: PurposeClarityInput = { text, grade_level: "5" };
+const typo: PurposeClarityInput = { text, grade_level: "fifth" };
+//                                       ^ not assignable to '"3" | "4" | … | "12"'
+```
+
+A grade arriving as a `string` — from a form, a database, a request body — needs narrowing
+before it fits. Validate it where the external value enters your system, which is where the
+check belongs; the evaluator still rejects a bad value at run time either way.
 
 ## Installation
 

--- a/sdks/typescript/scripts/generate-schema.ts
+++ b/sdks/typescript/scripts/generate-schema.ts
@@ -37,6 +37,7 @@ type JsonObject = { [key: string]: JsonValue };
 
 interface EvaluatorConfig {
   evaluator: { id: string };
+  input_schema?: { $ref: string };
   output_schema: { $ref: string };
 }
 
@@ -92,6 +93,60 @@ export function toPascalCase(str: string): string {
  * Generates the content of a Zod schema TypeScript file from a config.json path.
  * Returns slug, output path, and file content.
  */
+/**
+ * Render one declared input as a TypeScript property.
+ *
+ * A declared `enum` becomes a literal union, which is the point: the contract's accepted
+ * values become a compile error instead of a run-time one. Anything else is `string` — the
+ * bounds (`minLength`, `maxLength`) are not expressible in the type system and stay with
+ * `validateInputs`, which is the authoritative check either way.
+ */
+function renderInputProperty(name: string, spec: JsonObject): string {
+  const enumValues = spec['enum'];
+  const type = Array.isArray(enumValues) && enumValues.length > 0
+    ? enumValues.map((v) => JSON.stringify(v)).join(' | ')
+    : 'string';
+
+  const description = typeof spec['description'] === 'string' ? spec['description'] : undefined;
+  const doc = description ? `  /** ${description} */\n` : '';
+
+  return `${doc}  ${JSON.stringify(name)}: ${type};`;
+}
+
+/** The input type for a contract, or `undefined` when it declares no input schema. */
+function renderInputType(
+  configDir: string,
+  config: EvaluatorConfig,
+  className: string,
+): { code: string; source: string } | undefined {
+  if (!config.input_schema?.$ref) return undefined;
+
+  const schemaPath = resolve(configDir, config.input_schema.$ref);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf-8')) as JsonObject;
+  const properties = (schema['properties'] ?? {}) as Record<string, JsonObject>;
+
+  const names = Object.keys(properties);
+  if (names.length === 0) return undefined;
+
+  // Every declared input is required in every contract today; if that changes, an absent
+  // entry in `required` should render as optional rather than silently stay mandatory.
+  const required = new Set((schema['required'] ?? []) as string[]);
+  const missing = names.filter((n) => !required.has(n));
+  if (missing.length > 0) {
+    throw new Error(
+      `${config.input_schema.$ref} declares optional inputs (${missing.join(', ')}), which ` +
+        'this generator does not render yet — add optional-property support before shipping it.',
+    );
+  }
+
+  const body = names.map((name) => renderInputProperty(name, properties[name])).join('\n');
+
+  return {
+    code: `export type ${className}Input = {\n${body}\n};`,
+    source: relative(SDK_ROOT, schemaPath),
+  };
+}
+
 export function generateSchemaFile(configPath: string): GeneratedSchema {
   const absConfigPath = resolve(configPath);
   const configDir = dirname(absConfigPath);
@@ -121,14 +176,17 @@ export function generateSchemaFile(configPath: string): GeneratedSchema {
   const zodCode = parseSchema(resolved);
 
   const relSchemaPath = relative(SDK_ROOT, schemaPath);
+  const input = renderInputType(configDir, config, className);
 
   const content = [
     GENERATED_MARKER,
     `// Source: ${relSchemaPath}`,
+    ...(input ? [`//         ${input.source}`] : []),
     `// Regenerate: npm run generate:schemas`,
     ``,
     `import { z } from 'zod';`,
     ``,
+    ...(input ? [`/** What this evaluator accepts, from its input schema. */`, input.code, ``] : []),
     `// prettier-ignore`,
     `export const ${className}OutputSchema = ${zodCode};`,
     ``,

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/revision-accuracy.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/revision-accuracy.ts
@@ -2,14 +2,15 @@ import { RevisionAccuracyOutputSchema, type RevisionAccuracyResult } from '../..
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/revision-accuracy/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/revision-accuracy/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/revision-accuracy/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/revision-accuracy/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type RevisionAccuracyInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { RevisionAccuracyInput } from '../../../schemas/feedback/ela-writing/revision-accuracy.js';
+
+export type { RevisionAccuracyInput };
 
 /**
  * Judges whether the feedback correctly identifies what the student writing needs.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/revision-actionability.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/revision-actionability.ts
@@ -2,14 +2,15 @@ import { RevisionActionabilityOutputSchema, type RevisionActionabilityResult } f
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/revision-actionability/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/revision-actionability/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/revision-actionability/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/revision-actionability/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type RevisionActionabilityInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { RevisionActionabilityInput } from '../../../schemas/feedback/ela-writing/revision-actionability.js';
+
+export type { RevisionActionabilityInput };
 
 /**
  * Judges whether the feedback tells the student what to actually do next.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/revision-manageability.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/revision-manageability.ts
@@ -2,14 +2,15 @@ import { RevisionManageabilityOutputSchema, type RevisionManageabilityResult } f
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/revision-manageability/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/revision-manageability/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/revision-manageability/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/revision-manageability/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type RevisionManageabilityInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { RevisionManageabilityInput } from '../../../schemas/feedback/ela-writing/revision-manageability.js';
+
+export type { RevisionManageabilityInput };
 
 /**
  * Judges whether the revision the feedback asks for is achievable.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/strength-acknowledgment.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/strength-acknowledgment.ts
@@ -2,14 +2,15 @@ import { StrengthAcknowledgmentOutputSchema, type StrengthAcknowledgmentResult }
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/strength-acknowledgment/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/strength-acknowledgment/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/strength-acknowledgment/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/strength-acknowledgment/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type StrengthAcknowledgmentInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { StrengthAcknowledgmentInput } from '../../../schemas/feedback/ela-writing/strength-acknowledgment.js';
+
+export type { StrengthAcknowledgmentInput };
 
 /**
  * Judges whether the feedback names what the student did well.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/student-response-specificity.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/student-response-specificity.ts
@@ -2,14 +2,15 @@ import { StudentResponseSpecificityOutputSchema, type StudentResponseSpecificity
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/student-response-specificity/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/student-response-specificity/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/student-response-specificity/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/student-response-specificity/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type StudentResponseSpecificityInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { StudentResponseSpecificityInput } from '../../../schemas/feedback/ela-writing/student-response-specificity.js';
+
+export type { StudentResponseSpecificityInput };
 
 /**
  * Judges whether the feedback engages this student's actual writing.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/tone-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/tone-appropriateness.ts
@@ -2,14 +2,15 @@ import { ToneAppropriatenessOutputSchema, type ToneAppropriatenessResult } from 
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/tone-appropriateness/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/tone-appropriateness/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/tone-appropriateness/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/tone-appropriateness/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type ToneAppropriatenessInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { ToneAppropriatenessInput } from '../../../schemas/feedback/ela-writing/tone-appropriateness.js';
+
+export type { ToneAppropriatenessInput };
 
 /**
  * Judges whether the feedback addresses the work rather than the student.

--- a/sdks/typescript/src/evaluators/feedback/ela-writing/withholding-answers.ts
+++ b/sdks/typescript/src/evaluators/feedback/ela-writing/withholding-answers.ts
@@ -2,14 +2,15 @@ import { WithholdingAnswersOutputSchema, type WithholdingAnswersResult } from '.
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/feedback/ela-writing/withholding-answers/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/feedback/ela-writing/withholding-answers/user.txt';
 import CONFIG from '../../../../../../evals/feedback/ela-writing/withholding-answers/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/feedback/ela-writing/withholding-answers/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type WithholdingAnswersInput = InputsOf<{ properties: Record<'student_text' | 'feedback_text', unknown> }>;
+import type { WithholdingAnswersInput } from '../../../schemas/feedback/ela-writing/withholding-answers.js';
+
+export type { WithholdingAnswersInput };
 
 /**
  * Judges whether the feedback guides revision without writing it for the student.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/background-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/background-knowledge-demands.ts
@@ -2,14 +2,15 @@ import { BackgroundKnowledgeDemandsOutputSchema, type BackgroundKnowledgeDemands
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/background-knowledge-demands/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type BackgroundKnowledgeDemandsInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { BackgroundKnowledgeDemandsInput } from '../../../schemas/student-facing-text/ela-reading/background-knowledge-demands.js';
+
+export type { BackgroundKnowledgeDemandsInput };
 
 /**
  * Evaluates how much prior subject knowledge a student needs to comprehend a text,

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/grade-level-appropriateness.ts
@@ -5,14 +5,15 @@ import {
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type GradeLevelAppropriatenessInput = InputsOf<{ properties: Record<'text', unknown> }>;
+import type { GradeLevelAppropriatenessInput } from '../../../schemas/student-facing-text/ela-reading/grade-level-appropriateness.js';
+
+export type { GradeLevelAppropriatenessInput };
 
 /**
  * Reports the grade band a text is appropriate for at independent reading, plus a second

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/meaning-directness.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/meaning-directness.ts
@@ -2,14 +2,15 @@ import { MeaningDirectnessOutputSchema, type MeaningDirectnessResult } from '../
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/meaning-directness/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/meaning-directness/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/meaning-directness/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type MeaningDirectnessInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { MeaningDirectnessInput } from '../../../schemas/student-facing-text/ela-reading/meaning-directness.js';
+
+export type { MeaningDirectnessInput };
 
 /**
  * Evaluates how directly a text states its meaning, as against relying on inference,

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/organizational-structure.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/organizational-structure.ts
@@ -2,14 +2,15 @@ import { OrganizationalStructureOutputSchema, type OrganizationalStructureResult
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type OrganizationalStructureInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { OrganizationalStructureInput } from '../../../schemas/student-facing-text/ela-reading/organizational-structure.js';
+
+export type { OrganizationalStructureInput };
 
 /**
  * Evaluates organizational structure in student-facing text.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/purpose-clarity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/purpose-clarity.ts
@@ -2,14 +2,15 @@ import { PurposeClarityOutputSchema, type PurposeClarityResult } from '../../../
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/purpose-clarity/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type PurposeClarityInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { PurposeClarityInput } from '../../../schemas/student-facing-text/ela-reading/purpose-clarity.js';
+
+export type { PurposeClarityInput };
 
 /**
  * Evaluates purpose clarity in student-facing text.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.ts
@@ -2,14 +2,15 @@ import { ReferenceKnowledgeDemandsOutputSchema, type ReferenceKnowledgeDemandsRe
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineSingleStepEvaluator } from '../../single-step.js';
-import type { InputsOf } from '../../inputs.js';
 import SYSTEM_PROMPT from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/system.txt';
 import USER_PROMPT_TEMPLATE from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/user.txt';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type ReferenceKnowledgeDemandsInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { ReferenceKnowledgeDemandsInput } from '../../../schemas/student-facing-text/ela-reading/reference-knowledge-demands.js';
+
+export type { ReferenceKnowledgeDemandsInput };
 
 /**
  * Evaluates reference knowledge demands in student-facing text.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/sentence-structure.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/sentence-structure.ts
@@ -14,7 +14,6 @@ import {
 import type { EvaluationResult } from '../../../schemas/index.js';
 import type { BaseEvaluatorConfig } from '../../base.js';
 import { defineMultiStepEvaluator } from '../../multi-step.js';
-import type { InputsOf } from '../../inputs.js';
 import ANALYSIS_SYSTEM from '../../../../../../evals/student-facing-text/ela-reading/sentence-structure/analysis-system.txt';
 import ANALYSIS_USER from '../../../../../../evals/student-facing-text/ela-reading/sentence-structure/analysis-user.txt';
 import COMPLEXITY_SYSTEM from '../../../../../../evals/student-facing-text/ela-reading/sentence-structure/complexity-system.txt';
@@ -26,7 +25,9 @@ import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/sent
 import INPUT_SCHEMA from '../../../../../../evals/student-facing-text/ela-reading/sentence-structure/input_schema.json';
 
 /** What this evaluator accepts, taken from its `input_schema.json`. */
-export type SentenceStructureInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { SentenceStructureInput } from '../../../schemas/student-facing-text/ela-reading/sentence-structure.js';
+
+export type { SentenceStructureInput };
 
 /**
  * Evaluates sentence-structure complexity in student-facing text.

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../prompts/vocabulary-complexity/index.js';
 import type { EvaluationResult } from '../../../schemas/index.js';
 import { BaseEvaluator, Provider, type BaseEvaluatorConfig } from '../../base.js';
-import { validateInputs, type InputsOf } from '../../inputs.js';
+import { validateInputs } from '../../inputs.js';
 import { requireStep } from '../../single-step.js';
 import { requireConditionValues, requirePreprocessing } from '../../multi-step.js';
 import { declaredCredentials } from '../../credentials.js';
@@ -21,7 +21,9 @@ import { EvaluatorError, wrapProviderError } from '../../../errors.js';
 import CONFIG from '../../../../../../evals/student-facing-text/ela-reading/vocabulary-complexity/config.json';
 
 /** What this evaluator accepts, named by its `input_schema.json`. */
-export type VocabularyComplexityInput = InputsOf<{ properties: Record<'text' | 'grade_level', unknown> }>;
+import type { VocabularyComplexityInput } from '../../../schemas/student-facing-text/ela-reading/vocabulary-complexity.js';
+
+export type { VocabularyComplexityInput };
 
 /** The vocabulary evaluator's stage-1 output, fed to stage 2 as prompt input. */
 export interface BackgroundKnowledge {

--- a/sdks/typescript/src/schemas/feedback/ela-writing/revision-accuracy.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/revision-accuracy.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/revision-accuracy/output_schema.json
+//         ../../evals/feedback/ela-writing/revision-accuracy/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type RevisionAccuracyInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const RevisionAccuracyOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "accurate_task_assessment": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Identifies whether the feedback correctly assesses revision need."), "revision_need_identification": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Distinguishes between needed revision and move-on feedback."), "appropriate_signal_when_task_complete": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Provides a clear signal that the student can move on when the task goal is met.") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/revision-actionability.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/revision-actionability.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/revision-actionability/output_schema.json
+//         ../../evals/feedback/ela-writing/revision-actionability/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type RevisionActionabilityInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const RevisionActionabilityOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "directive_verb_or_focused_question": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Presence of a directive verb or focused question"), "clarity_of_target": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Clarity of the target (what to revise)"), "specificity_of_next_move": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Specificity of the next move"), "reasonable_student_action": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the student could reasonably act without further clarification") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/revision-manageability.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/revision-manageability.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/revision-manageability/output_schema.json
+//         ../../evals/feedback/ela-writing/revision-manageability/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type RevisionManageabilityInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const RevisionManageabilityOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "length": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("The length of the feedback"), "number_of_distinct_issues": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Number of distinct issues raised"), "clear_priority": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether those issues are clearly prioritized"), "student_knows_next_step": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the student would know immediately what to do first and could process and act on the feedback in one revision attempt.") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/strength-acknowledgment.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/strength-acknowledgment.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/strength-acknowledgment/output_schema.json
+//         ../../evals/feedback/ela-writing/strength-acknowledgment/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type StrengthAcknowledgmentInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const StrengthAcknowledgmentOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "presence_of_praise": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Presence of praise that is specific and authentic"), "specificity": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Specificity of the acknowledgment rather than generic praise"), "anchoring_to_evidence": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Anchoring to evidence in the student response"), "process_vs_trait_framing": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Process-vs-trait framing") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/student-response-specificity.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/student-response-specificity.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/student-response-specificity/output_schema.json
+//         ../../evals/feedback/ela-writing/student-response-specificity/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type StudentResponseSpecificityInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const StudentResponseSpecificityOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "specific_reference_to_student_work": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Feedback should clearly reference or build on the student's specific idea, wording, or use of evidence"), "not_generic_or_template_based": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Feedback should not be a stock phrase that could apply to any response"), "engage_based_on_accurate_understanding": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Engages with the student's actual response, rather than something the student did not actually say or attempt. Demonstrates accurate understanding of what the student wrote.") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/tone-appropriateness.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/tone-appropriateness.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/tone-appropriateness/output_schema.json
+//         ../../evals/feedback/ela-writing/tone-appropriateness/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type ToneAppropriatenessInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const ToneAppropriatenessOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "neutral_professional_language": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the language is neutral and professional versus harsh or dismissive"), "targets_work_not_student": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the feedback targets the work versus judging the student as a person"), "praise_proportionate_to_work": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether any praise matches the actual quality of the work versus overstating it") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/feedback/ela-writing/withholding-answers.ts
+++ b/sdks/typescript/src/schemas/feedback/ela-writing/withholding-answers.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/feedback/ela-writing/withholding-answers/output_schema.json
+//         ../../evals/feedback/ela-writing/withholding-answers/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type WithholdingAnswersInput = {
+  /** The student's written response. */
+  "student_text": string;
+  /** The teacher's feedback to the student. */
+  "feedback_text": string;
+};
 
 // prettier-ignore
 export const WithholdingAnswersOutputSchema = z.object({ "reasoning": z.string().describe("Step-by-step reasoning before the final answer: assess the student response against the task goal, then judge whether the teacher feedback meets the criterion."), "key_features": z.object({ "points_toward_evidence_without_supplying": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the feedback points toward where to find evidence rather than supplying the actual evidence"), "prompts_revision_without_rewriting": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether it prompts the student to revise rather than rewriting or modeling the full response"), "leaves_core_thinking_to_student": z.object({ "met": z.union([z.literal(0), z.literal(1)]).describe("1 if this key feature is satisfied by the feedback, 0 otherwise."), "justification": z.string().describe("One or two sentences grounding the met/not-met decision in the specific student response and teacher feedback.") }).strict().describe("Whether the guidance leaves the core thinking (selecting, explaining, or wording the evidence) to the student") }).strict().describe("Per-key-feature assessment; each feature judged independently."), "proposed_adjustment": z.string().describe("How the teacher feedback could be modified to meet the criterion. If it already meets the criterion, say so briefly."), "quality_score": z.union([z.literal(0), z.literal(1)]).describe("Overall: 1 if the feedback meets the criterion, 0 otherwise.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/background-knowledge-demands.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/background-knowledge-demands.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/background-knowledge-demands/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/background-knowledge-demands/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type BackgroundKnowledgeDemandsInput = {
+  /** The passage to evaluate. */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const BackgroundKnowledgeDemandsOutputSchema = z.object({ "identified_topics": z.array(z.string()).describe("The core subjects/concepts found in the text."), "curriculum_check": z.string().describe("Whether the topics are standard K-8 knowledge or specialized high-school-level knowledge."), "assumptions_and_scaffolding": z.string().describe("What the author assumes the reader already knows versus what is explained in the text."), "friction_analysis": z.string().describe("Whether difficulty comes from vocabulary/sentence structure or from actual background knowledge demands."), "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The background knowledge complexity level of the text."), "reasoning": z.string().describe("A detailed synthesis of why the text fits the chosen complexity level.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/grade-level-appropriateness.ts
@@ -1,8 +1,15 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/grade-level-appropriateness/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/grade-level-appropriateness/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type GradeLevelAppropriatenessInput = {
+  /** The passage to evaluate. Note this evaluator takes no grade input — it determines which grade band the text suits. Bounds mirror the SDK text input spec (sdks/settings/grade-level-appropriateness/settings.toml: min_text_length / max_text_length). */
+  "text": string;
+};
 
 // prettier-ignore
 export const GradeLevelAppropriatenessOutputSchema = z.object({ "reasoning": z.string().describe("Numbered bullet points for each of the 3 analysis steps (quantitative, qualitative, background knowledge), followed by a 4th bullet point called 'synthesis'."), "grade_band": z.enum(["K-1","2-3","4-5","6-8","9-10","11-12"]).describe("Target grade band for the text at independent reading."), "alternative_grade_band": z.enum(["K-1","2-3","4-5","6-8","9-10","11-12"]).describe("A second grade band that could read and comprehend the text with the scaffolding named in scaffolding_needed, or as a read-aloud."), "scaffolding_needed": z.string().describe("The types of scaffolding (picture, graph, additional context, vocabulary pre-teaching, ...) that make the text accessible at alternative_grade_band.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/meaning-directness.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/meaning-directness.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/meaning-directness/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/meaning-directness/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type MeaningDirectnessInput = {
+  /** The passage to evaluate. Bounds mirror the SDK text input spec (sdks/settings/conventionality/settings.toml: min_text_length / max_text_length). */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const MeaningDirectnessOutputSchema = z.object({ "reasoning": z.string().describe("A detailed explanation of the rating, citing specific features in the text and referencing the expert guardrails (e.g., noting if the text relies on abstract qualities/rhetorical idealization, if vocabulary/background knowledge demands make a literal text vague for the grade level, or if it is strictly concrete/procedural)."), "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The conventionality complexity level of the text."), "conventionality_features": z.array(z.string()).describe("The specific language features driving the complexity (e.g., literal narrative, concrete actions, less familiar expressions, sustained irony, abstract qualities, rhetorical idealization, archaic phrasing) with direct quotes from the text."), "grade_context": z.string().describe("How the conventionality demands compare to general expectations for the provided target grade."), "instructional_insights": z.string().describe("Actionable pedagogical suggestions for scaffolding the conventionality features in the classroom.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/organizational-structure.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/organizational-structure.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/organizational-structure/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/organizational-structure/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type OrganizationalStructureInput = {
+  /** The passage to evaluate. */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const OrganizationalStructureOutputSchema = z.object({ "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The Organizational Structure complexity level for the target grade."), "reasoning": z.string().describe("A high-level summary of why the text is at this organizational complexity level for the target grade."), "details": z.object({ "detailed_summary": z.array(z.object({ "factor": z.string().describe("The specific text complexity factor identified."), "description": z.string().describe("How this factor manifests in the text."), "effect_on_complexity_dimension": z.string().describe("How this factor affects the reader's ability to understand the text's specific complexity dimension.") }).strict()).describe("Individual organizational complexity factors with descriptions and their effects."), "adjustment_and_scaffolding": z.array(z.object({ "scaffolding_need": z.string().describe("The complexity factor that requires scaffolding."), "suggestion": z.string().describe("A specific instructional strategy to support students with this factor.") }).strict()).describe("Scaffolding strategies to make the text's structure accessible at the target grade."), "recommended_use_cases": z.array(z.object({ "opportunity": z.string().describe("An instructional opportunity related to the text."), "suggestion": z.string().describe("A specific way to leverage this text for that instructional purpose.") }).strict()).describe("Additional instructional opportunities for using this text's structure.") }).strict().describe("Practical instructional details including scaffolding strategies and recommended use cases.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/purpose-clarity.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/purpose-clarity.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/purpose-clarity/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/purpose-clarity/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type PurposeClarityInput = {
+  /** The passage to evaluate. */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const PurposeClarityOutputSchema = z.object({ "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex","more_context_needed"]).describe("The Purpose complexity level for the target grade."), "reasoning": z.string().describe("A high-level summary of why the text is at this complexity level for the target grade."), "details": z.object({ "detailed_summary": z.array(z.object({ "factor": z.string().describe("The specific text complexity factor identified."), "description": z.string().describe("How this factor manifests in the text."), "effect_on_complexity_dimension": z.string().describe("How this factor affects the reader's ability to understand the text's specific complexity dimension.") }).strict()).describe("Individual complexity factors with descriptions and their effects."), "adjustment_and_scaffolding": z.array(z.object({ "scaffolding_need": z.string().describe("The complexity factor that requires scaffolding."), "suggestion": z.string().describe("A specific instructional strategy to support students with this factor.") }).strict()).describe("Scaffolding strategies to make the text accessible at the target grade."), "recommended_use_cases": z.array(z.object({ "opportunity": z.string().describe("An instructional opportunity related to the text."), "suggestion": z.string().describe("A specific way to leverage this text for that instructional purpose.") }).strict()).describe("Additional instructional opportunities for using this text.") }).strict().describe("Practical instructional details including scaffolding strategies and recommended use cases.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/reference-knowledge-demands.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/reference-knowledge-demands.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/reference-knowledge-demands/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/reference-knowledge-demands/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type ReferenceKnowledgeDemandsInput = {
+  /** The passage to evaluate. */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const ReferenceKnowledgeDemandsOutputSchema = z.object({ "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The Reference Knowledge Demands complexity level for the target grade."), "reasoning": z.string().describe("A high-level summary of why the text is at this complexity level for the target grade."), "details": z.object({ "detailed_summary": z.array(z.object({ "factor": z.string().describe("The specific text complexity factor identified."), "description": z.string().describe("How this factor manifests in the text."), "effect_on_complexity_dimension": z.string().describe("How this factor affects the reader's ability to understand the text's specific complexity dimension.") }).strict()).describe("Individual complexity factors with descriptions and their effects."), "adjustment_and_scaffolding": z.array(z.object({ "scaffolding_need": z.string().describe("The complexity factor that requires scaffolding."), "suggestion": z.string().describe("A specific instructional strategy to support students with this factor.") }).strict()).describe("Scaffolding strategies to make the text accessible at the target grade."), "recommended_use_cases": z.array(z.object({ "opportunity": z.string().describe("An instructional opportunity related to the text."), "suggestion": z.string().describe("A specific way to leverage this text for that instructional purpose.") }).strict()).describe("Additional instructional opportunities for using this text.") }).strict().describe("Practical instructional details including scaffolding strategies and recommended use cases.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/sentence-structure.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/sentence-structure.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/sentence-structure/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/sentence-structure/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type SentenceStructureInput = {
+  /** The passage to evaluate. */
+  "text": string;
+  /** Target student grade level. Selects which of the three rubric_grade_* preprocessing entries supplies {rubric}. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const SentenceStructureOutputSchema = z.object({ "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The sentence structure complexity level of the text."), "reasoning": z.string().describe("Detailed, pedagogically appropriate reasoning explaining how the qualitative structure and quantitative sentence statistics combine to produce the chosen complexity level.") }).strict();

--- a/sdks/typescript/src/schemas/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/schemas/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -1,8 +1,17 @@
 // GENERATED — do not edit directly.
 // Source: ../../evals/student-facing-text/ela-reading/vocabulary-complexity/output_schema.json
+//         ../../evals/student-facing-text/ela-reading/vocabulary-complexity/input_schema.json
 // Regenerate: npm run generate:schemas
 
 import { z } from 'zod';
+
+/** What this evaluator accepts, from its input schema. */
+export type VocabularyComplexityInput = {
+  /** The passage to evaluate for vocabulary complexity. */
+  "text": string;
+  /** Target student grade level. */
+  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
+};
 
 // prettier-ignore
 export const VocabularyComplexityOutputSchema = z.object({ "tier_2_words": z.string().describe("List of Tier 2 words: words commonly used in academic settings, more complex than colloquial or everyday language, often with multiple meanings."), "tier_3_words": z.string().describe("List of Tier 3 words: overly academic or domain-specific words."), "archaic_words": z.string().describe("List of archaic words, or common words used in an archaic way, not commonly used in modern conversational language."), "other_complex_words": z.string().describe("All other words that can increase complexity of the text (e.g., idioms, unfamiliar proper nouns that function as vocabulary)."), "complexity_score": z.enum(["slightly_complex","moderately_complex","very_complex","exceedingly_complex"]).describe("The vocabulary complexity level of the text."), "reasoning": z.string().describe("A detailed explanation of the rating. Grades 3-4 reference density and cumulative effect, contextual scaffolding, abstract vs. concrete vocabulary, conceptual load, and the provided student background knowledge; other grades reference the annotation guide and rubric.") }).strict();

--- a/sdks/typescript/tests/unit/declarations.test.ts
+++ b/sdks/typescript/tests/unit/declarations.test.ts
@@ -77,7 +77,7 @@ describe('input types match the contracts they name', () => {
     expect(Object.keys(properties).sort()).toEqual(Object.keys(contract).sort());
   });
 
-  it.each(DECLARED)('$typeName carries the contract\'s enum values', ({ properties, contract }) => {
+  it.each(DECLARED)('$typeName carries the contract\'s enum values', ({ typeName, properties, contract }) => {
     // The reason for generating these rather than deriving them: a declared `enum` becomes a
     // literal union, so a bad grade is a compile error instead of a run-time one on a paid
     // call. A field with no enum stays `string` — the length bounds are not expressible.
@@ -86,7 +86,7 @@ describe('input types match the contracts they name', () => {
         ? spec.enum.map((v) => JSON.stringify(v)).join(' | ')
         : 'string';
 
-      expect(properties[name], `${name} in ${'$'}{'{typeName}'}`).toBe(expected);
+      expect(properties[name], `${typeName}.${name}`).toBe(expected);
     }
   });
 });

--- a/sdks/typescript/tests/unit/declarations.test.ts
+++ b/sdks/typescript/tests/unit/declarations.test.ts
@@ -30,42 +30,64 @@ function evaluatorSources(dir: string): string[] {
 interface Declared {
   file: string;
   typeName: string;
-  keys: string[];
-  contractKeys: string[];
+  /** Property name -> the TypeScript type text the generator emitted. */
+  properties: Record<string, string>;
+  contract: Record<string, { enum?: string[] }>;
 }
 
-const DECLARED: Declared[] = evaluatorSources(join(SRC, 'evaluators')).flatMap((file) => {
+/** The generated schema modules, which now carry each evaluator's input type. */
+function generatedModules(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return generatedModules(path);
+    return path.endsWith('.ts') ? [path] : [];
+  });
+}
+
+const DECLARED: Declared[] = generatedModules(join(SRC, 'schemas')).flatMap((file) => {
   const source = readFileSync(file, 'utf-8');
 
-  const typeMatch = source.match(
-    /export type (\w+Input) = InputsOf<\{ properties: Record<([^>]+), unknown> \}>/,
-  );
-  const schemaMatch = source.match(/import INPUT_SCHEMA from '([^']+input_schema\.json)'/);
-  if (!typeMatch || !schemaMatch) return [];
+  // `export type XInput = { ... };` as the generator prints it.
+  const typeMatch = source.match(/export type (\w+Input) = \{\n([\s\S]*?)\n\};/);
+  const sourceMatch = source.match(/^\/\/\s+(\S*input_schema\.json)$/m);
+  if (!typeMatch || !sourceMatch) return [];
 
-  // The contract the module itself imports, resolved the same way the compiler does.
-  const relative = schemaMatch[1].replace(/^(\.\.\/)+/, '');
-  const contract = JSON.parse(readFileSync(join(EVALS, relative.replace(/^evals\//, '')), 'utf-8'));
+  const properties: Record<string, string> = {};
+  for (const line of typeMatch[2].split('\n')) {
+    const prop = line.match(/^\s*"([^"]+)":\s*(.+);$/);
+    if (prop) properties[prop[1]] = prop[2].trim();
+  }
 
-  return [
-    {
-      file,
-      typeName: typeMatch[1],
-      keys: [...typeMatch[2].matchAll(/'([^']+)'/g)].map((m) => m[1]),
-      contractKeys: Object.keys(contract.properties),
-    },
-  ];
+  const relative = sourceMatch[1].replace(/^(\.\.\/)+/, '').replace(/^evals\//, '');
+  const contract = JSON.parse(readFileSync(join(EVALS, relative), 'utf-8')) as {
+    properties: Record<string, { enum?: string[] }>;
+  };
+
+  return [{ file, typeName: typeMatch[1], properties, contract: contract.properties }];
 });
 
 describe('input types match the contracts they name', () => {
   it('finds them, so the cases below cannot pass vacuously', () => {
-    expect(DECLARED).toHaveLength(16);
+    // Fifteen generated modules; math assembles its payload from per-component results and
+    // has no single output schema, so its input type stays hand-written.
+    expect(DECLARED).toHaveLength(15);
   });
 
-  it.each(DECLARED)('$typeName', ({ keys, contractKeys }) => {
-    // Written out rather than derived, because deriving from `typeof <json>` is what broke
-    // the declaration bundle. This is the check that keeps the two honest.
-    expect([...keys].sort()).toEqual([...contractKeys].sort());
+  it.each(DECLARED)('$typeName names the inputs its contract declares', ({ properties, contract }) => {
+    expect(Object.keys(properties).sort()).toEqual(Object.keys(contract).sort());
+  });
+
+  it.each(DECLARED)('$typeName carries the contract\'s enum values', ({ properties, contract }) => {
+    // The reason for generating these rather than deriving them: a declared `enum` becomes a
+    // literal union, so a bad grade is a compile error instead of a run-time one on a paid
+    // call. A field with no enum stays `string` — the length bounds are not expressible.
+    for (const [name, spec] of Object.entries(contract)) {
+      const expected = spec.enum
+        ? spec.enum.map((v) => JSON.stringify(v)).join(' | ')
+        : 'string';
+
+      expect(properties[name], `${name} in ${'$'}{'{typeName}'}`).toBe(expected);
+    }
   });
 });
 
@@ -75,6 +97,16 @@ describe('the source never reintroduces the cause', () => {
     const offenders = evaluatorSources(join(SRC, 'evaluators')).filter((file) =>
       /export type \w+Input = InputsOf<typeof /.test(readFileSync(file, 'utf-8')),
     );
+
+    expect(offenders.map((f) => f.replace(SRC, 'src'))).toEqual([]);
+  });
+
+  it('leaves the input types to the generator', () => {
+    // A hand-written one would drift from its contract's enum values, which is what the
+    // generator exists to prevent. Math is the exception and declares its own.
+    const offenders = evaluatorSources(join(SRC, 'evaluators'))
+      .filter((file) => /export type \w+Input = \{/.test(readFileSync(file, 'utf-8')))
+      .filter((file) => !file.includes('math-standards-alignment'));
 
     expect(offenders.map((f) => f.replace(SRC, 'src'))).toEqual([]);
   });

--- a/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/organizational-structure.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** The declared grade type. Cast onto it to drive the *runtime* rejection path,
+ * which the literal union would otherwise make unreachable from TypeScript. */
+type GradeLevelInput = '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
 import CONFIG from '../../../../../evals/student-facing-text/ela-reading/organizational-structure/config.json';
 import { OrganizationalStructureEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/organizational-structure.js';
@@ -245,12 +249,12 @@ describe('OrganizationalStructureEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/purpose-clarity.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** The declared grade type. Cast onto it to drive the *runtime* rejection path,
+ * which the literal union would otherwise make unreachable from TypeScript. */
+type GradeLevelInput = '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
 import CONFIG from '../../../../../evals/student-facing-text/ela-reading/purpose-clarity/config.json';
 import { PurposeClarityEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/purpose-clarity.js';
@@ -237,12 +241,12 @@ describe('PurposeClarityEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/reference-knowledge-demands.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** The declared grade type. Cast onto it to drive the *runtime* rejection path,
+ * which the literal union would otherwise make unreachable from TypeScript. */
+type GradeLevelInput = '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 import { runPreprocessingStep } from '../../../src/features/preprocessing.js';
 import CONFIG from '../../../../../evals/student-facing-text/ela-reading/reference-knowledge-demands/config.json';
 import { ReferenceKnowledgeDemandsEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/reference-knowledge-demands.js';
@@ -237,12 +241,12 @@ describe('ReferenceKnowledgeDemandsEvaluator - Validation', () => {
   });
 
   it('rejects grade below 3', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '2' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 
   it('rejects grade above 12', async () => {
-    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' })).rejects.toThrow(/Invalid grade/);
+    await expect(evaluator.evaluate({ text: 'Some text.', grade_level: '13' as GradeLevelInput })).rejects.toThrow(/Invalid grade/);
     expect(mockProvider.generateStructured).not.toHaveBeenCalled();
   });
 

--- a/sdks/typescript/tests/unit/evaluators/validation.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/validation.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/** The declared grade type. These cases feed it invalid values on purpose, to prove the
+ * runtime check still rejects what the literal union now also rejects at compile time. */
+type GradeLevelInput = '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 import { VocabularyComplexityEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.js';
 import { BackgroundKnowledgeDemandsEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/background-knowledge-demands.js';
 import { MeaningDirectnessEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/meaning-directness.js';
@@ -249,7 +253,7 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (below minimum)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade as GradeLevelInput }))
         .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
 
@@ -259,7 +263,7 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (above maximum)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade as GradeLevelInput }))
         .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
 
@@ -270,7 +274,7 @@ describe('Input Validation - Grade Validation', () => {
     ])('should reject grade %s (invalid format)', async (_label, grade) => {
       const validText = 'This is a sample text for testing.';
 
-      await expect(evaluator.evaluate({ text: validText, grade_level: grade }))
+      await expect(evaluator.evaluate({ text: validText, grade_level: grade as GradeLevelInput }))
         .rejects.toThrow(`Invalid grade_level "${grade}". Accepted values: 3, 4, 5, 6, 7, 8, 9, 10, 11, 12.`);
     });
   });


### PR DESCRIPTION
Every contract enum was discarded at the type level, so `grade_level` was `string`:

```ts
const typo: PurposeClarityInput = { text: '…', grade_level: 'fifth' };  // compiled
```

That failed only at run time, on a paid API call. Now it is the union its contract declares, generated from the same file the runtime check reads.

## Why the type could not just be derived

`InputsOf<typeof INPUT_SCHEMA>` reads a JSON *import*, and TypeScript widens `"3"` to `string` there — no `as const` is possible on a JSON module. That constraint was real, and it is what the comment in `inputs.ts` was describing.

It does not apply to a generator, which reads the JSON at build time and prints source text. The output schemas have been generated from contracts all along; the input rationale simply was never revisited once that existed. This extends the same generator rather than adding a second mechanism, so it inherits the `--check` CI gate and the `GENERATED` marker.

## Plain types, not zod

Deliberately, and it is the opposite call from the output path:

- outputs need a **runtime parser** — untrusted model JSON, and the same schema constrains generation — so `z.infer` is a free by-product of a schema that must exist
- inputs are caller-supplied and already validated by `validateInputs`, which reads the contract directly and produces the field ordering and exact messages SPEC §4.1 mandates

A zod input schema would mean two validators disagreeing about wording, and sixteen more zod values in a public API #258 is actively decoupling from zod. A plain type has neither cost.

```ts
export type PurposeClarityInput = {
  /** The passage to evaluate. */
  "text": string;
  /** Target student grade level. */
  "grade_level": "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12";
};
```

Field descriptions come across from the contract too. Fields without an enum stay `string` — length bounds are not expressible in the type system and remain with the runtime check.

## Scope

**8 of 32 declared inputs carry an enum**, across two fields: `grade_level` on the seven text-complexity evaluators, and `jurisdiction`, which was already narrowed to the `Jurisdiction` enum. Math keeps a hand-written input type — it has no single output schema, so no generated module.

## Breaking, and documented

Passing a literal is unaffected; **passing a `string` variable no longer compiles**. That is the one cost, and it lands on the common case of a grade arriving from a form or database. Both documents cover it: the README shows the union and says to narrow at the boundary, and MIGRATION §2b gives the before/after plus a `toGrade` helper.

Doing this after 1.0 would break every caller passing a string, which is why it is now.

## Guards

`tests/unit/declarations.test.ts` now reads the generated modules and checks, per evaluator, that the emitted properties match the contract's keys **and** that each enum field's union is exactly the contract's values. Verified load-bearing: changing one generated `"3"` to `"2"` fails it. Two further cases assert no evaluator reintroduces `InputsOf<typeof …>` or hand-writes an input type.

## Validation

- `typecheck`, `lint`, `test:unit` (1379), `verify:dist` (6/6), `scripts/check.py` — whose `eval-schemas` check runs the generator in `--check` mode, so the committed files are provably in sync
- regeneration is idempotent
- verified in a clean consumer project against `npm pack`: the typo, an out-of-range literal at the call site, and a `string` variable are all compile errors; a valid grade compiles

Four unit tests that deliberately pass out-of-range grades now cast onto the declared type. That cast is the point — it drives the runtime rejection path the literal union would otherwise make unreachable from TypeScript.
