### PR TITLE
feat(sdk): deprecate recordInputs and drop opt-in input text telemetry

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -296,7 +296,7 @@ Every evaluator takes the same options:
 | `modelOverride` | Run every call on a different `{ provider, model }`; `provider` is the exported `Provider` enum |
 | `llmProvider` | Bring your own provider (see below) |
 | `maxRetries` | Retries per failed call (default 2, so 3 attempts) |
-| `telemetry` | `true`, `false`, or `TelemetryOptions` (default on, without input recording) |
+| `telemetry` | `true`, `false`, or `TelemetryOptions` (default on) |
 | `logger` / `logLevel` | Inject a logger, or set the console logger's level with the exported `LogLevel` enum (default `LogLevel.WARN`) |
 
 `TelemetryOptions` and `Logger` are both exported. Their shapes:
@@ -304,7 +304,6 @@ Every evaluator takes the same options:
 ```typescript
 interface TelemetryOptions {
   enabled?: boolean;              // default true
-  recordInputs?: boolean;         // default false: input text is not sent unless you opt in
   learningCommonsApiKey?: string; // set: events are attributed to you. unset: anonymous
 }
 
@@ -315,6 +314,10 @@ interface Logger {              // LogContext is { evaluator?, operation?, error
   error(message: string, context?: LogContext): void;
 }
 ```
+
+Telemetry never includes the text you evaluate. The event carries its length, the evaluator, the
+grade level you passed, the provider, latency, status, any error class name, token counts, and the
+SDK version.
 
 Telemetry failures are logged at `warn` and never affect an evaluation, so a restricted-egress
 environment will see a warning per call at the default level; `telemetry: false` silences it.

--- a/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
+++ b/sdks/typescript/src/evaluators/academic-standards-alignment/mathematics/math-standards-alignment.ts
@@ -662,7 +662,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         provider: this.detailProvider.label,
         tokenUsage,
         metadata: { stage_details: stageDetails },
-        inputText: question,
       }).catch(() => undefined);
 
       return this.envelope(
@@ -688,7 +687,6 @@ export class MathStandardsAlignmentEvaluator extends BaseEvaluator {
         tokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: question,
       }).catch(() => undefined);
 
       if (error instanceof EvaluatorError) throw error;

--- a/sdks/typescript/src/evaluators/base.ts
+++ b/sdks/typescript/src/evaluators/base.ts
@@ -32,7 +32,10 @@ export interface TelemetryOptions {
   /** Enable telemetry (default: true) */
   enabled?: boolean;
 
-  /** Record input text in telemetry (default: false) */
+  /**
+   * @deprecated Ignored, and removed in the next major. Telemetry does not
+   * send the text you evaluate.
+   */
   recordInputs?: boolean;
 
   /**
@@ -45,7 +48,7 @@ export interface TelemetryOptions {
 /**
  * Telemetry options after defaults are applied. The key remains optional.
  */
-type NormalizedTelemetryOptions = Required<Pick<TelemetryOptions, 'enabled' | 'recordInputs'>> &
+type NormalizedTelemetryOptions = Required<Pick<TelemetryOptions, 'enabled'>> &
   Pick<TelemetryOptions, 'learningCommonsApiKey'>;
 
 /**
@@ -129,10 +132,10 @@ export interface BaseEvaluatorConfig {
   maxRetries?: number;
 
   /**
-   * Telemetry configuration (default: enabled, without input recording)
+   * Telemetry configuration (default: enabled)
    *
    * Can be:
-   * - `true`: Enable with defaults (recordInputs: false)
+   * - `true`: Enable with defaults
    * - `false`: Disable completely
    * - `TelemetryOptions`: Granular control
    */
@@ -438,21 +441,18 @@ export abstract class BaseEvaluator {
     if (telemetry === false) {
       return {
         enabled: false,
-        recordInputs: false,
       };
     }
 
     if (telemetry === true || telemetry === undefined) {
       return {
         enabled: true,
-        recordInputs: false,
       };
     }
 
     // Handle granular config object
     return {
       enabled: telemetry.enabled ?? true,
-      recordInputs: telemetry.recordInputs ?? false,
       learningCommonsApiKey: telemetry.learningCommonsApiKey,
     };
   }
@@ -574,7 +574,6 @@ export abstract class BaseEvaluator {
     errorCode?: string;
     tokenUsage?: TokenUsage;
     metadata?: TelemetryMetadata;
-    inputText?: string;
   }): Promise<void> {
     if (!this.telemetryClient) {
       return;
@@ -595,8 +594,6 @@ export abstract class BaseEvaluator {
       token_usage: params.tokenUsage,
       metadata: params.metadata,
       model_override: this.config.modelOverride ? true : undefined,
-      // Include input text only if recording is enabled
-      input_text: this.config.telemetry.recordInputs ? params.inputText : undefined,
     });
   }
 }

