### PR TITLE
fix(sdk)!: give math one result-type name and finish its snake_case keys

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -356,8 +356,13 @@ payload bare.
 ```
 
 Every key is snake_case now, matching the other fifteen evaluators: `statement_code`,
-`learning_components`, `aligned_count`, `total_count`. Nothing else about the payload changed.
+`learning_components`, `aligned_count`, `total_count`, and (on the bulk methods only)
+`coarse_filtered`. The one exception is the `error` object the bulk methods attach, whose
+`statusCode` and `retryable` stay camelCase because they mirror the error classes themselves.
 Batch CSVs still accept `statementCode` as a column alias.
+
+The payload type has one name, `MathStandardsAlignmentResult`. It was also exported as
+`StandardAlignmentResult`; that name is gone.
 
 The evaluator needs **both** `anthropicApiKey` and `learningCommonsApiKey`;
 `getEvaluator(id).requiredCredentials` lists the non-LLM ones.
@@ -371,9 +376,23 @@ and is not, since it only trims and upper-cases:
 const bare = stored.replace(/^CCSS\.MATH\.CONTENT\./i, "");
 ```
 
-`evaluateItems` keeps its name and arguments. **`evaluateByGrade` is now
-`evaluateByGradeLevel`** — arguments unchanged. Neither returns an envelope: one call fans out
-over many question × standard pairs, so there is no single model or duration to report.
+`evaluateItems` keeps its name, but **its items renamed `statementCodes` to
+`statement_codes`**:
+
+```diff
+- evaluator.evaluateItems([{ question, statementCodes: ["5.NF.A.1"] }], jurisdiction);
++ evaluator.evaluateItems([{ question, statement_codes: ["5.NF.A.1"] }], jurisdiction);
+```
+
+Passing the old shape is reported per item as `InputValidationError`, naming the field to
+rename; it does not throw for the whole call, so a mixed batch still returns its valid items.
+
+**`evaluateByGrade` is now `evaluateByGradeLevel`**, arguments unchanged. Its
+`QuestionBankResult` is snake_case throughout: `by_question`, `by_standard`, `covered_by`,
+`coverage_count`, `evaluated_count`, `error_count`, `filtered_count`, `no_components_count`.
+
+Neither returns an envelope: one call fans out over many question x standard pairs, so there
+is no single model or duration to report.
 
 ## 9. Smaller behaviour changes
 

--- a/sdks/typescript/src/batch/families/standards.ts
+++ b/sdks/typescript/src/batch/families/standards.ts
@@ -1,6 +1,6 @@
 import {
   MathStandardsAlignmentEvaluator,
-  type StandardAlignmentResult,
+  type MathStandardsAlignmentResult,
 } from '../../evaluators/academic-standards-alignment/mathematics/math-standards-alignment.js';
 import { Jurisdiction } from '../../knowledge-graph/index.js';
 import { Provider } from '../../evaluators/base.js';
@@ -46,7 +46,7 @@ function resolveJurisdiction(raw: string | undefined): Jurisdiction {
 }
 
 /** Structured verdict carried on BatchResult.payload for standards rows. */
