### PR TITLE
docs(sdk): correct the false claims and fill the gaps four clean-room runs found

### DIFF
--- a/sdks/typescript/MIGRATION.md
+++ b/sdks/typescript/MIGRATION.md
@@ -2,7 +2,7 @@
 
 1.0.0 moves every evaluator onto the shared, language-neutral contracts under `evals/`, so the SDK reads its models, prompts, grades, inputs and output shapes from the same declarations the Python SDK and the notebooks use. The payoff is that a result is now identical across our SDKs; the cost is that most of the public surface changed at once.
 
-Twenty-six exported names are gone and seventy-three are new. Work through the sections below in order — the first four affect every caller.
+Twenty-six exported names are gone and ninety-seven are new. Work through the sections below in order — the first four affect every caller.
 
 ## 0. Upgrade the package and the peers together
 
@@ -72,7 +72,7 @@ Input names by family:
 | Feedback (7 evaluators) | `{ student_text, feedback_text }` |
 | `MathStandardsAlignmentEvaluator` | `{ question, statement_code, jurisdiction }` |
 
-Unknown keys, missing keys and out-of-range values now throw `InputValidationError` before any model runs. Text is bounded at 1–10,000 characters, measured as you sent it.
+Unknown keys, missing keys and out-of-range values now throw `InputValidationError` before any model runs. Each text input is bounded by its own contract, measured as you sent it: 10,000 characters at the top for all of them, and a minimum of 1 except Background Knowledge Demands, Grade Level Appropriateness, Meaning Directness and Sentence Structure, which require 10. The error states the limit it applied.
 
 ## 2. The result envelope changed shape
 