--- a/sdks/typescript/src/evaluators/multi-step.ts
+++ b/sdks/typescript/src/evaluators/multi-step.ts
@@ -397,7 +397,6 @@ export function defineMultiStepEvaluator<TInput extends Record<string, string>, 
           provider: this.provider.label,
           tokenUsage,
           metadata: { stage_details: stageDetails },
-          inputText: text,
         }).catch(() => undefined);
 
         this.logger.info(`${LABEL} evaluation completed successfully`, {
@@ -446,7 +445,6 @@ export function defineMultiStepEvaluator<TInput extends Record<string, string>, 
           tokenUsage,
           errorCode: error instanceof Error ? error.name : 'UnknownError',
           metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-          inputText: text,
         }).catch(() => undefined);
 
         if (error instanceof EvaluatorError) throw error;

--- a/sdks/typescript/src/evaluators/single-step.ts
+++ b/sdks/typescript/src/evaluators/single-step.ts
@@ -247,7 +247,6 @@ export function defineSingleStepEvaluator<TInput extends Record<string, string>,
           provider: this.provider.label,
           tokenUsage,
           metadata: { stage_details: stageDetails },
-          inputText: text,
         }).catch(() => undefined);
 
         this.logger.info(`${LABEL} evaluation completed successfully`, {
@@ -289,7 +288,6 @@ export function defineSingleStepEvaluator<TInput extends Record<string, string>,
           tokenUsage,
           errorCode: error instanceof Error ? error.name : 'UnknownError',
           metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-          inputText: text,
         }).catch(() => undefined);
 
         if (error instanceof EvaluatorError) throw error;

--- a/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
+++ b/sdks/typescript/src/evaluators/student-facing-text/ela-reading/vocabulary-complexity.ts
@@ -239,7 +239,6 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
         metadata: {
           stage_details: stageDetails,
         },
-        inputText: text,
       }).catch(() => {
       });
 
@@ -279,7 +278,6 @@ export class VocabularyComplexityEvaluator extends BaseEvaluator {
         tokenUsage: totalTokenUsage,
         errorCode: error instanceof Error ? error.name : 'UnknownError',
         metadata: stageDetails.length > 0 ? { stage_details: stageDetails } : undefined,
-        inputText: text,
       }).catch(() => {
       });
 