-export interface StandardsVerdict extends StandardAlignmentResult {
+export interface StandardsVerdict extends MathStandardsAlignmentResult {
   question: string;
   jurisdiction: Jurisdiction;
 }

--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -51,9 +51,6 @@ export type MathStandardsAlignmentInput = InputsOf<{ properties: Record<'questio
   jurisdiction: Jurisdiction;
 };
 
-/** Alias of {@link StandardAlignmentResult}, for the `<Evaluator>Result` convention. */
-export type MathStandardsAlignmentResult = StandardAlignmentResult;
-
 export { Jurisdiction } from '../../../knowledge-graph/index.js';
 
 // ---------------------------------------------------------------------------
@@ -69,18 +66,25 @@ export interface LearningComponentResult {
 }
 
 /**
- * What `evaluate()` resolves its `result` to.
+ * What `evaluate()` resolves its `result` to, and what the bulk methods return arrays of.
  *
- * Named for the alignment rather than the evaluator because the bulk methods return arrays of
- * it too. {@link MathStandardsAlignmentResult} is the alias that keeps the
- * `<Evaluator>Result` convention true for all sixteen evaluators.
+ * One name rather than two. This was also exported as `StandardAlignmentResult`, which every
+ * signature actually used while the `<Evaluator>Result` name went unused, so the convention
+ * the second name existed to satisfy never reached anyone reading autocomplete.
+ *
+ * The keys are snake_case throughout, including the fields the SDK adds rather than the
+ * contract: `coarse_filtered` and the bulk counts have no contract counterpart, but a Python
+ * equivalent would name them that way, and one convention per payload beats two.
+ * `error.statusCode` / `error.retryable` are the exception: they mirror
+ * `DependencyError.statusCode` and `EvaluatorError.retryable`, and callers copy between the
+ * live error and this reported copy of it.
  */
-export interface StandardAlignmentResult {
+export interface MathStandardsAlignmentResult {
   statement_code: string;
   learning_components: LearningComponentResult[];
   aligned_count: number;
   total_count: number;
-  coarseFiltered?: boolean;
+  coarse_filtered?: boolean;
   /**
    * Set when this pair could not be evaluated. Produced only by evaluateItems and
    * evaluateByGradeLevel; evaluate() throws instead.
@@ -106,30 +110,30 @@ export interface QuestionItem {
 /** One question's results. `error` is set when the question itself could not be used. */
 export interface QuestionResult {
   question: string;
-  standards: StandardAlignmentResult[];
-  error?: StandardAlignmentResult['error'];
+  standards: MathStandardsAlignmentResult[];
+  error?: MathStandardsAlignmentResult['error'];
 }
 
 export interface QuestionBankResult {
-  byQuestion: QuestionResult[];
-  byStandard: Array<{
+  by_question: QuestionResult[];
+  by_standard: Array<{
     statement_code: string;
-    coveredBy: Array<{
+    covered_by: Array<{
       question: string;
       aligned_count: number;
       total_count: number;
     }>;
-    coverageCount: number;
+    coverage_count: number;
     /**
-     * Denominators for coverageCount. The four sum to the number of questions, so a
-     * zero coverageCount can be attributed: measured and unaligned (evaluatedCount),
-     * never measured (errorCount, filteredCount, noComponentsCount).
+     * Denominators for coverage_count. The four sum to the number of questions, so a
+     * zero coverage_count can be attributed: measured and unaligned (evaluated_count),
+     * never measured (error_count, filtered_count, no_components_count).
      */
-    evaluatedCount: number;
-    errorCount: number;
-    filteredCount: number;
+    evaluated_count: number;
+    error_count: number;
+    filtered_count: number;
     /** Standard exists but nothing is authored against it, so nothing was measurable. */
-    noComponentsCount: number;
+    no_components_count: number;
   }>;
 }
 
@@ -177,7 +181,7 @@ const KG_SUBJECT = 'Mathematics';
 const BY_GRADE_WARN_PAIRS = 500;
 
 /** Flattens a thrown value into the reportable shape, keeping what a report can group on. */
-function describeFailure(err: unknown): NonNullable<StandardAlignmentResult['error']> {
+function describeFailure(err: unknown): NonNullable<MathStandardsAlignmentResult['error']> {
   if (!(err instanceof Error)) return { message: String(err) };
   // `name` is the canonical error code, so there is no separate code field.
   return {
@@ -247,7 +251,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
   async evaluate(
     input: MathStandardsAlignmentInput,
-  ): Promise<EvaluationResult<StandardAlignmentResult>> {
+  ): Promise<EvaluationResult<MathStandardsAlignmentResult>> {
     validateInputs(input, INPUT_SCHEMA);
     return this._evaluateCore(input.question, input.statement_code, input.jurisdiction);
   }
@@ -278,6 +282,18 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         // The question is checked whether or not the item carries codes: an item with
         // an empty list still has a question the caller may have got wrong.
         validateInputs({ question: item.question }, QUESTION_SCHEMA);
+        // Checked before iterating, so a missing or misspelled list is reported as the
+        // caller's bad input rather than escaping as a raw TypeError. `statementCodes`
+        // is called out by name because it is what this field was before 1.0.
+        if (!Array.isArray(item.statement_codes)) {
+          const legacy = (item as unknown as { statementCodes?: unknown }).statementCodes;
+          throw new InputValidationError(
+            legacy !== undefined
+              ? 'statement_codes is required. This item carries `statementCodes`, which was ' +
+                  'its name before 1.0; rename it to `statement_codes`.'
+              : 'statement_codes is required and must be an array of standard codes.',
+          );
+        }
         for (const code of item.statement_codes) {
           validateInputs({ statement_code: code }, CODE_SCHEMA);
         }
@@ -290,7 +306,11 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
       }
       return {
         question: item.question,
-        statement_codes: [...new Set(item.statement_codes)],
+        // Guarded rather than assumed: an item that failed the check above still reaches
+        // here, and it carries its failure at item level with no codes to report against.
+        statement_codes: Array.isArray(item.statement_codes)
+          ? [...new Set(item.statement_codes)]
+          : [],
         validationError,
       };
     });
@@ -371,7 +391,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         const relevant = relevanceMaps.get(i) ?? new Set(item.statement_codes);
 
         const standards = await Promise.all(
-          item.statement_codes.map(async (code): Promise<StandardAlignmentResult> => {
+          item.statement_codes.map(async (code): Promise<MathStandardsAlignmentResult> => {
             if (!relevant.has(code)) {
               const cached = lcCache.get(code);
               const failure = lcFailures.get(code);
@@ -380,11 +400,11 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
                 learning_components: [],
                 aligned_count: 0,
                 total_count: cached?.components.length ?? 0,
-                coarseFiltered: true,
+                coarse_filtered: true,
                 ...(failure ? { error: describeFailure(failure) } : {}),
               };
             }
-            let result: StandardAlignmentResult;
+            let result: MathStandardsAlignmentResult;
             try {
               result = (await bankLimit(() => this._evaluateCore(item.question, code, jurisdiction)))
                 .result;
@@ -436,7 +456,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     });
     // statementCode is nullable in the KG API, so skip standards without one. Deduped
     // because a jurisdiction reusing a code across courses returns one item per
-    // course, which would otherwise repeat that code in byStandard.
+    // course, which would otherwise repeat that code in by_standard.
     const codes = [...new Set(
       academicStandards
         .map((s) => s.statementCode)
@@ -457,21 +477,21 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
     if (codes.length === 0) {
       return {
-        byQuestion: questions.map((q) => ({ question: q, standards: [] })),
-        byStandard: [],
+        by_question: questions.map((q) => ({ question: q, standards: [] })),
+        by_standard: [],
       };
     }
 
     const items = questions.map((q) => ({ question: q, statement_codes: codes }));
-    const byQuestion = await this.evaluateItems(items, jurisdiction, options);
+    const by_question = await this.evaluateItems(items, jurisdiction, options);
 
-    const byStandard = codes.map((code) => {
-      const results = byQuestion.map(({ question, standards }) => ({
+    const by_standard = codes.map((code) => {
+      const results = by_question.map(({ question, standards }) => ({
         question,
         result: standards.find((s) => s.statement_code === code),
       }));
 
-      const coveredBy = results.flatMap(({ question, result }) => {
+      const covered_by = results.flatMap(({ question, result }) => {
         // An errored pair measured nothing, so it is neither coverage nor
         // evidence against it.
         if (!result || result.error || result.aligned_count === 0) return [];
@@ -480,23 +500,23 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 
       return {
         statement_code: code,
-        coveredBy,
-        coverageCount: coveredBy.length,
+        covered_by,
+        coverage_count: covered_by.length,
         // total_count > 0 required: a standard with no learning components measured
         // nothing, so counting it as evaluated would make "0 aligned of 1 evaluated"
         // read as a judgement rather than an absence of data.
-        evaluatedCount: results.filter(
-          ({ result }) => result && !result.error && !result.coarseFiltered && result.total_count > 0,
+        evaluated_count: results.filter(
+          ({ result }) => result && !result.error && !result.coarse_filtered && result.total_count > 0,
         ).length,
-        errorCount: results.filter(({ result }) => result?.error).length,
-        filteredCount: results.filter(({ result }) => result?.coarseFiltered).length,
-        noComponentsCount: results.filter(
-          ({ result }) => result && !result.error && !result.coarseFiltered && result.total_count === 0,
+        error_count: results.filter(({ result }) => result?.error).length,
+        filtered_count: results.filter(({ result }) => result?.coarse_filtered).length,
+        no_components_count: results.filter(
+          ({ result }) => result && !result.error && !result.coarse_filtered && result.total_count === 0,
         ).length,
       };
     });
 
-    return { byQuestion, byStandard };
+    return { by_question, by_standard };
   }
 
   // -------------------------------------------------------------------------
@@ -510,10 +530,10 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
    * learning components resolves without one — and `tokenUsage` of zero is what says so.
    */
   private envelope(
-    result: StandardAlignmentResult,
+    result: MathStandardsAlignmentResult,
     startTime: number,
     usage?: { inputTokens: number; outputTokens: number },
-  ): EvaluationResult<StandardAlignmentResult> {
+  ): EvaluationResult<MathStandardsAlignmentResult> {
     return {
       evaluator: EVALUATOR_ID,
       result,
@@ -529,7 +549,7 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
     question: string,
     statementCode: string,
     jurisdiction: Jurisdiction,
-  ): Promise<EvaluationResult<StandardAlignmentResult>> {
+  ): Promise<EvaluationResult<MathStandardsAlignmentResult>> {
 
     const startTime = Date.now();
     const stageDetails: StageDetail[] = [];
@@ -749,6 +769,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
 export async function evaluateMathStandardsAlignment(
   input: MathStandardsAlignmentInput,
   config: MathStandardsAlignmentEvaluatorConfig,
-): Promise<EvaluationResult<StandardAlignmentResult>> {
+): Promise<EvaluationResult<MathStandardsAlignmentResult>> {
   return new MathStandardsAlignmentEvaluator(config).evaluate(input);
 }

--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -308,8 +308,12 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         question: item.question,
         // Guarded rather than assumed: an item that failed the check above still reaches
         // here, and it carries its failure at item level with no codes to report against.
+        //
+        // Non-strings are dropped rather than echoed back. The item already carries the
+        // InputValidationError that names them, and reporting one would put a non-string in
+        // a field this evaluator's own types declare as `string`.
         statement_codes: Array.isArray(item.statement_codes)
-          ? [...new Set(item.statement_codes)]
+          ? [...new Set(item.statement_codes.filter((c): c is string => typeof c === 'string'))]
           : [],
         validationError,
       };

--- a/sdks/typescript/src/evaluators/index.ts
+++ b/sdks/typescript/src/evaluators/index.ts
@@ -104,7 +104,6 @@ export {
   evaluateMathStandardsAlignment,
   type MathStandardsAlignmentEvaluatorConfig,
   type LearningComponentResult,
-  type StandardAlignmentResult,
   type MathStandardsAlignmentResult,
   type QuestionItem,
   type QuestionBankResult,

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -162,7 +162,6 @@ export {
   evaluateMathStandardsAlignment,
   type MathStandardsAlignmentEvaluatorConfig,
   type LearningComponentResult,
-  type StandardAlignmentResult,
   type MathStandardsAlignmentResult,
   type QuestionItem,
   type QuestionBankResult,

--- a/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
+++ b/sdks/typescript/tests/integration/math-standards-alignment.integration.test.ts
@@ -100,7 +100,7 @@ describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, 
       for (const qr of filtered) {
         console.log(`\n  Q: "${qr.question.slice(0, 70)}…"`);
         for (const s of qr.standards) {
-          if (s.coarseFiltered) {
+          if (s.coarse_filtered) {
             console.log(`    ${s.statement_code.padEnd(12)} [COARSE FILTERED]`);
           } else {
             const tag = s.aligned_count > 0 ? `ALIGNED ${s.aligned_count}/${s.total_count}` : `not aligned 0/${s.total_count}`;
@@ -117,7 +117,7 @@ describe('MathStandardsAlignmentEvaluator - integration', { timeout: 300_000 }, 
       for (const gtStd of areaGT.standards) {
         const filteredStd = areaFiltered.standards.find((s) => s.statement_code === gtStd.statement_code)!;
         const wasAligned = gtStd.aligned_count > 0;
-        const wasFiltered = filteredStd.coarseFiltered === true;
+        const wasFiltered = filteredStd.coarse_filtered === true;
         const status = wasFiltered && wasAligned ? '❌ FALSE NEGATIVE' :
                        wasFiltered ? '○ filtered (correctly — not aligned)' :
                        wasAligned ? '✓ passed through (correctly — aligned)' :

--- a/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math-standards-alignment.test.ts
@@ -233,7 +233,7 @@ describe('a failed learning-component prefetch is reported, not silently zero', 
     );
 
     const [standard] = item.standards;
-    expect(standard.coarseFiltered, 'must reach the coarse-filtered branch').toBe(true);
+    expect(standard.coarse_filtered, 'must reach the coarse-filtered branch').toBe(true);
     expect(standard.total_count).toBe(0);
     expect(standard.error?.message, 'the failure must reach the caller').toContain(
       'KG unavailable',

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -668,6 +668,23 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems malformed items', () =
     expect(results[0].error?.message).toContain('rename it to `statement_codes`');
   });
 
+  it('never reports a non-string statement_code, even on an errored item', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: makeMockKgClient() }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statement_codes: [123, STATEMENT_CODE] } as unknown as QuestionItem],
+      JURISDICTION,
+    );
+
+    expect(results[0].error?.name).toBe('InputValidationError');
+    expect(results[0].error?.message).toContain('must be a string');
+    // The declared type says `string`; echoing the bad value back would make it a lie.
+    for (const s of results[0].standards) {
+      expect(typeof s.statement_code).toBe('string');
+    }
+    expect(results[0].standards.map((s) => s.statement_code)).toEqual([STATEMENT_CODE]);
+  });
+
   it('isolates one malformed item without failing its siblings', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: makeMockKgClient() }));
 

--- a/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/math/standards-alignment.test.ts
@@ -3,6 +3,7 @@ import {
   MathStandardsAlignmentEvaluator,
   Jurisdiction,
   type MathStandardsAlignmentEvaluatorConfig,
+  type QuestionItem,
 } from '../../../../src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.js';
 import { ConfigurationError, InputValidationError, LLMOutputProcessingError, KnowledgeGraphError, RateLimitError } from '../../../../src/errors.js';
 import type { LLMProvider } from '../../../../src/providers/base.js';
@@ -154,7 +155,7 @@ describe('MathStandardsAlignmentEvaluator - ambiguous statement codes', () => {
 });
 
 describe('MathStandardsAlignmentEvaluator - evaluate', () => {
-  it('returns StandardAlignmentResult with correct shape on happy path', async () => {
+  it('returns MathStandardsAlignmentResult with correct shape on happy path', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
     const { result } = await evaluator.evaluate({ question: QUESTION, statement_code: STATEMENT_CODE, jurisdiction: JURISDICTION });
 
@@ -378,7 +379,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     expect(mockProvider.generateStructured).toHaveBeenCalledTimes(2);
   });
 
-  it('byQuestion has correct shape for M questions × N shared codes', async () => {
+  it('by_question has correct shape for M questions x N shared codes', async () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig());
     const questions = ['Q1', 'Q2', 'Q3'];
     const codes = ['3.MD.C.7.d', '3.OA.A.1'];
@@ -396,7 +397,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     }
   });
 
-  it('marks coarse-filtered standards with coarseFiltered=true and empty LC list', async () => {
+  it('marks coarse-filtered standards with coarse_filtered=true and empty LC list', async () => {
     vi.mocked(mockProvider.generateStructured)
       .mockResolvedValueOnce({
         data: { standards: [{ standard: '3.MD.C.7.d', relevant: true }, { standard: '3.OA.A.1', relevant: false }] },
@@ -412,13 +413,13 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     );
 
     const filtered = results[0].standards.find((s) => s.statement_code === '3.OA.A.1')!;
-    expect(filtered.coarseFiltered).toBe(true);
+    expect(filtered.coarse_filtered).toBe(true);
     expect(filtered.learning_components).toHaveLength(0);
     // Reported from the pre-fetch, so "skipped" is not confused with "has none".
     expect(filtered.total_count).toBe(2);
 
     const evaluated = results[0].standards.find((s) => s.statement_code === '3.MD.C.7.d')!;
-    expect(evaluated.coarseFiltered).toBeUndefined();
+    expect(evaluated.coarse_filtered).toBeUndefined();
     expect(evaluated.learning_components).toHaveLength(2);
   });
 
@@ -449,7 +450,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     );
 
     const result = results[0].standards[0];
-    expect(result.coarseFiltered).toBeUndefined();
+    expect(result.coarse_filtered).toBeUndefined();
     expect(result.learning_components).toHaveLength(2);
   });
 
@@ -488,7 +489,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems (shared codes)', () =>
     );
 
     expect(results[0].standards).toHaveLength(2);
-    expect(results[0].standards.every((s) => !s.coarseFiltered)).toBe(true);
+    expect(results[0].standards.every((s) => !s.coarse_filtered)).toBe(true);
     expect(results[0].standards.every((s) => s.learning_components.length > 0)).toBe(true);
   });
 
@@ -553,7 +554,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
 
   it('fetches standards for grade and jurisdiction, deduping codes reused across courses', async () => {
     // A jurisdiction reusing one code across courses returns an item per course.
-    // Without deduping, byStandard would repeat that code.
+    // Without deduping, by_standard would repeat that code.
     const repo = makeMockKgClient({
       getStandardsByGradeLevel: vi.fn().mockResolvedValue([
         { caseIdentifierUUID: 'u1', statementCode: '3.MD.C.7.d', description: 'Area', statementType: 'Standard', normalizedStatementType: 'Standard', gradeLevel: ['3'] },
@@ -565,8 +566,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
     const result = await evaluator.evaluateByGradeLevel([QUESTION], '3', JURISDICTION, { useCoarseFilter: false });
 
     expect(repo.getStandardsByGradeLevel).toHaveBeenCalledWith('3', { jurisdiction: JURISDICTION, academicSubject: 'Mathematics' });
-    expect(result.byStandard.map((s) => s.statement_code)).toEqual(['3.MD.C.7.d', '3.OA.A.1']);
-    expect(result.byQuestion[0].standards).toHaveLength(2);
+    expect(result.by_standard.map((s) => s.statement_code)).toEqual(['3.MD.C.7.d', '3.OA.A.1']);
+    expect(result.by_question[0].standards).toHaveLength(2);
   });
 
   it('warns when the grade-wide fan-out is large, and stays quiet when it is not', async () => {
@@ -589,7 +590,7 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
     expect(logger.warn.mock.calls[0][1]).toMatchObject({ questions: 1, standards: 501, pairs: 501 });
   });
 
-  it('returns byStandard with coverageCount counting questions with aligned_count > 0', async () => {
+  it('returns by_standard with coverage_count counting questions with aligned_count > 0', async () => {
     let callNum = 0;
     vi.mocked(mockProvider.generateStructured).mockImplementation(async () => {
       callNum++;
@@ -613,16 +614,16 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
     const result = await evaluator.evaluateByGradeLevel(['Q1', 'Q2'], '3', JURISDICTION, { useCoarseFilter: false });
 
-    expect(result.byStandard[0].coverageCount).toBe(1);
-    expect(result.byStandard[0].coveredBy[0].question).toBe('Q1');
+    expect(result.by_standard[0].coverage_count).toBe(1);
+    expect(result.by_standard[0].covered_by[0].question).toBe('Q1');
   });
 
-  it('returns empty byStandard and byQuestion stubs when KG returns no standards for grade', async () => {
+  it('returns empty by_standard and by_question stubs when KG returns no standards for grade', async () => {
     const repo = makeMockKgClient({ getStandardsByGradeLevel: vi.fn().mockResolvedValue([]) });
     const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }));
     const result = await evaluator.evaluateByGradeLevel([QUESTION], '3', JURISDICTION);
-    expect(result.byStandard).toEqual([]);
-    expect(result.byQuestion).toEqual([{ question: QUESTION, standards: [] }]);
+    expect(result.by_standard).toEqual([]);
+    expect(result.by_question).toEqual([{ question: QUESTION, standards: [] }]);
   });
 
   it('passes California jurisdiction to getStandardsByGradeLevel', async () => {
@@ -637,6 +638,52 @@ describe('MathStandardsAlignmentEvaluator - evaluateByGradeLevel', () => {
 // ---------------------------------------------------------------------------
 // Error isolation
 // ---------------------------------------------------------------------------
+
+describe('MathStandardsAlignmentEvaluator - evaluateItems malformed items', () => {
+  // An item missing its code list used to escape as `TypeError: item.statement_codes is
+  // not iterable`, outside the taxonomy, so no `instanceof` in the docs caught it.
+  it('reports a missing statement_codes as the caller\'s bad input', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: makeMockKgClient() }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION } as unknown as QuestionItem],
+      JURISDICTION,
+    );
+
+    expect(results[0].error?.name).toBe('InputValidationError');
+    expect(results[0].error?.message).toContain('statement_codes is required');
+  });
+
+  it('names the pre-1.0 spelling when an item still carries statementCodes', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: makeMockKgClient() }));
+
+    const results = await evaluator.evaluateItems(
+      [{ question: QUESTION, statementCodes: [STATEMENT_CODE] } as unknown as QuestionItem],
+      JURISDICTION,
+    );
+
+    expect(results[0].error?.name).toBe('InputValidationError');
+    // The whole point: say what to rename, since this is the shape 0.8.0 callers hold.
+    expect(results[0].error?.message).toContain('`statementCodes`');
+    expect(results[0].error?.message).toContain('rename it to `statement_codes`');
+  });
+
+  it('isolates one malformed item without failing its siblings', async () => {
+    const evaluator = new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: makeMockKgClient() }));
+
+    const results = await evaluator.evaluateItems(
+      [
+        { question: QUESTION } as unknown as QuestionItem,
+        { question: QUESTION, statement_codes: [STATEMENT_CODE] },
+      ],
+      JURISDICTION,
+    );
+
+    expect(results[0].error?.name).toBe('InputValidationError');
+    expect(results[1].error).toBeUndefined();
+    expect(results[1].standards[0].aligned_count).toBe(2);
+  });
+});
 
 describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () => {
   function failingCodeClient(badCode: string): KnowledgeGraphClient {
@@ -842,10 +889,10 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     const errored = await new MathStandardsAlignmentEvaluator(makeConfig({ _kgClient: repo }))
       .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
-    expect(errored.byQuestion[0].standards[0].error).toBeDefined();
-    expect(errored.byStandard[0].coveredBy).toEqual([]);
-    expect(errored.byStandard[0]).toMatchObject({
-      coverageCount: 0, errorCount: 1, evaluatedCount: 0, noComponentsCount: 0,
+    expect(errored.by_question[0].standards[0].error).toBeDefined();
+    expect(errored.by_standard[0].covered_by).toEqual([]);
+    expect(errored.by_standard[0]).toMatchObject({
+      coverage_count: 0, error_count: 1, evaluated_count: 0, no_components_count: 0,
     });
 
     // Same zero coverage, but measured: every LC came back unaligned.
@@ -858,8 +905,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     const unaligned = await new MathStandardsAlignmentEvaluator(makeConfig())
       .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
-    expect(unaligned.byStandard[0]).toMatchObject({
-      coverageCount: 0, errorCount: 0, evaluatedCount: 1, noComponentsCount: 0,
+    expect(unaligned.by_standard[0]).toMatchObject({
+      coverage_count: 0, error_count: 0, evaluated_count: 1, no_components_count: 0,
     });
 
     // Third way to reach zero coverage: never evaluated because the filter skipped it.
@@ -871,8 +918,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
     const filtered = await new MathStandardsAlignmentEvaluator(makeConfig())
       .evaluateByGradeLevel(['Q1'], '3', JURISDICTION, { useCoarseFilter: true });
 
-    expect(filtered.byStandard[0]).toMatchObject({
-      coverageCount: 0, errorCount: 0, evaluatedCount: 0, filteredCount: 1,
+    expect(filtered.by_standard[0]).toMatchObject({
+      coverage_count: 0, error_count: 0, evaluated_count: 0, filtered_count: 1,
     });
 
     // Fourth way: the standard exists but has no learning components, so nothing was
@@ -884,8 +931,8 @@ describe('MathStandardsAlignmentEvaluator - evaluateItems error isolation', () =
       .evaluateByGradeLevel(['Q1'], '3', JURISDICTION);
 
     // Its own counter, so all-zeros is never the only signal.
-    expect(unauthored.byStandard[0]).toMatchObject({
-      coverageCount: 0, errorCount: 0, evaluatedCount: 0, filteredCount: 0, noComponentsCount: 1,
+    expect(unauthored.by_standard[0]).toMatchObject({
+      coverage_count: 0, error_count: 0, evaluated_count: 0, filtered_count: 0, no_components_count: 1,
     });
   });
 });


### PR DESCRIPTION
Two frozen-at-1.0 defects on math's public types, plus the crash the first one was hiding.

## 1. Two exported names for one type

`StandardAlignmentResult` and `MathStandardsAlignmentResult` were both exported, the second an
alias of the first. The alias existed so math would obey the `<Evaluator>Result` convention
that the other fifteen evaluators follow — and it failed at that job, because **no signature
ever used it**:

```ts
evaluate(input: MathStandardsAlignmentInput): Promise<EvaluationResult<StandardAlignmentResult>>
declare function evaluateMathStandardsAlignment(...): Promise<EvaluationResult<StandardAlignmentResult>>
```

Anyone hovering `evaluate()` or following autocomplete saw the name the convention was meant to
replace. We paid for two public names and got the benefit of neither.

Now one name, `MathStandardsAlignmentResult`, used everywhere. Removing an exported type is
breaking, so this had to happen before 1.0; adding one back later is free if we are wrong.

## 2. The payload mixed both casing conventions, two levels deep

#260 renamed the contract-declared keys to snake_case and stopped there, leaving the
SDK-added fields camelCase:

```
statement_code        by_standard[].statement_code
learning_components     .coveredBy[].aligned_count      <- snake inside camel
aligned_count           .coverageCount                  <- camel
total_count             .evaluatedCount / errorCount / filteredCount / noComponentsCount
coarseFiltered   <- camel
```

A caller wrote `r.byStandard[0].statement_code` then `.coverageCount` and had to remember which
rule applied per field. Nine fields are now snake_case: `coarse_filtered`, `by_question`,
`by_standard`, `covered_by`, `coverage_count`, `evaluated_count`, `error_count`,
`filtered_count`, `no_components_count`.

The reason is not symmetry. These have no contract counterpart, but a Python equivalent of
`evaluate_by_grade_level` would name them `coverage_count` / `by_question` naturally, and the
two SDKs would then disagree about identical concepts — which is the failure canonical naming
exists to prevent.

**`error.statusCode` and `error.retryable` deliberately stay camelCase**, now with a comment
saying why: they are a flattened copy of a thrown error and mirror `DependencyError.statusCode`
and `EvaluatorError.retryable`. Snake-casing them would mean the live error says
`err.statusCode` while the reported copy of the same error says `result.error.status_code`, and
callers move between those two constantly. That would add an inconsistency, not remove one.

## 3. `evaluateItems` crashed on the pre-1.0 item shape

#260 renamed `QuestionItem.statementCodes` to `statement_codes`, and `evaluateItems` never
validated it. The old shape escaped as a raw `TypeError`, outside the error taxonomy entirely,
so none of the documented `instanceof` handling caught it:

```
0.8.0 shape -> TypeError | item.statement_codes is not iterable
```

It is now a per-item `InputValidationError` that names the field to rename, and only fails that
item — a mixed batch still returns its valid ones:

```
old item shape -> InputValidationError
  statement_codes is required. This item carries `statementCodes`, which was its name
  before 1.0; rename it to `statement_codes`.
```

Three tests cover it: the missing field, the pre-1.0 spelling, and isolation from a valid
sibling. Proven non-vacuous — removing the guard fails all three with the original
`TypeError`.

## MIGRATION.md

§8 said "Every key is snake_case now", which was false while `coarseFiltered` and the bulk
counts were not, and "`evaluateItems` keeps its name and arguments", which was false the moment
#260 landed. Both corrected, with the rename shown as a diff, the `error` exception stated, and
the removed type name called out.

## Verification

- 1388 unit tests (3 new), `tsc --noEmit`, `eslint`, `verify:dist`, `verify:package` all clean.
- Live against the packed tarball, all three paths:

```
StandardAlignmentResult exported: false
evaluate() keys: statement_code, learning_components, aligned_count, total_count
evaluateItems standard keys: statement_code, learning_components, aligned_count, total_count
QuestionBankResult keys: by_question, by_standard
by_standard[0] keys: statement_code, covered_by, coverage_count, evaluated_count,
                    error_count, filtered_count, no_components_count

camelCase keys on evaluateItems output: none
camelCase keys on QuestionBankResult: none
```

The camelCase sweep walks the live objects recursively, so it covers the nesting the audit
flagged rather than just the top level.