@@ -135,9 +135,12 @@ function toRow(dimension: string, evaluation: EvaluationResult, outcome: Declare
 
 ## 2a. The verdict *values* changed — check your stored data
 
-Nothing in the compiler will tell you about this, because `readOutcome` returns `score:
-string`. Every complexity verdict changed case and separator, and the top grade band was
-relabelled:
+The compiler will not tell you about this if you go through `readOutcome`, which returns
+`score: string`. It *will* catch a comparison against the typed payload:
+`band === "11-CCR"` gives `TS2367: ... have no overlap`, so run `tsc` before you start
+grepping.
+
+Every complexity verdict changed case and separator, and the top grade band was relabelled:
 
 | | 0.8.0 | 1.0.0 |
 | --- | --- | --- |
@@ -207,10 +210,10 @@ expressible in the type system and stay with the run-time check. The affected fi
 | `<Evaluator>Internal` types | `<Evaluator>Result` |
 | `GradeLevelAppropriatenessSchema` | `GradeLevelAppropriatenessOutputSchema` |
 | `evaluator.evaluateByGrade(...)` | `evaluator.evaluateByGradeLevel(...)` |
-| `GradeBand` as a **value** (it was a Zod enum, so `GradeBand.options` worked) | type only. For the runtime list use `GradeLevelAppropriatenessOutputSchema.shape.grade_band` |
+| `GradeBand` as a **value** (it was a Zod enum, so `GradeBand.options` worked) | type only. For the runtime list use `GradeLevelAppropriatenessOutputSchema.shape.grade_band.options` |
 | `Providers` (redundant alias; `Provider` already existed and is unchanged) | use `Provider` |
 
-Removed outright, so a `TS2305` on any of these has an entry here:
+Removed outright. Most report `TS2305`, but where a similar name survives TypeScript reports `TS2724` with a "did you mean" instead. `GradeLevelAppropriatenessSchema`, `Providers`, `ValidationError` and the two `*Internal` types below all do, so search for both codes:
 
 | removed | replacement |
 | --- | --- |
@@ -264,9 +267,15 @@ return settled.map((outcome, i) => {
 
 One reparenting is easy to miss: **`StandardNotFoundError` now extends `InputValidationError`**, not `KnowledgeGraphError`. A code that does not resolve is a bad input, not an upstream failure, so a `catch (e) { if (e instanceof KnowledgeGraphError) ... }` that used to see it no longer will.
 
-New: `DependencyError`, `LLMProviderError`, `ConfigurationError` (thrown at construction for
-a missing credential), and `LLMOutputProcessingError` for a response that arrived but could
-not be used.
+New: `DependencyError`, `LLMProviderError`, and `LLMOutputProcessingError` for a response
+that arrived but could not be used. `ConfigurationError` is **not** new (it shipped in
+0.8.0), but its base class and constructor changed with the rest, so existing `catch`
+blocks for it still need the audit below.
+
+`RateLimitError` renamed its payload: **`retryAfter` is now `retryAfterMs`**, and it is
+`number | null` rather than `number | undefined`. 0.8.0's own documented idiom was
+`sleep(error.retryAfter || 5000)`; left unchanged that silently becomes a constant 5s
+backoff. A narrowed `error` gives you `TS2339` here, but an `any`-typed `catch` will not.
 
 **The base class changed too**, which the rename table above does not cover:
 
@@ -399,7 +408,12 @@ is no single model or duration to report.
 - **`supportedGrades`** — read as `SomeEvaluator.metadata.supportedGrades`, the static. It was
   never available on an instance in either version. It now reports what the contract says the
   evaluator targets. Previously it was derived from the grade input's enum, so the seven feedback evaluators and Grade Level Appropriateness published `[]`. It is not a validation set — where a `grade_level` input exists, its schema enum is what rejects a bad value.
-- **Vocabulary Complexity** reports the model that actually ran for grades 3–4, which differs from the 5–12 branch. If you asserted one model string for all grades, it will now differ.
+- **Model strings moved for two evaluators.** Grade Level Appropriateness went from
+  `google:gemini-2.5-pro` to `google:gemini-3.6-flash`, and Sentence Structure from
+  `openai:gpt-4o` to `openai:gpt-4o-2024-08-06`. Vocabulary Complexity still reports a
+  different model for grades 3-4 than for 5-12, exactly as it did in 0.8.0. Models come
+  from each evaluator's contract and move with it, so assert on results rather than on
+  `metadata.model`.
 - **Grade Level Appropriateness and Sentence Structure** emit exactly the fields their contracts declare. GLA returns `grade_band`, `alternative_grade_band`, `scaffolding_needed`, `reasoning`.
 - **The three complexity-score schemas** are generated from their contracts, so field descriptions and enum values follow the contract rather than a hand-written copy.
 
@@ -410,9 +424,11 @@ is no single model or duration to report.
   `RevisionAccuracyEvaluator`, `RevisionActionabilityEvaluator`,
   `RevisionManageabilityEvaluator`, `StrengthAcknowledgmentEvaluator`,
   `StudentResponseSpecificityEvaluator`, `ToneAppropriatenessEvaluator`,
-  `WithholdingAnswersEvaluator`. Also newly public:
-  `OrganizationalStructureEvaluator`, `ReferenceKnowledgeDemandsEvaluator`, and
-  `StandardNotFoundError` (see section 4 — it was not exported in 0.8.0).
+  `WithholdingAnswersEvaluator`. **All seven need `openaiApiKey`.** Also newly public:
+  `OrganizationalStructureEvaluator` and `ReferenceKnowledgeDemandsEvaluator`, both needing
+  `googleApiKey`, and `StandardNotFoundError` (see section 4; it was not exported in 0.8.0).
+  A missing key throws `ConfigurationError` at construction, so a project holding only one
+  provider's key cannot reach the others; the README's evaluator tables list every one.
 - **`llmProvider`** — bring your own provider. Inject any `LLMProvider` and no API keys are needed, for Vertex AI, Bedrock, a gateway or an eval framework's model system. Mutually exclusive with `modelOverride`.
 - **The `feedback` batch family**, alongside `text-complexity` and `math-standards-alignment`.
 - **`getEvaluators()` / `getEvaluator(id)`** — a registry over all sixteen. Both return
@@ -436,4 +452,17 @@ is no single model or duration to report.
   not an evaluator. Each evaluator carries exactly one former id, so a class-name stem such as
   `smk` or `purpose` does not resolve; use the ids in the table.
 
-The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both existed in 0.8.0; they are documented in the [README](./README.md) now, which is the change.
+The `@learning-commons/evaluators/batch` entry point and the `evaluators-batch` command both
+existed in 0.8.0, and are documented in the [README](./README.md) now. **Their API changed as
+well**, which nothing above covers:
+
+| 0.8.0 | 1.0.0 |
+| --- | --- |
+| `EvaluatorGroup` | `EvaluatorFamily`, a different shape: `members`, `columns`, `requiredKeys()`, `createRunner()` instead of `evaluatorIds`, `requiresGoogleKey`, `requiresOpenAIKey` |
+| `getAvailableGroups()` | `getFamilies()`, plus `getFamily(id)` for one |
+| `BatchEvaluator.evaluate(inputs, groupId, onProgress?)` | `evaluate(inputs, family, options?)`, where `options` also accepts a bare `onProgress` function, so an existing third argument keeps working |
+| `BatchInput.text` / `.grade` | `BatchInput.columns: Record<string, string>`, a removal rather than the `grade` to `gradeLevel` rename in section 5 |
+
+The CLI gained `--family`, `--evaluator`, `--model`, `--learning-commons-api-key` and `-y`.
+`--evaluator` takes the full registry id (`student_facing_text.ela_reading.vocabulary_complexity`),
+not the short name.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -40,8 +40,8 @@ no build step to run:
 npx tsx quickstart.ts
 ```
 
-`node quickstart.ts` also works from Node 22.6 onward, where Node strips types itself, but not
-on the 20.19 floor above.
+A runner is the portable choice. Recent Node versions strip types themselves, so
+`node quickstart.ts` works there too, but the 20.19 floor above cannot.
 
 CommonJS consumers can `require` the package but will need to rewrite the top-level `await`
 in these snippets. Two caveats there: the CommonJS build requires ESM-only packages, so it

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -33,8 +33,25 @@ untyped; without it `tsc` reports `TS7016` from inside `@ai-sdk/provider`, not f
 package. This SDK's declarations typecheck cleanly on their own, so `skipLibCheck` is not
 required on their account — but adding it is the other way to silence that peer's gap.
 
+To run a snippet, use a TypeScript runner. The config above is `noEmit`-shaped, so there is
+no build step to run:
+
+```bash
+npx tsx quickstart.ts
+```
+
+`node quickstart.ts` also works from Node 22.6 onward, where Node strips types itself, but not
+on the 20.19 floor above.
+
 CommonJS consumers can `require` the package but will need to rewrite the top-level `await`
-in these snippets.
+in these snippets. Two caveats there: the CommonJS build requires ESM-only packages, so it
+needs `require(esm)` (hence the Node range above), and **Jest's default CommonJS transform
+cannot load it at all**: `SyntaxError: Cannot use import statement outside a module`, from
+inside `ai`. Add those packages to `transformIgnorePatterns`, or run Jest in ESM mode:
+
+```js
+transformIgnorePatterns: ['node_modules/(?!(ai|p-limit|syllable|text-readability)/)'],
+```
 
 Each evaluator's argument and payload types are exported — `VocabularyComplexityInput`,
 `VocabularyComplexityResult` and so on — so you can name them in your own signatures. Both are
@@ -70,7 +87,21 @@ npm error Found: zod@3.25.76
 
 Forcing past it with `--legacy-peer-deps` or `--force` installs zod 3 anyway, and the build
 then fails on our declarations instead — `Namespace '…/zod/v3/external' has no exported member
-'core'`. Either way the answer is zod 4; there is nothing to fix at the call site.
+'core'`.
+
+**If your project already depends on zod 3, widen your own range first.** The install above
+will not do it for you, because `npm install zod` honours the `^3` you already declared:
+
+```bash
+npm install zod@^4          # then re-run the install above
+```
+
+That is a major upgrade of a dependency you own, so review zod's own 3 to 4 notes for your
+call sites. Nothing needs fixing at *this* SDK's call sites; the schemas it exports are zod 4
+values, and once there is a single zod 4 copy they compose with yours directly.
+
+The floor is `zod@^4.1.8` rather than `^4.0.0` because `ai@7` itself requires
+`zod@^3.25.76 || ^4.1.8`.
 
 Next, install the provider adapter(s) for the evaluators you plan to run — the table below gives each evaluator's provider:
 
@@ -122,10 +153,22 @@ Demands each return a nested `details`; Vocabulary Complexity returns `tier_2_wo
 Sentence Structure returns just the score and reasoning. Each evaluator exports its payload
 type (`VocabularyComplexityResult` and so on) — that is the authoritative shape.
 
-The feedback family's `quality_score` is the **number** `0` or `1`, and its `key_features` maps
-each criterion to `{ met: 0 | 1, justification: string }` — `met` is a number, not a boolean.
+The feedback family's `quality_score` is the **number** `0` or `1`, and its `key_features`
+gives each criterion a `{ met: 0 | 1, justification: string }`, where `met` is a number, not a
+boolean. `key_features` is a fixed struct, not an index-signature map, so `key_features[name]`
+for a `string` name is a type error; and **the criterion keys differ per evaluator**, e.g.
 
-`metadata.model` names every model that ran, joined by `+` when an evaluator uses more than one — so a multi-step evaluator reports e.g. `openai:gpt-4o-…+openai:gpt-4.1-…`. Which models run can also depend on the input: Vocabulary Complexity takes a different branch for grades 3-4 than for 5-12. The **Required key** column below is what you must supply, not a promise about which provider serves a given call. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
+```
+RevisionAccuracy     accurate_task_assessment, revision_need_identification,
+                     appropriate_signal_when_task_complete
+ToneAppropriateness  neutral_professional_language, targets_work_not_student,
+                     praise_proportionate_to_work
+```
+
+To enumerate them for any evaluator, read its exported schema:
+`Object.keys(ToneAppropriatenessOutputSchema.shape.key_features.shape)`.
+
+`metadata.model` names every model that ran, joined by `+` when an evaluator uses more than one — so a multi-step evaluator reports e.g. `openai:gpt-4o-…+openai:gpt-4.1-…`. Which models run can also depend on the input: Vocabulary Complexity takes a different branch for grades 3-4 than for 5-12. The **Required key** column below is what you must supply, not a promise about which provider serves a given call: construction validates the union of keys an evaluator could need across all its branches, so Vocabulary Complexity demands both keys even at a grade where only one provider runs. Model strings come from each evaluator's contract and change with it, so treat `metadata.model` as the record of what actually ran rather than something to assert on. When you need one comparable value per evaluation regardless of evaluator, use `readOutcome`:
 
 ```typescript
 import { readOutcome, VocabularyComplexityEvaluator } from "@learning-commons/evaluators";
@@ -256,6 +299,26 @@ Every evaluator takes the same options:
 | `telemetry` | `true`, `false`, or `TelemetryOptions` (default on, without input recording) |
 | `logger` / `logLevel` | Inject a logger, or set the console logger's level with the exported `LogLevel` enum (default `LogLevel.WARN`) |
 
+`TelemetryOptions` and `Logger` are both exported. Their shapes:
+
+```typescript
+interface TelemetryOptions {
+  enabled?: boolean;              // default true
+  recordInputs?: boolean;         // default false: input text is not sent unless you opt in
+  learningCommonsApiKey?: string; // set: events are attributed to you. unset: anonymous
+}
+
+interface Logger {              // LogContext is { evaluator?, operation?, error?, ...unknown }
+  debug(message: string, context?: LogContext): void;
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+}
+```
+
+Telemetry failures are logged at `warn` and never affect an evaluation, so a restricted-egress
+environment will see a warning per call at the default level; `telemetry: false` silences it.
+
 `Provider` and `LogLevel` are enums, not strings — `provider: "google"` and
 `logLevel: "ERROR"` do not compile. The members are `Provider.OpenAI`, `Provider.Google`,
 `Provider.Anthropic`, and `LogLevel.DEBUG`, `INFO`, `WARN`, `ERROR`, `SILENT`:
@@ -343,9 +406,11 @@ const evaluation = await new SentenceStructureEvaluator({ llmProvider: myProvide
 // evaluation.metadata.model === "byo:gpt-4o-mini"
 ```
 
-`schema` is a Zod schema. `zod` is bundled with this package rather than being a peer, so a
-backend that needs the schema in another form should convert it rather than expect a matching
-`zod` of its own. An object missing any of the three members throws `ConfigurationError`.
+`schema` is a Zod schema, and because `zod` is a peer dependency it is an instance of *your*
+zod: the same copy your own code imports, which is what makes `Output.object({ schema })`
+above compile without conversion. A backend that needs another form can convert it with
+zod's own helpers (`z.toJSONSchema(schema)`). An object missing any of the three members
+throws `ConfigurationError`.
 
 It is mutually exclusive with `modelOverride`: setting both throws `ConfigurationError`.
 
@@ -369,7 +434,38 @@ const output = await new BatchEvaluator({
 console.log(`${output.summary.successful}/${output.summary.totalTasks} succeeded`);
 ```
 
-`getFamily(id)` gives you a family's members and column spec if you need to inspect it first.
+`getFamilies()` lists the three families; `getFamily(id)` gives one family's members and column
+spec if you need to inspect it before running:
+
+```typescript
+getFamilies().map((f) => f.id);          // ["text-complexity", "math-standards-alignment", "feedback"]
+getFamily("feedback").members.length;    // 7
+getFamily("text-complexity").columns;    // [{ name, required, aliases?, default? }, ...]
+```
+
+Note that **`text-complexity` has eight members**: the seven complexity evaluators plus Grade
+Level Appropriateness, which the tables above list separately because it determines a grade
+rather than judging against one. It ignores the required `grade_level` column, which the other
+seven need. Use `--evaluator` to run a subset.
+
+To format results yourself rather than letting the command write them:
+
+```typescript
+import { renderOutputs, type ReportMeta } from "@learning-commons/evaluators/batch";
+
+const meta: ReportMeta = {
+  csvPath: "./input.csv",      // recorded in the report header
+  groupId: "text-complexity",  // the family id
+  reportId: "run-2026-08-31",
+  generatedAt: new Date(),
+  totalInputRows: rows.length,
+};
+
+const { csv, json, html } = renderOutputs("text-complexity", output, meta);
+```
+
+`html` is absent for families without a report of their own. `formatAsCSV(output)`,
+`formatAsJSON(output, meta)` and `formatAsHTML(output, meta)` are the individual projections.
 
 The same thing is available as a command, installed as `evaluators-batch`. This is what
 writes `results.csv`, `results.json`, and — for `text-complexity` and
@@ -380,9 +476,10 @@ npx evaluators-batch input.csv --family text-complexity --output-dir ./results -
 npx evaluators-batch --help
 ```
 
-`-y` makes it non-interactive: without it, it prompts for anything missing, which hangs a CI
-job. Keys come from `--google-api-key` and friends or from the matching environment
-variables. Each family has a row limit — 50 for `text-complexity` and `feedback`, 5000 for
+`-y` makes it non-interactive: without it, it prompts on a TTY for anything missing. Off a TTY
+it does not hang; it exits 1 naming what is absent, e.g. `Specify --family`. Pass `-y`
+anyway so a scripted run fails on the missing input rather than on a prompt it cannot answer.
+Keys come from `--google-api-key` and friends or from the matching environment variables. Each family has a row limit — 50 for `text-complexity` and `feedback`, 5000 for
 `math-standards-alignment`, and `getFamily(id).maxInputRows` is authoritative.
 `--bypass-row-limit` lifts it.
 


### PR DESCRIPTION
Every documentation defect the four clean-room runs found. All of it ships inside the 1.0.0
tarball, so none of it is fixable after publish.

Each claim below was checked by running it. Where the audits and I were both wrong, the
verified answer is what went in.

## README

**The zod paragraph was false, and three of four agents caught it independently.** Line 345
said *"`zod` is bundled with this package rather than being a peer"* — contradicting line 61 of
the same file, and impossible on its face, since a bundled zod could not produce the
install-time `ERESOLVE` the same document documents. My stale text from #258. Worse, it sat in
the `llmProvider` section, so the advice was inverted exactly where a reader is writing code
against it: a BYO backend *does* receive the consumer's own zod, which is why
`Output.object({ schema })` compiles.

**The install command fails in any project already on zod 3, and the fix was undocumented.**
This is what failed clean room 2. The README diagnosed the ERESOLVE precisely and then never
gave the command: `npm install zod` honours the `^3` already declared, so re-running does
nothing. Now stated, with the fact that this is a major upgrade of a dependency the reader
owns and needs their own review.

**There were no instructions for running a snippet.** The README specifies ESM, top-level
`await` and a `noEmit` tsconfig, then stops. Both fresh-install agents had to guess; both
picked Node's native type stripping, which does not exist on the 20.19 floor the README
requires. Now `npx tsx`, with that caveat.

**"CommonJS consumers can `require` the package" was too strong.** Jest's default CommonJS
transform cannot load it at all (`SyntaxError: Cannot use import statement outside a module`,
from inside `ai`). Documented with the `transformIgnorePatterns` fix.

**`key_features` was described as a map; it is a closed struct**, so `key_features[name]` for a
`string` name is a type error — and the criterion keys differ per evaluator, which nothing
said:

```
RevisionAccuracy     accurate_task_assessment, revision_need_identification, …
ToneAppropriateness  neutral_professional_language, targets_work_not_student, …
```

**`renderOutputs` was prescribed but never specified.** The README told readers to use it and
never gave its signature; its third argument, `ReportMeta`, was unguessable. Now a working
snippet, plus the three individual projections.

**`TelemetryOptions` and `Logger` were named as accepted values with no shape.** Both now
given. `TelemetryOptions.learningCommonsApiKey` is worth having in writing: it switches
telemetry from anonymous to attributed, and a reader had no way to learn it exists.

**Also:** `getFamilies()` documented at all; `text-complexity` has **eight** members, not the
seven its table implies, because Grade Level Appropriateness is in that family; the `-y` flag's
stated CI hazard was wrong (off a TTY it exits 1, it does not hang); construction validates the
*union* of keys an evaluator could need, so Vocabulary Complexity demands both keys even at a
grade where only one provider runs.

## MIGRATION

- **"seventy-three are new" was wrong** — the two figures were on different bases. Measured:
  26 removed, **97** added. 73 is the total runtime export count of 1.0.0.
- **The text bound is per evaluator, and both the guide and the audit had it wrong.** The guide
  said a flat "1–10,000"; the audit said the minimum is really 10. Neither: twelve evaluators
  declare a minimum of 1, and four (Background Knowledge Demands, Grade Level
  Appropriateness, Meaning Directness, Sentence Structure) declare 10.
- **`ConfigurationError` was listed as new.** It shipped in 0.8.0, so a reader does have
  existing `catch` blocks to audit — and its base class and constructor changed.
- **`RateLimitError.retryAfter` is now `retryAfterMs`**, unmentioned. 0.8.0's own documented
  idiom was `sleep(error.retryAfter || 5000)`, which silently becomes a constant 5s backoff.
- **The batch entry point's changes were described as documentation-only.** `EvaluatorGroup`
  and `getAvailableGroups` were removed, `BatchInput` lost `text` and `grade` for `columns`,
  and the CLI grew five flags. Verified each against 0.8.0's own declarations — including one
  correction to the audit's account: `evaluate`'s third argument still accepts a bare
  `onProgress` function, so existing calls keep working.
- **The nine new evaluators had no credentials named** — feedback x7 need `openaiApiKey`,
  Organizational Structure and Reference Knowledge Demands need `googleApiKey`. A project
  holding one provider's key could not tell the rest were unreachable.
- **"a `TS2305` on any of these has an entry here"** — five removals report `TS2724` with a
  "did you mean" instead, so a `TS2305`-only sweep misses them.
- **`.options` was missing** from the `GradeBand` replacement, making the cell unpasteable in a
  table whose whole purpose is old-expression to new-expression.
- **§9's Vocabulary "behaviour change" was not one** — 0.8.0 already reported per-grade models,
  byte-identical. Meanwhile two models *did* move and went unmentioned: Grade Level
  Appropriateness `gemini-2.5-pro` to `gemini-3.6-flash`, Sentence Structure `gpt-4o` to
  `gpt-4o-2024-08-06`.
- **"Nothing in the compiler will tell you about this" was overstated** — `TS2367` catches a
  comparison against the typed payload. It is only blind on the `readOutcome` path.

## Verification

Rather than reason about the prose, I compiled and ran it: every new snippet plus every
assertion the corrected text makes, against the packed tarball under
`nodenext`/`strict`/`skipLibCheck: false`.

```
renderOutputs -> string string
families: [ 'text-complexity', 'math-standards-alignment', 'feedback' ]
feedback members: 7 (doc says 7)
text-complexity members: 8 (doc says 8)
ToneAppropriateness: neutral_professional_language, targets_work_not_student, praise_proportionate_to_work
RevisionAccuracy:   accurate_task_assessment, revision_need_identification, appropriate_signal_when_task_complete
criterion names differ per evaluator: true
grade_band.options is a list: true K-1, 2-3, 4-5, 6-8, 9-10, 11-12
TelemetryOptions keys: enabled, recordInputs, learningCommonsApiKey
Logger methods: debug, info, warn, error
retryAfterMs: 1200 | retryAfter is gone: true
```

That harness caught one of my own errors before it landed (an invalid `DependencyId` in the
`RateLimitError` example).

1389 tests, `tsc --noEmit`, and `eslint` clean. New text is ASCII-only.

## Note on four of these

`renderOutputs`, `TelemetryOptions`/`Logger`, the nine credentials, and the missing `.options`
were all reported three rounds ago and I did not act on them. They are fixed here.