--- a/sdks/typescript/src/telemetry/types.ts
+++ b/sdks/typescript/src/telemetry/types.ts
@@ -65,7 +65,6 @@ export interface TelemetryEvent {
   token_usage?: TokenUsage; // Aggregated across all stages and attempts
   metadata?: TelemetryMetadata; // Optional per-stage breakdown
   model_override?: boolean; // true when the caller supplied a modelOverride
-  input_text?: string; // Input text (only if recordInputs enabled)
 }
 
 /**

--- a/sdks/typescript/tests/unit/evaluators/telemetry-input-text.test.ts
+++ b/sdks/typescript/tests/unit/evaluators/telemetry-input-text.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeaningDirectnessEvaluator } from '../../../src/evaluators/student-facing-text/ela-reading/meaning-directness.js';
+import type { LLMProvider } from '../../../src/providers/base.js';
+
+/**
+ * Telemetry never carries the evaluated text. `recordInputs` used to opt into
+ * sending it and is now a deprecated no-op. These guard both halves: setting it
+ * does nothing, and neither the success nor the error path can put the text
+ * back on the wire.
+ */
+
+const sent = vi.fn();
+
+vi.mock('../../../src/telemetry/client.js', () => ({
+  TelemetryClient: class {
+    send = sent;
+  },
+}));
+
+const provider: LLMProvider = {
+  label: 'google:stub',
+  generateStructured: vi.fn(),
+  generateText: vi.fn(),
+};
+
+vi.mock('../../../src/providers/index.js', () => ({
+  createProvider: vi.fn(() => provider),
+}));
+
+const TEXT =
+  'The author uses sustained irony throughout to critique the hypocrisy of civilized society.';
+
+const evaluator = () =>
+  new MeaningDirectnessEvaluator({
+    googleApiKey: 'k',
+    // The deprecated no-op, as a 1.0.x caller still writes it.
+    telemetry: { recordInputs: true },
+  });
+
+beforeEach(() => {
+  sent.mockClear();
+  sent.mockResolvedValue(undefined);
+  vi.mocked(provider.generateStructured).mockReset();
+});
+
+describe('telemetry omits the evaluated text', () => {
+  it('sends no input_text on success, and ignores a stale recordInputs', async () => {
+    vi.mocked(provider.generateStructured).mockResolvedValue({
+      data: {
+        conventionality_features: ['sustained irony'],
+        grade_context: 'Exceeds typical Grade 10 expectations.',
+        instructional_insights: 'Pre-teach irony.',
+        complexity_score: 'very_complex',
+        reasoning: 'Relies on sustained irony.',
+      },
+      model: 'gemini-3-flash-preview',
+      usage: { inputTokens: 250, outputTokens: 120 },
+      latencyMs: 900,
+    });
+
+    await evaluator().evaluate({ text: TEXT, grade_level: '10' });
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    const event = sent.mock.calls[0][0];
+    expect(event).not.toHaveProperty('input_text');
+    expect(JSON.stringify(event)).not.toContain(TEXT);
+    expect(event.text_length_chars).toBe(TEXT.length);
+  });
+
+  it('sends no input_text on the error path', async () => {
+    vi.mocked(provider.generateStructured).mockRejectedValue(new Error('API timeout'));
+
+    await expect(evaluator().evaluate({ text: TEXT, grade_level: '10' })).rejects.toThrow(
+      'API timeout'
+    );
+
+    expect(sent).toHaveBeenCalledTimes(1);
+    const event = sent.mock.calls[0][0];
+    expect(event.status).toBe('error');
+    expect(event).not.toHaveProperty('input_text');
+    expect(JSON.stringify(event)).not.toContain(TEXT);
+  });
+});


### PR DESCRIPTION
Telemetry no longer sends the text you evaluate, under any configuration.

## What changed

- `TelemetryEvent.input_text` and the `inputText` argument to `sendTelemetry` are removed. All eight call sites (single-step ×2, multi-step ×2, math standards alignment ×2, vocabulary complexity ×2) stop passing the text; each still passes `textLength`, so `text_length_chars` is unchanged.
- `TelemetryOptions.recordInputs` remains as a `@deprecated` no-op. It is no longer read, and is dropped from `NormalizedTelemetryOptions` and `normalizeTelemetryConfig`.
- New `tests/unit/evaluators/telemetry-input-text.test.ts` covers both halves: setting `recordInputs: true` does nothing, and no event on the success or error path contains the text.
- README's `TelemetryOptions` shape and telemetry section updated to match.

## Verification

`typecheck` clean, `lint` clean, 1386/1386 unit tests pass. Both call shapes above were compiled against this branch to confirm neither errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
