### PR TITLE
fix(sdk)!: bound the peer ranges and declare the Node versions that work

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -20,7 +20,9 @@ One command, not two:
 npm install @learning-commons/evaluators@^1 zod@^4 ai@^7 @ai-sdk/google@^4 @ai-sdk/openai@^4 @ai-sdk/anthropic@^4
 ```
 
-Install only the adapters you use. Node's minimum is unchanged at `>=20.19.0`.
+Install only the adapters you use. Node's floor is unchanged, but the range is now
+`^20.19.0 || >=22.12.0`: the CommonJS build requires ESM-only packages, so it needs
+`require(esm)`, which 20.19 has and 21.x / 22.0-22.11 do not.
 
 **`zod` is now a peer dependency and must be added.** In 0.8.0 it was bundled, so npm
 installed a copy for us; now your project declares it, which is what guarantees there is only
@@ -330,9 +332,12 @@ Covered by step 0 above, which has to happen first. For reference:
 
 | Peer | 0.8.0 | 1.0.0 |
 | --- | --- | --- |
-| `ai` | `>=6.0.0` | `>=7.0.0` |
-| `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0` |
-| `zod` | *(bundled as a dependency)* | `^4.0.0` — now a peer you declare |
+| `ai` | `>=6.0.0` | `>=7.0.0 <8` |
+| `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/anthropic` | `>=3.0.0` | `>=4.0.0 <5` |
+| `zod` | *(bundled as a dependency)* | `^4.1.8` — now a peer you declare |
+
+The `zod` floor is `4.1.8` rather than `4.0.0` because `ai@7` itself requires
+`zod@^3.25.76 || ^4.1.8`; a lower floor is not installable alongside it.
 
 ## 8. Math standards alignment: named inputs, and the envelope
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,8 @@
 
 TypeScript SDK for [Learning Commons evaluators](https://docs.learningcommons.org/evaluators/understanding-evaluators/introduction) — sixteen LLM-backed evaluators for the complexity of text students read, the quality of feedback they receive, and the alignment of math items to standards.
 
-Requires Node >= 20.19.0.
+Requires Node 20.19+ or 22.12+ (`^20.19.0 || >=22.12.0`) — the CommonJS build needs
+`require(esm)`, which Node 21.x and 22.0-22.11 lack.
 
 The SDK is ESM-first and the examples below use top-level `await`, so a TypeScript project
 needs `"type": "module"` in `package.json`, `@types/node`, and:

--- a/sdks/typescript/batch/package.json
+++ b/sdks/typescript/batch/package.json
@@ -1,0 +1,6 @@
+{
+  "//": "Subpath stub for resolvers that ignore `exports` (webpack 4, browserify, tools built on `resolve`). Modern resolvers use the root exports map and never read this file.",
+  "main": "../dist/batch/index.cjs",
+  "module": "../dist/batch/index.js",
+  "types": "../dist/batch/index.d.ts"
+}

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -44,14 +44,14 @@
         "zod": "^4.4.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@ai-sdk/anthropic": ">=4.0.0",
-        "@ai-sdk/google": ">=4.0.0",
-        "@ai-sdk/openai": ">=4.0.0",
-        "ai": ">=7.0.0",
-        "zod": "^4.0.0"
+        "@ai-sdk/anthropic": ">=4.0.0 <5",
+        "@ai-sdk/google": ">=4.0.0 <5",
+        "@ai-sdk/openai": ">=4.0.0 <5",
+        "ai": ">=7.0.0 <8",
+        "zod": "^4.1.8"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/anthropic": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "description": "TypeScript SDK for Learning Commons educational evaluators",
   "type": "module",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -39,6 +40,7 @@
   },
   "files": [
     "dist",
+    "batch/package.json",
     "README.md",
     "MIGRATION.md",
     "CHANGELOG.md",
@@ -51,7 +53,7 @@
     "generate:kg-types": "openapi-typescript https://docs.learningcommons.org/api-reference/knowledge-graph-api/openapi.yaml -o src/knowledge-graph/kg-api.d.ts",
     "build": "tsup",
     "verify:dist": "vitest run tests/declarations",
-    "verify:package": "publint --strict && attw --pack .",
+    "verify:package": "publint --strict && attw --pack . && node scripts/verify-package.mjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
@@ -85,11 +87,11 @@
   },
   "homepage": "https://github.com/learning-commons-org/evaluators/tree/main/sdks/typescript#readme",
   "peerDependencies": {
-    "@ai-sdk/anthropic": ">=4.0.0",
-    "@ai-sdk/google": ">=4.0.0",
-    "@ai-sdk/openai": ">=4.0.0",
-    "ai": ">=7.0.0",
-    "zod": "^4.0.0"
+    "@ai-sdk/anthropic": ">=4.0.0 <5",
+    "@ai-sdk/google": ">=4.0.0 <5",
+    "@ai-sdk/openai": ">=4.0.0 <5",
+    "ai": ">=7.0.0 <8",
+    "zod": "^4.1.8"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/openai": {
@@ -140,6 +142,6 @@
     }
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/sdks/typescript/scripts/verify-package.mjs
+++ b/sdks/typescript/scripts/verify-package.mjs
@@ -1,0 +1,242 @@
+/**
+ * Packaging checks that `publint` and `attw` do not make.
+ *
+ * Both of those passed on four separate real defects: an unsatisfiable `zod` peer floor, an
+ * `engines` range admitting Node versions where the CommonJS entry throws, a missing `main`
+ * that makes legacy runtime resolution fail outright, and unbounded `>=` peer ranges. They
+ * check the manifest's shape and how TypeScript resolves types; none of them installs the
+ * declared floors or executes the built artifacts. These do.
+ *
+ * Run against a freshly packed tarball: `npm run verify:package`.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
+
+const failures = [];
+const notes = [];
+
+function fail(check, detail) {
+  failures.push(`${check}: ${detail}`);
+  console.error(`  ✗ ${check}\n      ${detail.split('\n').join('\n      ')}`);
+}
+function pass(check, detail = '') {
+  console.log(`  ✓ ${check}${detail ? ` — ${detail}` : ''}`);
+}
+
+function run(cmd, args, cwd) {
+  return execFileSync(cmd, args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/** Pack once; every check installs this exact artifact. */
+function pack() {
+  const out = run('npm', ['pack', '--silent'], ROOT).trim().split('\n').pop();
+  return join(ROOT, out);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Peer ranges are bounded.
+//
+// An unbounded `>=` lets the next major of a peer install with no warning and break at
+// run time, which is the one thing a peer range exists to prevent.
+// ---------------------------------------------------------------------------
+function checkPeerBounds() {
+  const unbounded = Object.entries(pkg.peerDependencies ?? {}).filter(
+    ([, range]) => /^>=?[^<]*$/.test(range.trim()) && !range.includes('<'),
+  );
+  if (unbounded.length > 0) {
+    fail(
+      'peer ranges are bounded',
+      unbounded.map(([n, r]) => `${n}: "${r}" admits the next major`).join('\n'),
+    );
+    return;
+  }
+  pass('peer ranges are bounded');
+}
+
+// ---------------------------------------------------------------------------
+// 2. The declared peer floors install together.
+//
+// Peers can contradict each other: `ai@7` requires `zod@^3.25.76 || ^4.1.8`, so a `zod`
+// floor below 4.1.8 is not installable alongside it no matter what we declare.
+// ---------------------------------------------------------------------------
+function checkPeerFloorsInstall(tarball) {
+  const floors = Object.entries(pkg.peerDependencies ?? {})
+    .map(([name, range]) => {
+      const m = range.match(/(\d+\.\d+\.\d+)/);
+      return m ? `${name}@${m[1]}` : null;
+    })
+    .filter(Boolean);
+
+  const dir = mkdtempSync(join(tmpdir(), 'verify-floors-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'f', private: true }) + '\n');
+    run('npm', ['install', '--silent', tarball, ...floors], dir);
+    pass('declared peer floors install together', floors.join(' '));
+  } catch (e) {
+    const out = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    const reason = out.split('\n').filter((l) => /ERESOLVE|Found:|peer /.test(l)).slice(0, 4);
+    fail('declared peer floors install together', [floors.join(' '), ...reason].join('\n'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. `main` is present and exists.
+//
+// Resolvers without `exports` support (webpack 4, browserify, tools built on `resolve`)
+// read `main` only. `attw` reports node10 green off `types` alone, so it cannot see this.
+// ---------------------------------------------------------------------------
+function checkMain() {
+  if (!pkg.main) {
+    fail('main is declared', 'absent — legacy resolvers cannot find the package at all');
+    return;
+  }
+  if (!existsSync(join(ROOT, pkg.main))) {
+    fail('main is declared', `${pkg.main} does not exist`);
+    return;
+  }
+  pass('main is declared', pkg.main);
+}
+
+/**
+ * Every `exports` subpath needs a directory stub too, since a resolver that ignores
+ * `exports` also has no way to find the subpath. `main` alone fixes only the root.
+ */
+function checkSubpathStubs() {
+  const subpaths = Object.keys(pkg.exports ?? {}).filter(
+    (k) => k.startsWith('./') && k !== './package.json',
+  );
+  const missing = [];
+  for (const sub of subpaths) {
+    const stub = join(ROOT, sub.slice(2), 'package.json');
+    if (!existsSync(stub)) {
+      missing.push(`${sub} has no ${sub.slice(2)}/package.json stub`);
+      continue;
+    }
+    const target = JSON.parse(readFileSync(stub, 'utf-8')).main;
+    if (!target || !existsSync(join(dirname(stub), target))) {
+      missing.push(`${sub} stub points at a missing main (${target})`);
+    }
+  }
+  if (missing.length > 0) {
+    fail('exports subpaths have legacy stubs', missing.join('\n'));
+    return;
+  }
+  pass('exports subpaths have legacy stubs', subpaths.join(', ') || 'none');
+}
+
+// ---------------------------------------------------------------------------
+// 4. `engines` excludes Node versions where `require()` of the CJS entry throws.
+//
+// The CJS build statically requires ESM-only packages, so it needs `require(esm)`:
+// unflagged in 20.19+ and 22.12+, absent in 21.x and 22.0–22.11.
+// ---------------------------------------------------------------------------
+function checkEnginesAgainstRequireEsm() {
+  const range = pkg.engines?.node ?? '';
+  const broken = ['21.0.0', '22.0.0', '22.11.0'];
+  const admitted = broken.filter((v) => satisfiesLoosely(range, v));
+  if (admitted.length > 0) {
+    fail(
+      'engines excludes Nodes without require(esm)',
+      `"${range}" admits ${admitted.join(', ')}, where requiring the CJS entry throws ERR_REQUIRE_ESM`,
+    );
+    return;
+  }
+  pass('engines excludes Nodes without require(esm)', range);
+}
+
+/** Minimal range test for the two forms we use, so this needs no dependency. */
+function satisfiesLoosely(range, version) {
+  const [maj, min] = version.split('.').map(Number);
+  return range.split('||').some((partRaw) => {
+    const part = partRaw.trim();
+    let m = part.match(/^\^(\d+)\.(\d+)\.\d+$/);
+    if (m) return maj === Number(m[1]) && min >= Number(m[2]);
+    m = part.match(/^>=(\d+)\.(\d+)\.\d+$/);
+    if (m) return maj > Number(m[1]) || (maj === Number(m[1]) && min >= Number(m[2]));
+    return false;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 5. Both entry points load, from ESM and from CommonJS.
+// ---------------------------------------------------------------------------
+function checkRuntimeLoads(tarball) {
+  const dir = mkdtempSync(join(tmpdir(), 'verify-load-'));
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'l', private: true }) + '\n');
+    // The peers the artifacts actually import at load time.
+    run('npm', ['install', '--silent', tarball, 'ai', 'zod'], dir);
+
+    writeFileSync(
+      join(dir, 'load.cjs'),
+      `const a = require('@learning-commons/evaluators');\n` +
+        `const b = require('@learning-commons/evaluators/batch');\n` +
+        `if (a.getEvaluators().length === 0 || b.getFamilies().length === 0) throw new Error('empty');\n` +
+        `console.log('cjs ok');\n`,
+    );
+    writeFileSync(
+      join(dir, 'load.mjs'),
+      `import { getEvaluators } from '@learning-commons/evaluators';\n` +
+        `import { getFamilies } from '@learning-commons/evaluators/batch';\n` +
+        `if (getEvaluators().length === 0 || getFamilies().length === 0) throw new Error('empty');\n` +
+        `console.log('esm ok');\n`,
+    );
+
+    run(process.execPath, [join(dir, 'load.mjs')], dir);
+    pass('ESM require of both entry points');
+
+    run(process.execPath, [join(dir, 'load.cjs')], dir);
+    pass('CommonJS require of both entry points');
+
+    // The CJS entry must not depend on this Node happening to have require(esm) unflagged,
+    // beyond what `engines` promises. Reported as a note: it is the reason for check 4.
+    try {
+      run(process.execPath, ['--no-experimental-require-module', join(dir, 'load.cjs')], dir);
+      notes.push('CJS entry loads even without require(esm) — engines could be widened again');
+    } catch {
+      notes.push(
+        'CJS entry needs require(esm) (statically requires ESM-only peers), which is why ' +
+          'engines excludes 21.x and 22.0-22.11',
+      );
+    }
+  } catch (e) {
+    fail('entry points load', `${e.stdout ?? ''}${e.stderr ?? ''}`.split('\n').slice(0, 6).join('\n'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+console.log('Packaging checks beyond publint/attw:\n');
+const tarball = pack();
+try {
+  checkPeerBounds();
+  checkMain();
+  checkSubpathStubs();
+  checkEnginesAgainstRequireEsm();
+  checkPeerFloorsInstall(tarball);
+  checkRuntimeLoads(tarball);
+} finally {
+  rmSync(tarball, { force: true });
+}
+
+if (notes.length > 0) {
+  console.log('\nNotes:');
+  for (const n of notes) console.log(`  - ${n}`);
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} packaging check(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll packaging checks passed.');

--- a/sdks/typescript/scripts/verify-package.mjs
+++ b/sdks/typescript/scripts/verify-package.mjs
@@ -10,12 +10,10 @@
  * Run against a freshly packed tarball: `npm run verify:package`.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
@@ -35,10 +33,26 @@ function run(cmd, args, cwd) {
   return execFileSync(cmd, args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
-/** Pack once; every check installs this exact artifact. */
+/** Pack once; every check reads or installs this exact artifact. */
 function pack() {
   const out = run('npm', ['pack', '--silent'], ROOT).trim().split('\n').pop();
   return join(ROOT, out);
+}
+
+/**
+ * Paths inside the tarball, `package/`-prefix stripped.
+ *
+ * Everything below asserts against these rather than against the working tree: a file can
+ * exist in the repo and still be absent from the package, because `files` decides what
+ * ships. Checking the repo would pass on exactly the regression these checks exist to catch.
+ */
+function tarballPaths(tarball) {
+  return new Set(
+    run('tar', ['tzf', tarball], ROOT)
+      .split('\n')
+      .map((l) => l.trim().replace(/^package\//, ''))
+      .filter(Boolean),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -95,36 +109,44 @@ function checkPeerFloorsInstall(tarball) {
 // Resolvers without `exports` support (webpack 4, browserify, tools built on `resolve`)
 // read `main` only. `attw` reports node10 green off `types` alone, so it cannot see this.
 // ---------------------------------------------------------------------------
-function checkMain() {
+function checkMain(shipped) {
   if (!pkg.main) {
-    fail('main is declared', 'absent — legacy resolvers cannot find the package at all');
+    fail('main is declared and shipped', 'absent — legacy resolvers cannot find the package at all');
     return;
   }
-  if (!existsSync(join(ROOT, pkg.main))) {
-    fail('main is declared', `${pkg.main} does not exist`);
+  const rel = pkg.main.replace(/^\.\//, '');
+  if (!shipped.has(rel)) {
+    fail('main is declared and shipped', `${pkg.main} is not in the tarball (check "files")`);
     return;
   }
-  pass('main is declared', pkg.main);
+  pass('main is declared and shipped', pkg.main);
 }
 
 /**
  * Every `exports` subpath needs a directory stub too, since a resolver that ignores
  * `exports` also has no way to find the subpath. `main` alone fixes only the root.
  */
-function checkSubpathStubs() {
+function checkSubpathStubs(tarball, shipped) {
   const subpaths = Object.keys(pkg.exports ?? {}).filter(
     (k) => k.startsWith('./') && k !== './package.json',
   );
   const missing = [];
   for (const sub of subpaths) {
-    const stub = join(ROOT, sub.slice(2), 'package.json');
-    if (!existsSync(stub)) {
-      missing.push(`${sub} has no ${sub.slice(2)}/package.json stub`);
+    const dir = sub.slice(2);
+    const stubPath = `${dir}/package.json`;
+    if (!shipped.has(stubPath)) {
+      missing.push(`${sub}: ${stubPath} is not in the tarball (check "files")`);
       continue;
     }
-    const target = JSON.parse(readFileSync(stub, 'utf-8')).main;
-    if (!target || !existsSync(join(dirname(stub), target))) {
-      missing.push(`${sub} stub points at a missing main (${target})`);
+    // Read it out of the tarball too, so a stub that ships but points nowhere is caught.
+    const stub = JSON.parse(run('tar', ['xzOf', tarball, `package/${stubPath}`], ROOT));
+    if (!stub.main) {
+      missing.push(`${sub}: shipped stub declares no "main"`);
+      continue;
+    }
+    const target = join(dir, stub.main).replace(/\\/g, '/');
+    if (!shipped.has(target)) {
+      missing.push(`${sub}: stub main "${stub.main}" resolves to ${target}, not in the tarball`);
     }
   }
   if (missing.length > 0) {
@@ -220,9 +242,10 @@ function checkRuntimeLoads(tarball) {
 console.log('Packaging checks beyond publint/attw:\n');
 const tarball = pack();
 try {
+  const shipped = tarballPaths(tarball);
   checkPeerBounds();
-  checkMain();
-  checkSubpathStubs();
+  checkMain(shipped);
+  checkSubpathStubs(tarball, shipped);
   checkEnginesAgainstRequireEsm();
   checkPeerFloorsInstall(tarball);
   checkRuntimeLoads(tarball);


### PR DESCRIPTION
Four defects in the published manifest, all of which `publint --strict` and `attw` pass
clean, and all of which freeze the moment 1.0.0 ships. Found by an outside audit of the
packed tarball; each one is verified below by reproducing the failure and then re-testing.

## 1. The declared `zod` floor is not installable

We declared `zod: "^4.0.0"`. `ai@7` declares `zod: "^3.25.76 || ^4.1.8"`, so anyone pinned
between 4.0.0 and 4.1.7 gets:

```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: zod@4.0.0
npm error Could not resolve dependency:
npm error peer zod@"^3.25.76 || ^4.1.8" from ai@7.0.0
```

`MIGRATION.md` already stated the real constraint; the manifest just did not. Now `^4.1.8`,
and §7 says why.

## 2. Peer ranges were unbounded

`ai: ">=7.0.0"` and `@ai-sdk/*: ">=4.0.0"` mean a future `ai@8` installs with no warning and
breaks at run time — disabling the one signal npm has for "this has not been tested against
that major". Now `>=7.0.0 <8` and `>=4.0.0 <5`.

## 3. `engines` promised Node versions where `require()` throws

`dist/index.cjs` statically requires `ai`, `p-limit`, `syllable` and `text-readability`, all
of which are ESM-only. So the CommonJS entry needs `require(esm)` — unflagged in 20.19+ and
22.12+, absent in 21.x and 22.0-22.11. Verified:

```
Node 20.19.0                        -> works   (require(esm) was backported here)
Node 22.22 default                  -> works
--no-experimental-require-module    -> Error [ERR_REQUIRE_ESM]: require() of ES Module .../ai/dist/index.js
Jest 29, default CJS transform      -> SyntaxError: Cannot use import statement outside a module
```

The floor was already right for the right reason. The range now excludes the broken middle:
`^20.19.0 || >=22.12.0`. README and MIGRATION updated to match.

Jest is the larger affected population and is not fixed by an `engines` range; that note
belongs next to the README's CommonJS sentence and is coming in the docs PR.

## 4. Legacy resolvers could not find the package at all

Any resolver that ignores `exports` — webpack 4, browserify, tools built on `resolve` —
reads `main`, which was absent:

```
node10-algorithm FAIL @learning-commons/evaluators       -> MODULE_NOT_FOUND
node10-algorithm FAIL @learning-commons/evaluators/batch -> MODULE_NOT_FOUND
```

`attw` reports node10 green because it only checks *types*, which `types` + `typesVersions`
already satisfied. Restoring `main` fixes the root; the subpath needs a directory stub as
well, so `batch/package.json` ships too. Both now resolve:

```
node10-algorithm OK @learning-commons/evaluators       -> .../dist/index.cjs
node10-algorithm OK @learning-commons/evaluators/batch -> .../dist/batch/index.cjs
```

I removed `main` in #261 on the grounds that it "fixed nothing measurable" — that A/B only
covered type resolution, not runtime.

## The guard

`npm run verify:package` now runs `scripts/verify-package.mjs` after publint and attw. It
makes the checks those two do not: it installs the declared peer floors together, requires
both entry points from ESM and CJS, and asserts `main`, the subpath stubs, bounded peer
ranges, and an `engines` range that excludes the Nodes without `require(esm)`.

Proven non-vacuous by reverting each fix in turn:

```
zod peer -> ^4.0.0      ✗ declared peer floors install together
ai peer  -> >=7.0.0     ✗ peer ranges are bounded
engines  -> >=20.19.0   ✗ engines excludes Nodes without require(esm)  (admits 21.0.0, 22.0.0, 22.11.0)
main     -> removed     ✗ main is declared
```

## Verification

- 1385 unit tests, `tsc --noEmit`, `eslint`, `verify:dist` all clean.
- A pre-existing docs test caught the manifest/doc drift on the peer table before I did,
  which is why MIGRATION §7 and the README's Node line are in this PR.
- Against the packed tarball: `bundler`, `node16`, `nodenext` and `node10` all typecheck;
  every README snippet still compiles; CJS `require()` returns 73 root exports, 16
  evaluators, 9 batch exports; the peer floor `ai@7.0.0` + `zod@4.1.8` installs and runs.
- `publint --strict` and `attw` remain green on all 8 cells.

## Not in this PR

The stale README paragraph claiming zod is bundled, the Jest caveat, and the MIGRATION
corrections are the docs PR. The redundant `StandardAlignmentResult` alias and the
half-snake_case math payload are the types PR. Both are also frozen at 1.0.
